### PR TITLE
docs(vbr): documentation update 2026-01-21

### DIFF
--- a/docs/agent_job_vss_oracle.md
+++ b/docs/agent_job_vss_oracle.md
@@ -1,13 +1,14 @@
 ---
 title: "Oracle Archived Log Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_vss_oracle.html"
-last_updated: "11/4/2025"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Oracle Archived Log Settings
 
-In this article
 
 If you back up an Oracle database, you can specify how Veeam Agent for Microsoft Windows must process archived logs:
 
@@ -16,7 +17,9 @@ If you back up an Oracle database, you can specify how Veeam Agent for Microsoft
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Microsoft VSS settings section, select Process transaction logs with this job.
 5. In the Processing Settings window, click the Oracle tab.
-6. To specify a user account that Veeam Agent for Microsoft Windows will use to connect to the Oracle database, select from the Specify Oracle account with SYSDBA privileges list a user account that has SYSDBA rights on the database. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
+6. To specify a user account that Veeam Agent for Microsoft Windows will use to connect to the Oracle database, select from the Specify Oracle account with SYSDBA privileges list a user account configured as specified in section [Permissions for Guest Processing](agents_permissions.md#guest).
+
+If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
 
 By default, the Use guest OS credentials option is selected in the list. With this option selected, Veeam Agent for Microsoft Windows will connect to the Oracle database under the account that you have specified for the protected computer in the protection group settings.
 
@@ -41,6 +44,4 @@ It is recommended that you select this option for databases for which the ARCHIV
 
 ![Oracle Archived Log Settings ](images/agent_job_vss_oracle.webp "Specify Oracle Archived Log Settings")
 
-Page updated 11/4/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/agent_job_vss_scripts.md
+++ b/docs/agent_job_vss_scripts.md
@@ -1,13 +1,14 @@
 ---
 title: "Pre-Freeze and Post-Thaw Scripts"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_vss_scripts.html"
-last_updated: "11/21/2025"
+last_updated: "1/20/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Pre-Freeze and Post-Thaw Scripts
 
-In this article
 
 If you plan to back up data of applications that do not support VSS, you can specify what scripts Veeam Agent for Microsoft Windows must use to quiesce the OS on the protected computer. The pre-freeze script quiesces the file system and application data to bring the OS to a consistent state before Veeam Agent for Microsoft Windows requests the creation of a VSS snapshot. After the VSS snapshot is created, the post-thaw script brings the file system and applications to their initial state.
 
@@ -17,7 +18,9 @@ To specify pre-freeze and post-thaw scripts for the job:
 2. Click Applications.
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Processing Settings window, click the Scripts tab.
-5. From the Specify admin account for script execution list, select a user account that Veeam Agent for Microsoft Windows will use to run pre-freeze and post-thaw scripts. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
+5. From the Specify admin account for script execution list, select a user account that Veeam Agent for Microsoft Windows will use to run pre-freeze and post-thaw scripts. This account must be a Microsoft Windows user account or a Group Managed Service Account (gMSA).
+
+If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
 
 By default, the Use guest credentials option is selected in the list. With this option selected, Veeam Agent for Microsoft Windows will run pre-freeze and post-thaw scripts under the account that you have specified for the protected computer in the protection group settings.
 
@@ -35,6 +38,4 @@ You can use scripts of other formats as well, but we cannot guarantee correct pr
 
 ![Pre-Freeze and Post-Thaw Scripts](images/agent_job_vss_scripts.webp "Specify Pre-Freeze and Post-Thaw Scripts")
 
-Page updated 11/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/agent_job_vss_sharepoint.md
+++ b/docs/agent_job_vss_sharepoint.md
@@ -1,13 +1,14 @@
 ---
 title: "Microsoft SharePoint Account Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_vss_sharepoint.html"
-last_updated: "11/28/2023"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Microsoft SharePoint Account Settings
 
-In this article
 
 If you back up Microsoft SharePoint, you must specify a user account that has enough permissions on the application:
 
@@ -15,12 +16,10 @@ If you back up Microsoft SharePoint, you must specify a user account that has en
 2. Click Applications.
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Processing Settings window, click the SharePoint tab.
-5. From the Specify SharePoint admin account list, select a user account that Veeam Agent for Microsoft Windows will use to connect to the SharePoint application. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
+5. From the Specify SharePoint admin account list, select a user account configured as specified in section [Permissions for Guest Processing](agents_permissions.md#guest). If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
 
 By default, the Use guest credentials option is selected in the list. With this option selected, Veeam Agent for Microsoft Windows will connect to the SharePoint application under the account that you have specified for the protected computer in the protection group settings.
 
 ![Microsoft SharePoint Account Settings](images/agent_job_vss_sharepoint.webp "Specify Microsoft SharePoint Account Settings")
 
-Page updated 11/28/2023
 
-Page content applies to build 13.0.1.1071

--- a/docs/agent_job_vss_sql.md
+++ b/docs/agent_job_vss_sql.md
@@ -1,13 +1,14 @@
 ---
 title: "Microsoft SQL Server Transaction Log Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_vss_sql.html"
-last_updated: "11/4/2025"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Microsoft SQL Server Transaction Log Settings
 
-In this article
 
 |  |
 | --- |
@@ -21,7 +22,9 @@ If you back up Microsoft SQL Server, you can specify how Veeam Agent for Microso
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Microsoft VSS settings section, select Process transaction logs with this job.
 5. In the Processing Settings window, click the SQL tab.
-6. To specify a user account that Veeam Agent will use to connect to the Microsoft SQL Server, select from the Specify Windows account with sysadmin role on SQL Server list a user account that has access permissions on the database. This account must be a Microsoft Windows user account with roles and permissions as specified in section [Permissions for Guest Processing](agents_permissions.md#guest). Keep in mind that you cannot use Microsoft SQL Server accounts (for example, the SA account) to connect to the database.
+6. To specify a user account that Veeam Agent will use to connect to the Microsoft SQL Server, select from the Specify Windows account with sysadmin role on SQL Server list a user account that has access permissions on the database. This account must be a Microsoft Windows user account or a Group Managed Service Account (gMSA) with roles and permissions as specified in section [Permissions for Guest Processing](agents_permissions.md#guest).
+
+Keep in mind that you cannot use Microsoft SQL Server accounts (for example, the SA account) to connect to the database.
 
 By default, the Use guest credentials option is selected in the list. With this option selected, Veeam Agent will connect to the Microsoft SQL Server under the account that you have specified for the protected computer in the protection group settings.
 
@@ -49,6 +52,4 @@ If you have selected to back up transaction logs with Veeam Agent for Microsoft 
 
 ![Microsoft SQL Server Transaction Log Settings ](images/agent_job_vss_sql.webp)
 
-Page updated 11/4/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/agent_policy_win_vss_oracle.md
+++ b/docs/agent_policy_win_vss_oracle.md
@@ -1,13 +1,14 @@
 ---
 title: "Oracle Archived Log Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_policy_win_vss_oracle.html"
-last_updated: "11/4/2025"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Oracle Archived Log Settings
 
-In this article
 
 If you back up an Oracle database, you can specify how Veeam Agent for Microsoft Windows must process archived logs:
 
@@ -16,7 +17,7 @@ If you back up an Oracle database, you can specify how Veeam Agent for Microsoft
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Microsoft VSS settings section, select Process transaction logs with this job.
 5. In the Processing Settings window, click the Oracle tab.
-6. To specify a user account that Veeam Agent for Microsoft Windows will use to connect to the Oracle database, select from the Specify Oracle account with SYSDBA privileges list a user account that has SYSDBA rights on the database. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
+6. To specify a user account that Veeam Agent for Microsoft Windows will use to connect to the Oracle database, select from the Specify Oracle account with SYSDBA privileges list a user account configured as specified in section [Permissions for Guest Processing](agents_permissions.md#guest).. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
 
 By default, the Use guest OS credentials option is selected in the list. With this option selected, Veeam Agent for Microsoft Windows will connect to the Oracle database under the account that you have specified for the protected computer in the protection group settings.
 
@@ -41,6 +42,4 @@ It is recommended that you select this option for databases for which the ARCHIV
 
 ![Oracle Archived Log Settings](images/agent_policy_win_vss_oracle.webp "Specify Oracle Archived Log Settings")
 
-Page updated 11/4/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/agent_policy_win_vss_sharepoint.md
+++ b/docs/agent_policy_win_vss_sharepoint.md
@@ -1,13 +1,14 @@
 ---
 title: "Microsoft SharePoint Account Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_policy_win_vss_sharepoint.html"
-last_updated: "6/19/2024"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Microsoft SharePoint Account Settings
 
-In this article
 
 If you back up Microsoft SharePoint, you must specify a user account that has enough permissions on the application:
 
@@ -15,12 +16,10 @@ If you back up Microsoft SharePoint, you must specify a user account that has en
 2. Click Applications.
 3. In the displayed list, select a protection group or individual computer and click Edit.
 4. In the Processing Settings window, click the SharePoint tab.
-5. From the Specify SharePoint admin account list, select a user account that Veeam Agent for Microsoft Windows will use to connect to the SharePoint application. If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
+5. From the Specify SharePoint admin account list, select a user account configured as specified in section [Permissions for Guest Processing](agents_permissions.md#guest). If you have not set up credentials beforehand, click the Manage accounts link or click Add on the right to add credentials.
 
 By default, the Use guest credentials option is selected in the list. With this option selected, Veeam Agent for Microsoft Windows will connect to the SharePoint application under the account that you have specified for the protected computer in the protection group settings.
 
 ![Microsoft SharePoint Account Settings](images/agent_policy_win_vss_sharepoint.webp "Specify Microsoft SharePoint Account Settings")
 
-Page updated 6/19/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_repo_edit.md
+++ b/docs/backup_repo_edit.md
@@ -1,13 +1,14 @@
 ---
 title: "Editing Settings of Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_repo_edit.html"
-last_updated: "6/22/2023"
+last_updated: "1/20/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Editing Settings of Backup Repositories
 
-In this article
 
 You can edit settings of backup repositories that you have added to the backup infrastructure.
 
@@ -19,7 +20,7 @@ You can edit settings of backup repositories that you have added to the backup i
 |  |
 | --- |
 | Tip |
-| The following column headers show information on the repository storage settings:   * The Capacity column header — specifies a full size of a storage location where you keep your backups. * The Free column header — specifies the amount of free space on a storage location. It considers a size of all data that is already added to this storage location without using Veeam Backup & Replication. For example, if the storage location capacity is 100 GB, and you added to this location data that occupies 50 GB, the Free column header will display 50 GB. * The Used Space column header — specifies the amount of space occupied by backups created by Veeam Backup & Replication. Note that it does not consider data compression and deduplication that is not performed by means of Veeam Backup & Replication. For example, if Veeam Backup & Replication creates a backup that occupies 10 GB, and a size of this backup decreases to 9 GB after compression or deduplication performed by a storage appliance, the Used Space column header will display 10 GB. * The Membership column header — specifies a scale-out backup repository to which repositories are added as performance extents. This column is hidden by default. To display it, right-click any column header and select Membership from the drop-down menu. |
+| The following column headers show information on the repository storage settings:   * The Capacity column header — specifies a full size of a storage location where you keep your backups. * The Free column header — specifies the amount of free space on a storage location. It considers a size of all data that is already added to this storage location without using Veeam Backup & Replication. For example, if the storage location capacity is 100 GB, and you added to this location data that occupies 50 GB, the Free column header will display 50 GB\*. * The Used Space column header — specifies the amount of space occupied by backups created by Veeam Backup & Replication. Note that it does not consider data compression and deduplication that is not performed by means of Veeam Backup & Replication. For example, if Veeam Backup & Replication creates a backup that occupies 10 GB, and a size of this backup decreases to 9 GB after compression or deduplication performed by a storage appliance, the Used Space column header will display 10 GB\*. * The Membership column header — specifies a scale-out backup repository to which repositories are added as performance extents. This column is hidden by default. To display it, right-click any column header and select Membership from the drop-down menu. |
 
 To edit settings of a backup repository:
 
@@ -30,6 +31,6 @@ To edit settings of a backup repository:
 
 [![Click to zoom in](images/edit_repository.webp)](images/edit_repository.webp "Click to zoom in")
 
-Page updated 6/22/2023
+\*Here and throughout this document GB is considered as 2^30 bytes, TB as 2^40 bytes.
 
-Page content applies to build 13.0.1.1071
+

--- a/docs/em/em_installation_byb.md
+++ b/docs/em/em_installation_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "em"
 source_url: "https://helpcenter.veeam.com/docs/vbr/em/em_installation_byb.html"
-last_updated: "11/18/2025"
+last_updated: "1/20/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -24,7 +24,7 @@ Before you install Veeam Backup Enterprise Manager, check the following prerequi
 
 Since Enterprise Manager connects to the postgres database to access the configuration database, do not rename the postgres database upon the Enterprise Manager installation.
 
-* Check the Known Issues section of the [Veeam Backup & Replication Release Notes](https://www.veeam.com/veeam_backup_12_release_notes_rn.pdf).
+* Check the Known Issues section of the [Veeam Backup & Replication Release Notes](https://helpcenter.veeam.com/rn/veeam_backup_13_0_1_release_notes.html).
 
 Configuring PostgreSQL Instance
 

--- a/docs/em/em_upgrade_byb.md
+++ b/docs/em/em_upgrade_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "em"
 source_url: "https://helpcenter.veeam.com/docs/vbr/em/em_upgrade_byb.html"
-last_updated: "1/13/2026"
+last_updated: "1/20/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -16,7 +16,7 @@ Before starting the upgrade procedure, read and follow the recommendations below
 * A machine on which you plan to install Enterprise Manager must meet the system requirements. For more information, see [System Requirements](system_requirements.md).
 * A user account that you plan to use for upgrade must have sufficient permissions. For more information, see [Permissions](required_permissions.md).
 * Backup infrastructure components communicate with each other over specific ports. These ports must be open. For more information, see [Ports](used_ports.md).
-* Check the Known Issues section of the [Veeam Backup & Replication Release Notes](https://www.veeam.com/veeam_backup_12_release_notes_rn.pdf).
+* Check the Known Issues section of the [Veeam Backup & Replication Release Notes](https://helpcenter.veeam.com/rn/veeam_backup_13_0_1_release_notes.html).
 * With Enterprise Manager and connected backup servers, begin the backup infrastructure upgrade process with Enterprise Manager. Backup servers must be upgraded after that. When you use different versions of Veeam Backup Enterprise Manager and Veeam Backup & Replication, you may not be able to leverage all features of Veeam Backup Enterprise Manager. Moreover, data collection from backup servers of earlier versions takes more time, which can be critical if many backup servers are added to Enterprise Manager.
 
 If you have a backup server installed on the same machine, upgrade it immediately after completing upgrade of the Enterprise Manager server. Otherwise, the Configuration Database Connection Settings utility will not work properly for Veeam Backup & Replication. For more information about the utility, see [Connecting Enterprise Manager to Another Configuration Database](dbconfig_utility.md).

--- a/docs/entraid/entra_id_ports.md
+++ b/docs/entraid/entra_id_ports.md
@@ -3,7 +3,7 @@ title: "Ports"
 product: "vbr"
 doc_type: "entraid"
 source_url: "https://helpcenter.veeam.com/docs/vbr/entraid/entra_id_ports.html"
-last_updated: "1/14/2026"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -20,12 +20,12 @@ The main ports required to create backups of Microsoft Entra ID tenants are list
 | [Optional] HTTP proxy server | TCP | HTTP proxy server port | Port used by Veeam Backup & Replication to redirect traffic to Microsoft Azure services through a proxy server.  Note: This port is required if you configure a proxy server as described in Veeam Backup & Replication User Guide, section [Configuring HTTP/HTTPS Proxies](https://helpcenter.veeam.com/docs/vbr/em/hmc_configure_proxies.html?ver=13). |
 | Microsoft Entra ID Services | TCP | 443 | Management and data transport port required for communication with Microsoft Azure.  Note: To access the necessary Azure service, you can use the IP address, DNS name or [virtual network service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview) of the service. If you want to use an IP address, you can download a .JSON file with the full list of Azure IP ranges and service tags from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519). |
 | Azure Resource Manager | TCP | 443 |
-| [Optional] Proxy server | Microsoft Entra ID Services (Service tag: AzureActiveDirectory) | TCP | 443 | Management and data transport port required for communication with Microsoft Azure though a proxy server.  Note: To access the necessary Azure service, you can use the IP address, DNS name or [virtual network service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview) of the service. If you want to use an IP address, you can download a .JSON file with the full list of Azure IP ranges and service tags from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519). |
+| [Optional] HTTP proxy server | Microsoft Entra ID Services (Service tag: AzureActiveDirectory) | TCP | 443 | Management and data transport port required for communication with Microsoft Azure though a proxy server.  Note: To access the necessary Azure service, you can use the IP address, DNS name or [virtual network service tag](https://learn.microsoft.com/en-us/azure/virtual-network/service-tags-overview) of the service. If you want to use an IP address, you can download a .JSON file with the full list of Azure IP ranges and service tags from the [Microsoft Download Center](https://www.microsoft.com/en-us/download/confirmation.aspx?id=56519). |
 | Azure Resource Manager (Service tag: AzureResourceManager) | TCP | 443 |
 
 |  |
 | --- |
 | Important |
-| As Veeam Backup for Microsoft Entra ID is installed on the same machine where Veeam Backup & Replication runs, it also uses the same [ports](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?ver=13#backup-server).  To be able to use the log backup, log backup copy and tenant backup copy features, you must configure the ports listed in the [Cache Repositories](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?zoom_highlight=cache+proxy&ver=13#cache-repository-connections) and [Backup Repositories](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?ver=13#backup-repositories) sections of the Veeam Backup & Replication User Guide. |
+| * As Veeam Backup for Microsoft Entra ID is installed on the same machine where Veeam Backup & Replication runs, it also uses the same [ports](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?ver=13#backup-server). To be able to use the log backup, log backup copy and tenant backup copy features, you must configure the ports listed in the [Cache Repositories](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?ver=13#cache-repository-connections) and [Backup Repositories](https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html?ver=13#backup-repositories) sections of the Veeam Backup & Replication User Guide. * Veeam Backup for Microsoft Entra ID does not support remote backup proxies — instead, the backup server performs the role of a general-purpose backup proxy. |
 
 

--- a/docs/events/event_10010.md
+++ b/docs/events/event_10010.md
@@ -1,0 +1,49 @@
+---
+title: "Restore Point Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_10010.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Created
+
+
+Sent when a restore point is created during a backup job session. For more information, see [Backup Chain](https://helpcenter.veeam.com/docs/backup/vsphere/backup_files.html).
+
+General Information
+
+Event ID: 10010
+
+Event message details: VM <VmName> restore point has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| OibID | Machine ID. | OibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" |
+| OriginalOibID | Original machine ID. | OriginalOibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VmName | Machine name. | VmName="VM01" |
+| ServerName | Server name. | ServerName="pdcsrv01.tech.local" |
+| DateTime | Date and time when a restore point has been created. | DateTime="03/20/2025 12:34:03" |
+| IsCorrupted | Defines whether a restore point is corrupted. | IsCorrupted="False" |
+| Platform | Platform type. | Platform="0" |
+| StorageSize | Storage size. | StorageSize="13874364416" |
+| RepositoryID | Backup repository ID. | RepositoryID="88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec" |
+| IsFull | Defines whether a restore point is a full backup. | IsFull="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM 'VM01' restore point has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:36:09.190062+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=10010 OibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" OriginalOibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" VmRef="vm-01" VmName="VM01" ServerName="pdcsrv01.tech.local" DateTime="03/20/2025 12:34:03" IsCorrupted="False" Platform="0" StorageSize="13874364416" RepositoryID="88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec" IsFull="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM 'VM01' restore point has been created."] |
+
+

--- a/docs/events/event_10014.md
+++ b/docs/events/event_10014.md
@@ -1,0 +1,52 @@
+---
+title: "Restore Point Offloaded to Tape"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_10014.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Offloaded to Tape
+
+
+Sent when a restore point offloaded to the tape.
+
+General Information
+
+Event ID: 10014
+
+Event message details: VM <VmName> restore point has been offloaded to the tape <Barcode>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="47d76d50-7c0c-4c4c-9af1-5452387cdb5a" |
+| JobID | Job ID. | JobID="140e8222-4640-4db5-8c13-2507e39899ad" |
+| JobType | Job type. | JobType="28" |
+| TaskSessionID | Task session ID. | TaskSessionID="ad191b3e-76c1-466b-b6cc-3853baf97288" |
+| RepositoryOibID | Repository machine ID. | RepositoryOibID="02e48eae-4314-4fe6-bd46-5e9fbcb48e00" |
+| TapeOibID | Tape machine ID. | TapeOibID="71f3f7cd-92fd-4aeb-a307-a61dfddb3e3c" |
+| TapeStorageID | Tape storage ID. | TapeStorageID="4d61131b-8195-4330-8194-22f9b887968a" |
+| TapeStorageCreationTime | Data and time when a tape storage has been created. | TapeStorageCreationTime="03/20/2025 08:56:09" |
+| TapeID | Tape ID. | TapeID="35c1e3cc-74eb-4648-899a-bc2a8bb4ead4" |
+| Barcode | Tape barcode. | Barcode="WRM000LS" |
+| MediaPoolID | Tape media pool ID. | MediaPoolID="e3262542-20c9-42c5-9534-77e5e17fbb92" |
+| MediaSetID | Tape media set ID. | MediaSetID="1697828487" |
+| SequenceNumber | Tape sequence number. | SequenceNumber="1" |
+| TapeUsedSize | Tape used size. | TapeUsedSize="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM 'VMware Server 01' restore point has been offloaded to the tape WRM000LS." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:01:41.849873+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=10014 JobSessionID="47d76d50-7c0c-4c4c-9af1-5452387cdb5a" JobID="140e8222-4640-4db5-8c13-2507e39899ad" JobType="28" TaskSessionID="ad191b3e-76c1-466b-b6cc-3853baf97288" RepositoryOibID="02e48eae-4314-4fe6-bd46-5e9fbcb48e00" TapeOibID="71f3f7cd-92fd-4aeb-a307-a61dfddb3e3c" TapeStorageID="4d61131b-8195-4330-8194-22f9b887968a" TapeStorageCreationTime="03/20/2025 08:56:09" TapeID="35c1e3cc-74eb-4648-899a-bc2a8bb4ead4" Barcode="WRM000LS" MediaPoolID="e3262542-20c9-42c5-9534-77e5e17fbb92" MediaSetID="1697828487" SequenceNumber="1" TapeUsedSize="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM 'VMware Server 01' restore point has been offloaded to the tape WRM000LS."] |
+
+

--- a/docs/events/event_10050.md
+++ b/docs/events/event_10050.md
@@ -1,0 +1,49 @@
+---
+title: "Restore Point Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_10050.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Deleted
+
+
+Sent when a user deletes a restore point.
+
+General Information
+
+Event ID: 10050
+
+Event message details: Restore point for VM <VmName> has been removed by user <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| OibID | Machine ID. | OibID="3419db28-e212-48d7-9d63-67fd22a0a5c9" |
+| OriginalOibID | Original machine ID. | OriginalOibID="3419db28-e212-48d7-9d63-67fd22a0a5c9" |
+| VmRef | Machine reference ID. | VmRef="vm-02" |
+| VmName | Machine name. | VmName="VM02" |
+| ServerName | Server name. | ServerName="pdcsrv01.tech.local" |
+| DateTime | Date and time when a restore point has been created. | DateTime="03/20/2025 12:27:27" |
+| IsCorrupted | Defines whether a restore point is corrupted. | IsCorrupted="False" |
+| Platform | Platform type. | Platform="0" |
+| StorageSize | Storage size. | StorageSize="13873971200" |
+| RepositoryID | Backup repository ID. | RepositoryID="88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec" |
+| IsFull | Defines whether a restore point is a full backup. | IsFull="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore point for VM 'VM02' has been removed by user SYSTEM." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:27:27.401249+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=10050 OibID="3419db28-e212-48d7-9d63-67fd22a0a5c9" OriginalOibID="3419db28-e212-48d7-9d63-67fd22a0a5c9" VmRef="vm-02" VmName="VM02" ServerName="pdcsrv01.tech.local" DateTime="03/20/2025 12:27:27" IsCorrupted="False" Platform="0" StorageSize="13873971200" RepositoryID="88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec" IsFull="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore point for VM 'VM02' has been removed by user SYSTEM."] |
+
+

--- a/docs/events/event_10090.md
+++ b/docs/events/event_10090.md
@@ -1,0 +1,45 @@
+---
+title: "Restore Point Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_10090.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Updated
+
+
+Sent when a restore point is modified during a backup job session.
+
+General Information
+
+Event ID: 10090
+
+Event message details: VM <VmName> restore point has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| OibID | Machine ID. | OibID="13bc8b20-5da1-41f5-a3bb-3846130b2ce1" |
+| OriginalOibID | Original machine ID. | OriginalOibID="13bc8b20-5da1-41f5-a3bb-3846130b2ce1" |
+| IsCorrupted | Defines whether a restore point is corrupted. | IsCorrupted="False" |
+| Platform | Platform type. | Platform="0" |
+| StorageSize | Storage size. | StorageSize="23163547648" |
+| RepositoryID | Backup repository ID. | RepositoryID="af65f830-d196-40c9-a4bf-b54818481c99" |
+| IsFull | Defines whether a restore point is a full backup. | IsFull="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM 'VM03' restore point has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T10:27:12.477121-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=10090 OibID="13bc8b20-5da1-41f5-a3bb-3846130b2ce1" OriginalOibID="13bc8b20-5da1-41f5-a3bb-3846130b2ce1" IsCorrupted="False" Platform="0" StorageSize="23163547648" RepositoryID="af65f830-d196-40c9-a4bf-b54818481c99" IsFull="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM 'VM03' restore point has been modified."] |
+
+

--- a/docs/events/event_110.md
+++ b/docs/events/event_110.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_110.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Job Started
+
+
+Sent when a user starts a backup job session. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 110
+
+Event message details: Backup job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" |
+| JobID | Job ID. | JobID="c4415b30-de82-4403-8816-ea66636356e8" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="0" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup job 'VMware Production servers backup' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:32:51.289460+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=110 JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" JobID="c4415b30-de82-4403-8816-ea66636356e8" JobType="0" Platform="0" Flags="1" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup job 'VMware Production servers backup' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_114.md
+++ b/docs/events/event_114.md
@@ -1,0 +1,46 @@
+---
+title: "File to Tape Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_114.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File to Tape Job Started
+
+
+Sent when a user starts a file to tape job session. For more information, see [Creating File to Tape Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/creating_file_to_tape_jobs.html).
+
+General Information
+
+Event ID: 114
+
+Event message details: File to Tape Backup job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="0132c6cd-da23-448b-ae2d-d99f8a159af4" |
+| JobID | Job ID. | JobID="d6438c9f-239c-4728-9dd7-ace7bb36718a" |
+| JobType | Job type. | JobType="24" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="73502813-abc9-4576-849a-903b7d428177" |
+| OperationSummary | Operation details. | OperationSummary="File to tape: HPE007L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File to Tape Backup job 'Files to Tape' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T13:28:31.625928+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=114 JobSessionID="0132c6cd-da23-448b-ae2d-d99f8a159af4" JobID="d6438c9f-239c-4728-9dd7-ace7bb36718a" JobType="24" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="73502813-abc9-4576-849a-903b7d428177" OperationSummary="File to tape: HPE007L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File to Tape Backup job 'Files to Tape' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_115.md
+++ b/docs/events/event_115.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Erase Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_115.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Erase Job Started
+
+
+Sent when a user starts a tape erase job session. For more information, see [Erasing Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/erasing_tapes.html).
+
+General Information
+
+Event ID: 115
+
+Event message details: Tape Erase job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="7b5cae3a-6997-400b-afd5-8b789b6489e1" |
+| JobID | Job ID. | JobID="6ffc9539-d78c-45cc-9b32-086e140e754a" |
+| JobType | Job type. | JobType="32" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="73502813-abc9-4576-849a-903b7d428177" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to erase: HPE007L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Erase job 'Tape Erase' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:56:46.520387+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=115 JobSessionID="7b5cae3a-6997-400b-afd5-8b789b6489e1" JobID="6ffc9539-d78c-45cc-9b32-086e140e754a" JobType="32" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="73502813-abc9-4576-849a-903b7d428177" OperationSummary="Tapes to erase: HPE007L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Erase job 'Tape Erase' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_116.md
+++ b/docs/events/event_116.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Inventorying Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_116.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Inventorying Job Started
+
+
+Sent when a user starts a tape inventorying job session. For more information, see [Inventorying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/inventoring_tapes.html).
+
+General Information
+
+Event ID: 116
+
+Event message details: Tape Inventorying job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="6699d585-5290-4589-b2fb-40cc1b70953d" |
+| JobID | Job ID. | JobID="3ec9002a-9788-40f4-9a43-b5b690bd4253" |
+| JobType | Job type. | JobType="36" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="73502813-abc9-4576-849a-903b7d428177" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to inventory: HPE007L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Inventorying job 'Tape Library Inventorying' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:58:58.946951+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=116 JobSessionID="6699d585-5290-4589-b2fb-40cc1b70953d" JobID="3ec9002a-9788-40f4-9a43-b5b690bd4253" JobType="36" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="73502813-abc9-4576-849a-903b7d428177" OperationSummary="Tapes to inventory: HPE007L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Inventorying job 'Tape Library Inventorying has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_117.md
+++ b/docs/events/event_117.md
@@ -1,0 +1,23 @@
+---
+title: "Tape Cataloging Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_117.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Cataloging Job Started
+
+
+Sent when a user starts a tape cataloging job session. For more information, see [Cataloging Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/cataloging_tapes.html).
+
+General Information
+
+Event ID: 117
+
+Event message details: Tape Cataloging job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+

--- a/docs/events/event_118.md
+++ b/docs/events/event_118.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Verification Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_118.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Verification Job Started
+
+
+Sent when a user starts a tape verification job session. For more information, see [Verifying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/verifying_tapes.html).
+
+General Information
+
+Event ID: 118
+
+Event message details: Validate session has been initiated by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Description. | JobSessionID="6913f76f-4b00-470b-b2ce-badf2129c2f0" |
+| RestoreType | Restore type. | RestoreType="0" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| Platform | Platform type. | Platform="5" |
+| TargetObjectID | Target object ID. | TargetObject="00000000-0000-0000-0000-000000000000" |
+| SourceObjects | Source object IDs. | SourceObjects="b226f493-92ee-4b0e-b7b9-3590cec4ae1d" |
+| ExtraData | Operation details. | ExtraData="Tapes to validate: WRM000LS" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Validate session has been initiated by 'TECH\user1'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:59:11.688200+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=118 JobSessionID="6913f76f-4b00-470b-b2ce-badf2129c2f0" RestoreType="0" InitiatorName="TECH\user1" Platform="5" TargetObjectID="00000000-0000-0000-0000-000000000000" SourceObjects="b226f493-92ee-4b0e-b7b9-3590cec4ae1d" ExtraData="Tapes to validate: WRM000LS" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Validate session has been initiated by 'TECH\user1'."] |
+
+

--- a/docs/events/event_119.md
+++ b/docs/events/event_119.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Export Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_119.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Export Job Started
+
+
+Sent when a user starts a tape export job session. For more information, see [Exporting Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/importing_exporting_tape_media.html).
+
+General Information
+
+Event ID: 119
+
+Event message details: Tape Export job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" |
+| JobID | Job ID. | JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" |
+| JobType | Job type. | JobType="34" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="6e2d5920-cede-443f-aabd-e8072dc9f729" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to export: HPE009L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Export job 'Tape Export' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:02:49.813348+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=119 JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" JobType="34" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="6e2d5920-cede-443f-aabd-e8072dc9f729" OperationSummary="Tapes to export: HPE009L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Export job 'Tape Export' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_120.md
+++ b/docs/events/event_120.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Copy Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_120.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Copy Job Started
+
+
+Sent when a user starts a tape copy job session. For more information, see [Copying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/copying_tapes.html).
+
+General Information
+
+Event ID: 120
+
+Event message details: Tape Copy job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e00b4e4f-0bea-4444-b27c-34f1da944f68" |
+| JobID | Job ID. | JobID="1bb59d9d-729e-46a9-944b-4075fe049f79" |
+| JobType | Job type. | JobType="501" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetMediaPoolID | Target media pool ID. | TargetMediaPoolID="3730b44e-ce27-405b-ac31-d065294746ca" |
+| TapeIDs | Tape IDs. | TapeIDs="02fe017d-1e14-4711-85ba-cac8d53c7ec5" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to copy: HPE008L2; target pool: HPE - Standard Pool" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Copy job 'Tape Copy' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:03:42.229899+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=120 JobSessionID="e00b4e4f-0bea-4444-b27c-34f1da944f68" JobID="1bb59d9d-729e-46a9-944b-4075fe049f79" JobType="501" Platform="5" Flags="1" TargetMediaPoolID="3730b44e-ce27-405b-ac31-d065294746ca" TapeIDs="02fe017d-1e14-4711-85ba-cac8d53c7ec5" OperationSummary="Tapes to copy: HPE008L2; target pool: HPE - Standard Pool" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Copy job 'Tape Copy' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_121.md
+++ b/docs/events/event_121.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Eject Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_121.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Eject Job Started
+
+
+Sent when a user starts a tape eject job session. For more information, see [Ejecting Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/ejecting_tapes.html).
+
+General Information
+
+Event ID: 121
+
+Event message details: Tape Eject job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="d87d298a-c4e2-428d-8493-7b535975715d" |
+| JobID | Job ID. | JobID="3257e163-8a43-4426-a6f4-cf3acb5345e9" |
+| JobType | Job type. | JobType="33" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="d85af4ee-38e6-4e57-9ccd-9b02abf56201" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to eject: HPE002L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description=Tape Eject job 'Tape Eject' has been started by user TECH\user1."" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:03:07.935655+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=121 JobSessionID="d87d298a-c4e2-428d-8493-7b535975715d" JobID="3257e163-8a43-4426-a6f4-cf3acb5345e9" JobType="33" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="d85af4ee-38e6-4e57-9ccd-9b02abf56201" OperationSummary="Tapes to eject: HPE002L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Eject job 'Tape Eject' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_122.md
+++ b/docs/events/event_122.md
@@ -1,0 +1,46 @@
+---
+title: "Mark Tape As Free Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_122.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Mark Tape As Free Job Started
+
+
+Sent when a user starts a mark tape as free job session. For more information, see [Marking Tapes as Free](https://helpcenter.veeam.com/docs/backup/vsphere/marking_tapes_as_free.html).
+
+General Information
+
+Event ID: 122
+
+Event message details: Mark as Free job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e905fe5d-72fb-4d1c-beff-b9eee2f9861b" |
+| JobID | Job ID. | JobID="af8071ed-2ce4-4cdd-93a5-244c18364c48" |
+| JobType | Job type. | JobType="55" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="9c401c8c-36f7-499a-b420-b913186d5a5e" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to mark as free: HPE005L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Mark as Free job 'Mark as Free' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:11.312736+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=122 JobSessionID="e905fe5d-72fb-4d1c-beff-b9eee2f9861b" JobID="af8071ed-2ce4-4cdd-93a5-244c18364c48" JobType="55" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="9c401c8c-36f7-499a-b420-b913186d5a5e" OperationSummary="Tapes to mark as free: HPE005L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Mark as Free job 'Mark as Free' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_123.md
+++ b/docs/events/event_123.md
@@ -1,0 +1,46 @@
+---
+title: "Move To Media Pool Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_123.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Move To Media Pool Job Started
+
+
+Sent when a user starts a move to media pool job session. For more information, see [Moving Tapes to Another Media Pool](https://helpcenter.veeam.com/docs/backup/vsphere/moving_tapes_to_custom_pool.html).
+
+General Information
+
+Event ID: 123
+
+Event message details: Move to Media Pool job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="7f1ffcb6-698a-4c42-b8b2-c2f518a5d620" |
+| JobID | Job ID. | JobID="bc6e8331-8781-4fc7-85ec-9dd5c7687f3a" |
+| JobType | Job type. | JobType="57" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetMediaPoolID | Target media pool ID. | TargetMediaPoolID="3730b44e-ce27-405b-ac31-d065294746ca" |
+| TapeIDs | Tape IDs. | TapeIDs="02fe017d-1e14-4711-85ba-cac8d53c7ec5" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to move: HPE008L2; target pool: HPE - Standard Pool" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Move to Media Pool job 'Move to Media Pool' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:20.412346+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=123 JobSessionID="7f1ffcb6-698a-4c42-b8b2-c2f518a5d620" JobID="bc6e8331-8781-4fc7-85ec-9dd5c7687f3a" JobType="57" Platform="5" Flags="1" TargetMediaPoolID="3730b44e-ce27-405b-ac31-d065294746ca" TapeIDs="02fe017d-1e14-4711-85ba-cac8d53c7ec5" OperationSummary="Tapes to move: HPE008L2; target pool: HPE - Standard Pool" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Move to Media Pool job 'Move to Media Pool' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_124.md
+++ b/docs/events/event_124.md
@@ -1,0 +1,46 @@
+---
+title: "Delete From Library Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_124.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Delete From Library Job Started
+
+
+Sent when a user starts a delete from library job session.
+
+General Information
+
+Event ID: 124
+
+Event message details: Delete from Library job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="dd5e025f-7e6b-467a-94ba-c9e7c2911854" |
+| JobID | Job ID. | JobID="61fab03f-3065-431f-a2ef-1e4e141fe8e0" |
+| JobType | Job type. | JobType="56" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| TapeIDs | Tape IDs. | TapeIDs="6e2d5920-cede-443f-aabd-e8072dc9f729" |
+| OperationSummary | Operation details. | OperationSummary="Tapes to delete from library: HPE009L2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Delete from Library job 'Delete from Library' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:28.921117+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=124 JobSessionID="dd5e025f-7e6b-467a-94ba-c9e7c2911854" JobID="61fab03f-3065-431f-a2ef-1e4e141fe8e0" JobType="56" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" TapeIDs="6e2d5920-cede-443f-aabd-e8072dc9f729" OperationSummary="Tapes to delete from library: HPE009L2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Delete from Library job 'Delete from Library' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_125.md
+++ b/docs/events/event_125.md
@@ -1,0 +1,44 @@
+---
+title: "Library Discovery Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_125.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Library Discovery Job Started
+
+
+Sent when a user starts a library discovery job session. For more information, see [Inventorying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/inventoring_tapes.html).
+
+General Information
+
+Event ID: 125
+
+Event message details: Tape Library Discovery job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="85d54fa0-620f-42d0-8a56-ec9a87e858c2" |
+| JobID | Job ID. | JobID="4a9c5b19-283c-47a7-8179-103988a1aeec" |
+| JobType | Job type. | JobType="37" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Library Discovery job 'Tape Library Discovery' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:16:32.762154+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=125 JobSessionID="85d54fa0-620f-42d0-8a56-ec9a87e858c2" JobID="4a9c5b19-283c-47a7-8179-103988a1aeec" JobType="37" Platform="5" Flags="1" TargetObjectID="00000000-0000-0000-0000-000000000000" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Library Discovery job 'Tape Library Discovery' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_126.md
+++ b/docs/events/event_126.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Import Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_126.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Import Job Started
+
+
+Sent when a user starts a tape import job session. For more information, see [Loading Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/import_tapes.html).
+
+General Information
+
+Event ID: 126
+
+Event message details: Tape Import job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="8f26e24f-eeac-4606-9502-cf2ff0152af6" |
+| JobID | Job ID. | JobID="5137cdc1-9bc4-44e3-994c-919b4b709451" |
+| JobType | Job type. | JobType="35" |
+| Platform | Platform type. | Platform="5" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| TapeLibraryID | Tape library ID. | TapeLibraryID="15b8f345-b87d-406f-a5d9-cd1b0561bcfe" |
+| TapeIDs | Tape IDs. | TapeIDs="d85af4ee-38e6-4e57-9ccd-9b02abf56201" |
+| OperationSummary | Operation details. | OperationSummary="Library to import from: " |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Import job 'Tape Import' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:59:25.371237+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=126 JobSessionID="8f26e24f-eeac-4606-9502-cf2ff0152af6" JobID="5137cdc1-9bc4-44e3-994c-919b4b709451" JobType="35" Platform="5" Flags="1" TapeLibraryID="15b8f345-b87d-406f-a5d9-cd1b0561bcfe" TapeIDs="d85af4ee-38e6-4e57-9ccd-9b02abf56201" OperationSummary="Library to import from: " VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Import job 'Tape Import' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_150.md
+++ b/docs/events/event_150.md
@@ -1,0 +1,54 @@
+---
+title: "Backup Task Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_150.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Task Finished
+
+
+Sent when a backup task is finished. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 150
+
+Event message details: <VmName> task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" |
+| JobID | Job ID. | JobID="c4415b30-de82-4403-8816-ea66636356e8" |
+| JobType | Job type. | JobType="0" |
+| TaskSessionID | Task session ID. | TaskSessionID="5005b373-ad69-4081-a50a-835387c66824" |
+| OibID | Machine ID. | OibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" |
+| OriginalOibID | Original machine ID. | OriginalOibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" |
+| CreationTime | Date and time when a restore point has been created. | CreationTime="03/20/2025 12:34:03" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="0" |
+| JobDescription | Job description. | JobDescription="Created by Powershell at 03/20/2025 8:56:14 AM." |
+| SourceHostName | Source host name. | SourceHostName="pdc01.tech.local" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VmName | Machine name. | VmName="VM01" |
+| TransferredGb | Transferred data in GB. | TransferredGb="12.731" |
+| Platform | Platform type. | Platform="0" |
+| IsRetry | Defines whether the job will be retried. | IsRetry="False" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM01 task has finished with 'Success' state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:36:09.190062+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=150 JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" JobID="c4415b30-de82-4403-8816-ea66636356e8" JobType="0" TaskSessionID="5005b373-ad69-4081-a50a-835387c66824" OibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" OriginalOibID="35503d1d-28f9-49ed-82d5-b81c33f9d978" CreationTime="03/20/2025 12:34:03" Status="0" JobDescription="Created by Powershell at 03/20/2025 8:56:14 AM." SourceHostName="pdc01.tech.local" VmRef="vm-01" VmName="VM01" TransferredGb="12.731" Platform="0" IsRetry="False" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM01 task has finished with 'Success' state."] |
+
+

--- a/docs/events/event_151.md
+++ b/docs/events/event_151.md
@@ -1,0 +1,50 @@
+---
+title: "File Backup Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_151.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Backup Job Finished
+
+
+Sent when a file backup job session is finished. For more information, see [Creating File Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/file_share_backup_job.html).
+
+General Information
+
+Event ID: 151
+
+Event message details: Source <SourceName> task has finished with <State> state. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e2ae09f0-97d5-4e7e-8b5d-51f226f11ce7" |
+| JobID | Job ID. | JobID="21d267c3-1746-4806-800b-eca787723eae" |
+| JobType | Job type. | JobType="13000" |
+| TaskSessionID | Task session ID. | TaskSessionID="8794851b-fbf8-4560-9f59-401d8ca2b921" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="0" |
+| JobDescription | Job description. | JobDescription="SMB File Share backup" |
+| SourceHostName | Source host name. | SourceHostName="\\fs1\Folder" |
+| SourceName | Source name. | SourceName="\\fs1\Folder" |
+| TransferredGb | Transferred data in GB. | TransferredGb="0.059" |
+| Platform | Platform type. | Platform="11" |
+| IsRetry | Defines whether the job will be retried. | IsRetry="False" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Source '\\fs1\Folder' task has finished with 'Success' state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:11:59.583443+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=151 JobSessionID="e2ae09f0-97d5-4e7e-8b5d-51f226f11ce7" JobID="21d267c3-1746-4806-800b-eca787723eae" JobType="13000" TaskSessionID="8794851b-fbf8-4560-9f59-401d8ca2b921" Status="0" JobDescription="SMB File Share backup" SourceHostName="\\fs1\Folder" SourceName="\\fs1\Folder" TransferredGb="0.059" Platform="11" IsRetry="False" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Source '\\fs1\Folder' task has finished with 'Success' state."] |
+
+

--- a/docs/events/event_190.md
+++ b/docs/events/event_190.md
@@ -1,0 +1,46 @@
+---
+title: "Backup Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_190.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Job Finished
+
+
+Sent when a backup job session is finished. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 190
+
+Event message details: Backup job <JobName> finished with <State>. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" |
+| JobID | Job ID. | JobID="c4415b30-de82-4403-8816-ea66636356e8" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="0" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="VMware Production servers backup" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup job 'VMware Production servers backup' finished with Success. All objects have been backed up successfully." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:36:16.008569+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=190 JobSessionID="c0d93abe-3adf-4397-b762-351b73acf7e1" JobID="c4415b30-de82-4403-8816-ea66636356e8" JobResult="0" JobType="0" Platform="0" WillBeRetried="False" JobName="VMware Production servers backup" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup job 'VMware Production servers backup' finished with Success. All objects have been backed up successfully."] |
+
+

--- a/docs/events/event_194.md
+++ b/docs/events/event_194.md
@@ -1,0 +1,46 @@
+---
+title: "File to Tape Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_194.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File to Tape Job Finished
+
+
+Sent when a file to tape job session is finished. For more information, see [Creating File to Tape Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/creating_file_to_tape_jobs.html).
+
+General Information
+
+Event ID: 194
+
+Event message details: File to Tape Backup job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="0132c6cd-da23-448b-ae2d-d99f8a159af4" |
+| JobID | Job ID. | JobID="d6438c9f-239c-4728-9dd7-ace7bb36718a" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="24" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Files to Tape" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File to Tape Backup job 'Files to Tape' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T13:28:43.744565+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=194 JobSessionID="0132c6cd-da23-448b-ae2d-d99f8a159af4" JobID="d6438c9f-239c-4728-9dd7-ace7bb36718a" JobResult="0" JobType="24" Platform="5" WillBeRetried="False" JobName="Files to Tape" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File to Tape Backup job 'Files to Tape' finished with Success."] |
+
+

--- a/docs/events/event_195.md
+++ b/docs/events/event_195.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Erase Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_195.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Erase Job Finished
+
+
+Sent when a tape erase job session is finished. For more information, see [Erasing Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/erasing_tapes.html).
+
+General Information
+
+Event ID: 195
+
+Event message details: Tape Erase job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" |
+| JobID | Job ID. | JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="34" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Export" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Erase job 'Tape Export' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:02:50.798477+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=195 JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" JobResult="0" JobType="34" Platform="5" WillBeRetried="False" JobName="Tape Export" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Erase job 'Tape Export' finished with Success."] |
+
+

--- a/docs/events/event_196.md
+++ b/docs/events/event_196.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Inventorying Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_196.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Inventorying Job Finished
+
+
+Sent when a tape inventorying job session is finished. For more information, see [Inventorying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/inventoring_tapes.html).
+
+General Information
+
+Event ID: 196
+
+Event message details: Tape Inventorying job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="6699d585-5290-4589-b2fb-40cc1b70953d" |
+| JobID | Job ID. | JobID="3ec9002a-9788-40f4-9a43-b5b690bd4253" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="36" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Library Inventorying" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Inventorying job 'Tape Library Inventorying' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:59:03.730613+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=196 JobSessionID="6699d585-5290-4589-b2fb-40cc1b70953d" JobID="3ec9002a-9788-40f4-9a43-b5b690bd4253" JobResult="0" JobType="36" Platform="5" WillBeRetried="False" JobName="Tape Library Inventorying" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Inventorying job 'Tape Library Inventorying' finished with Success."] |
+
+

--- a/docs/events/event_197.md
+++ b/docs/events/event_197.md
@@ -1,0 +1,23 @@
+---
+title: "Tape Cataloging Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_197.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Cataloging Job Finished
+
+
+Sent when a tape cataloging job session is finished. For more information, see [Cataloging Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/cataloging_tapes.html).
+
+General Information
+
+Event ID: 197
+
+Event message details: Tape Cataloging job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+

--- a/docs/events/event_198.md
+++ b/docs/events/event_198.md
@@ -1,0 +1,41 @@
+---
+title: "Tape Verification Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_198.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Verification Job Finished
+
+
+Sent when a tape verification job session is finished. For more information, see [Verifying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/verifying_tapes.html).
+
+General Information
+
+Event ID: 198
+
+Event message details: The validate session has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="6913f76f-4b00-470b-b2ce-badf2129c2f0" |
+| Result | Result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="The validate session has finished with Success state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:59:15.659797+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=198 JobSessionID="6913f76f-4b00-470b-b2ce-badf2129c2f0" Result="0" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="The validate session has finished with Success state."] |
+
+

--- a/docs/events/event_199.md
+++ b/docs/events/event_199.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Export Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_199.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Export Job Finished
+
+
+Sent when a tape export job session is finished. ForFor more information, see [Exporting Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/importing_exporting_tape_media.html).
+
+General Information
+
+Event ID: 199
+
+Event message details: Tape Export job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" |
+| JobID | Job ID. | JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="34" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Export" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Export job 'Tape Export' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:02:50.798477+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=199 JobSessionID="02532b59-4908-44df-9350-bf184faccf5a" JobID="a66e65ba-a34b-4829-8a62-9c7ad2a91df0" JobResult="0" JobType="34" Platform="5" WillBeRetried="False" JobName="Tape Export" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Export job 'Tape Export' finished with Success."] |
+
+

--- a/docs/events/event_200.md
+++ b/docs/events/event_200.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Copy Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Copy Job Finished
+
+
+Sent when a tape copy job session is finished. For more information, see [Copying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/copying_tapes.html).
+
+General Information
+
+Event ID: 200
+
+Event message details: Tape Copy job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e00b4e4f-0bea-4444-b27c-34f1da944f68" |
+| JobID | Job ID. | JobID="1bb59d9d-729e-46a9-944b-4075fe049f79" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="501" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Copy" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Copy job 'Tape Copy' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:04:11.064253+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=200 JobSessionID="e00b4e4f-0bea-4444-b27c-34f1da944f68" JobID="1bb59d9d-729e-46a9-944b-4075fe049f79" JobResult="0" JobType="501" Platform="5" WillBeRetried="False" JobName="Tape Copy" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Copy job 'Tape Copy' finished with Success."] |
+
+

--- a/docs/events/event_20114.md
+++ b/docs/events/event_20114.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Renamed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_20114.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Renamed
+
+
+Sent when a user renames a tape. For more information, see [Viewing Tape Properties](https://helpcenter.veeam.com/docs/backup/vsphere/identifying_tapes.html).
+
+General Information
+
+Event ID: 20114
+
+Event message details: Tape <Barcode> has been renamed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeID | Tape ID. | TapeID="7cb0fced-4449-461c-88c4-0d17c25d43de" |
+| Barcode | Tape barcode. | Barcode="HPE007L2" |
+| MediaPoolID | Tape media pool ID. | MediaPoolID="2dfd969d-e7c6-4b67-9922-ea2f67478dcc" |
+| MediaSetID | Tape media set ID. | MediaSetID="1697828487" |
+| SequenceNumber | Tape sequence number. | SequenceNumber="1" |
+| TapeUsedSize | Tape used size. | TapeUsedSize="0" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape HPE007L2 has been renamed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:04:10.181972+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=20114 TapeID="7cb0fced-4449-461c-88c4-0d17c25d43de" Barcode="HPE007L2" MediaPoolID="2dfd969d-e7c6-4b67-9922-ea2f67478dcc" MediaSetID="1697828487" SequenceNumber="1" TapeUsedSize="0" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape HPE007L2 has been renamed."] |
+
+

--- a/docs/events/event_203.md
+++ b/docs/events/event_203.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Eject Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_203.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Eject Job Finished
+
+
+Sent when a tape eject job session is finished. For more information, see [Ejecting Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/ejecting_tapes.html).
+
+General Information
+
+Event ID: 203
+
+Event message details: Tape Eject job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="d87d298a-c4e2-428d-8493-7b535975715d" |
+| JobID | Job ID. | JobID="3257e163-8a43-4426-a6f4-cf3acb5345e9" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="33" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Eject" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Eject job 'Tape Eject' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:03:09.390196+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=203 JobSessionID="d87d298a-c4e2-428d-8493-7b535975715d" JobID="3257e163-8a43-4426-a6f4-cf3acb5345e9" JobResult="0" JobType="33" Platform="5" WillBeRetried="False" JobName="Tape Eject" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Eject job 'Tape Eject' finished with Success."] |
+
+

--- a/docs/events/event_204.md
+++ b/docs/events/event_204.md
@@ -1,0 +1,46 @@
+---
+title: "Mark Tape As Free Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_204.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Mark Tape As Free Job Finished
+
+
+Sent when a mark tape as free job session is finished. For more information, see [Marking Tapes as Free](https://helpcenter.veeam.com/docs/backup/vsphere/marking_tapes_as_free.html).
+
+General Information
+
+Event ID: 204
+
+Event message details: Mark as Free job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e905fe5d-72fb-4d1c-beff-b9eee2f9861b" |
+| JobID | Job ID. | JobID="af8071ed-2ce4-4cdd-93a5-244c18364c48" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="55" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Mark as Free" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Mark as Free job 'Mark as Free' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:11.656473+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=204 JobSessionID="e905fe5d-72fb-4d1c-beff-b9eee2f9861b" JobID="af8071ed-2ce4-4cdd-93a5-244c18364c48" JobResult="0" JobType="55" Platform="5" WillBeRetried="False" JobName="Mark as Free" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Mark as Free job 'Mark as Free' finished with Success."] |
+
+

--- a/docs/events/event_205.md
+++ b/docs/events/event_205.md
@@ -1,0 +1,46 @@
+---
+title: "Move To Media Pool Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_205.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Move To Media Pool Job Finished
+
+
+Sent when a move to media pool job session is finished. For more information, see [Moving Tapes to Another Media Pool](https://helpcenter.veeam.com/docs/backup/vsphere/moving_tapes_to_custom_pool.html).
+
+General Information
+
+Event ID: 205
+
+Event message details: Move to Media Pool job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="7f1ffcb6-698a-4c42-b8b2-c2f518a5d620" |
+| JobID | Job ID. | JobID="bc6e8331-8781-4fc7-85ec-9dd5c7687f3a" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="57" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Move to Media Pool" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Move to Media Pool job 'Move to Media Pool' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:20.803462+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=205 JobSessionID="7f1ffcb6-698a-4c42-b8b2-c2f518a5d620" JobID="bc6e8331-8781-4fc7-85ec-9dd5c7687f3a" JobResult="0" JobType="57" Platform="5" WillBeRetried="False" JobName="Move to Media Pool" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Move to Media Pool job 'Move to Media Pool' finished with Success."] |
+
+

--- a/docs/events/event_206.md
+++ b/docs/events/event_206.md
@@ -1,0 +1,46 @@
+---
+title: "Delete From Library Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_206.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Delete From Library Job Finished
+
+
+Sent when a delete from library job session is finished.
+
+General Information
+
+Event ID: 206
+
+Event message details: Delete from Library job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="dd5e025f-7e6b-467a-94ba-c9e7c2911854" |
+| JobID | Job ID. | JobID="61fab03f-3065-431f-a2ef-1e4e141fe8e0" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="56" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Delete from Library" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Delete from Library job 'Delete from Library' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:29.358624+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=206 JobSessionID="dd5e025f-7e6b-467a-94ba-c9e7c2911854" JobID="61fab03f-3065-431f-a2ef-1e4e141fe8e0" JobResult="0" JobType="56" Platform="5" WillBeRetried="False" JobName="Delete from Library" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Delete from Library job 'Delete from Library' finished with Success."] |
+
+

--- a/docs/events/event_207.md
+++ b/docs/events/event_207.md
@@ -1,0 +1,46 @@
+---
+title: "Library Discovery Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_207.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Library Discovery Job Finished
+
+
+Sent when a library discovery job session is finished. For more information, see [Inventorying Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/inventoring_tapes.html).
+
+General Information
+
+Event ID: 207
+
+Event message details: Tape Library Discovery job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e0688fcb-f2e6-4cff-88d3-2bc5b5bb52ac" |
+| JobID | Job ID. | JobID="c20a44f0-30a5-425b-96d5-ab6ffbc41bad" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="37" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Library Discovery" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Library Discovery job 'Tape Library Discovery' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:15:58.243835+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=207 JobSessionID="e0688fcb-f2e6-4cff-88d3-2bc5b5bb52ac" JobID="c20a44f0-30a5-425b-96d5-ab6ffbc41bad" JobResult="0" JobType="37" Platform="5" WillBeRetried="False" JobName="Tape Library Discovery" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Library Discovery job 'Tape Library Discovery' finished with Success."] |
+
+

--- a/docs/events/event_208.md
+++ b/docs/events/event_208.md
@@ -1,0 +1,46 @@
+---
+title: "Tape Import Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_208.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Import Job Finished
+
+
+Sent when a tape import job session is finished. For more information, see [Loading Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/import_tapes.html).
+
+General Information
+
+Event ID: 208
+
+Event message details: Tape Import job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="8f26e24f-eeac-4606-9502-cf2ff0152af6" |
+| JobID | Job ID. | JobID="5137cdc1-9bc4-44e3-994c-919b4b709451" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="1" |
+| JobType | Job type. | JobType="35" |
+| Platform | Platform type. | Platform="5" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Tape Import" |
+| SourceType | Job source type. | SourceType="6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape Import job 'Tape Import' finished with Warning. Job details: No tapes for import found in I/E ports. Completed with warning at Monday, March 31, 2025 10:59:26 AM" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T10:59:26.418165+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=208 JobSessionID="8f26e24f-eeac-4606-9502-cf2ff0152af6" JobID="5137cdc1-9bc4-44e3-994c-919b4b709451" JobResult="1" JobType="35" Platform="5" WillBeRetried="False" JobName="Tape Import" SourceType="6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape Import job 'Tape Import' finished with Warning. Job details: No tapes for import found in I/E ports. Completed with warning at Monday, March 31, 2025 10:59:26 AM"] |
+
+

--- a/docs/events/event_210_40210.md
+++ b/docs/events/event_210_40210.md
@@ -1,0 +1,46 @@
+---
+title: "Restore Session Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_210_40210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Session Started
+
+
+Sent when a user starts a restore session. For more information, see [Data Recovery](https://helpcenter.veeam.com/docs/backup/vsphere/data_recovery.html).
+
+General Information
+
+Event ID: 210, 40210
+
+Event message details: Restore session has been initiated by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" |
+| RestoreType | Restore operation type. | RestoreType="1" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| Platform | Platform type. | Platform="0" |
+| TargetObjectID | Target object ID. | TargetObjectID="00000000-0000-0000-0000-000000000000" |
+| SourceObjects | Source object IDs. | SourceObjects="fea7baba-dead-beef-c011-000000000001,fea7baba-dead-beef-c011-000000000002,fea7baba-dead-beef-c011-000000000003" |
+| ExtraData | Operation summary. | ExtraData="Objects to restore: VM01,VM02,VM03" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore session has been initiated by 'TECH\user1'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T13:59:10.100132+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40210 JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" RestoreType="1" InitiatorName="TECH\user1" Platform="0" TargetObjectID="00000000-0000-0000-0000-000000000000" SourceObjects="fea7baba-dead-beef-c011-000000000001,fea7baba-dead-beef-c011-000000000002,fea7baba-dead-beef-c011-000000000003" ExtraData="Objects to restore: VM01,VM02,VM03" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore session has been initiated by 'TECH\user1'."] |
+
+

--- a/docs/events/event_21210.md
+++ b/docs/events/event_21210.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to Backup Proxy Restored"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to Backup Proxy Restored
+
+
+Sent when a connection between a backup server and a backup proxy is restored.
+
+General Information
+
+Event ID: 21210
+
+Event message details: Connection to backup proxy <ObjectName> has been restored
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="6745a759-2205-4cd2-b172-8ec8f7e60ef8" |
+| ObjectID | Backup proxy ID. | ObjectID="18b661c1-d9dc-4233-90a0-7e7b10dc2d09" |
+| HostName | Backup server name. | HostName="VBRSRV01" |
+| ObjectName | Backup proxy name. | ObjectName="VMware Backup Proxy" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Connection to backup proxy VMware Backup Proxy has been restored." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T09:15:14.039156+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21210 HostID="6745a759-2205-4cd2-b172-8ec8f7e60ef8" ObjectID="18b661c1-d9dc-4233-90a0-7e7b10dc2d09" HostName="VBRSRV01" ObjectName="VMware Backup Proxy" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Connection to backup proxy VMware Backup Proxy has been restored."] |
+
+

--- a/docs/events/event_21214.md
+++ b/docs/events/event_21214.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to Backup Proxy Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21214.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to Backup Proxy Lost
+
+
+Sent when a backup server fails to connect to a backup proxy.
+
+General Information
+
+Event ID: 21214
+
+Event message details: Backup server has lost connection to backup proxy <ObjectName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="6745a759-2205-4cd2-b172-8ec8f7e60ef8" |
+| ObjectID | Backup proxy ID. | ObjectID="18b661c1-d9dc-4233-90a0-7e7b10dc2d09" |
+| HostName | Backup server name. | HostName="VBRSRV01" |
+| ObjectName | Backup proxy name. | ObjectName="VMware Backup Proxy" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup server has lost connection to backup proxy VMware Backup Proxy." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T09:15:22.617768+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21214 HostID="6745a759-2205-4cd2-b172-8ec8f7e60ef8" ObjectID="18b661c1-d9dc-4233-90a0-7e7b10dc2d09" HostName="VBRSRV01" ObjectName="VMware Backup Proxy" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup server has lost connection to backup proxy VMware Backup Proxy."] |
+
+

--- a/docs/events/event_21220.md
+++ b/docs/events/event_21220.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to Backup Repository Restored"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21220.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to Backup Repository Restored
+
+
+Sent when a connection between a backup server and a backup repository is restored.
+
+General Information
+
+Event ID: 21220
+
+Event message details: Connection to backup repository <ObjectName> has been restored
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="88548284-8918-46d5-9c59-be21e6cffdcf" |
+| ObjectID | Backup repository ID. | ObjectID="a7b98b83-9d41-46b3-a60b-e09d408910ba" |
+| HostName | Backup server name. | HostName="vbrsrv01.tech.local" |
+| ObjectName | Backup repository name. | ObjectName="repo01.tech.local" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Connection to backup repository repo01.tech.local has been restored." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:51:24.819907+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21220 HostID="88548284-8918-46d5-9c59-be21e6cffdcf" ObjectID="a7b98b83-9d41-46b3-a60b-e09d408910ba" HostName="vbrsrv01.tech.local" ObjectName="LongExtent" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Connection to backup repository repo01.tech.local has been restored."] |
+
+

--- a/docs/events/event_21224.md
+++ b/docs/events/event_21224.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to Backup Repository Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21224.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to Backup Repository Lost
+
+
+Sent when a backup server fails to connect to a backup repository.
+
+General Information
+
+Event ID: 21224
+
+Event message details: Backup server has lost connection to backup repository <ObjectName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="88548284-8918-46d5-9c59-be21e6cffdcf" |
+| ObjectID | Backup repository ID. | ObjectID="a7b98b83-9d41-46b3-a60b-e09d408910ba" |
+| HostName | Backup server name. | HostName="vbrsrv01.tech.local" |
+| ObjectName | Backup repository name. | ObjectName="repo01.tech.local" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup server has lost connection to backup repository repo01.tech.local." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:33:18.009834+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21224 HostID="88548284-8918-46d5-9c59-be21e6cffdcf" ObjectID="a7b98b83-9d41-46b3-a60b-e09d408910ba" HostName="vbrsrv01.tech.local" ObjectName="repo01.tech.local" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup server has lost connection to backup repository repo01.tech.local."] |
+
+

--- a/docs/events/event_21230.md
+++ b/docs/events/event_21230.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to WAN Accelerator Restored"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21230.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to WAN Accelerator Restored
+
+
+Sent when a connection between a backup server and a WAN accelerator is restored.
+
+General Information
+
+Event ID: 21230
+
+Event message details: Connection to WAN accelerator <ObjectName> has been restored
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="1f005143-75e1-4575-9cfd-7f24bd79b0f3" |
+| ObjectID | WAN accelerator ID. | ObjectID="90e5b18a-0dd8-4bb1-947a-23393985ec30" |
+| HostName | Backup server name. | HostName="VBRSRV01" |
+| ObjectName | WAN accelerator name. | ObjectName="WAN01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Connection to WAN accelerator wan01.tech.local has been restored." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T09:15:42.866117+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21230 HostID="1f005143-75e1-4575-9cfd-7f24bd79b0f3" ObjectID="90e5b18a-0dd8-4bb1-947a-23393985ec30" HostName="VBRSRV01" ObjectName="WAN01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Connection to WAN accelerator wan01.tech.local has been restored."] |
+
+

--- a/docs/events/event_21234.md
+++ b/docs/events/event_21234.md
@@ -1,0 +1,42 @@
+---
+title: "Connection to WAN Accelerator Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_21234.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection to WAN Accelerator Lost
+
+
+Sent when a backup server fails to connect to a WAN accelerator.
+
+General Information
+
+Event ID: 21234
+
+Event message details: Backup server has lost connection to WAN accelerator <ObjectName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Backup server ID. | HostID="1f005143-75e1-4575-9cfd-7f24bd79b0f3" |
+| ObjectID | WAN accelerator ID. | ObjectID="90e5b18a-0dd8-4bb1-947a-23393985ec30" |
+| HostName | Backup server name. | HostName="VBRSRV01" |
+| ObjectName | WAN accelerator name. | ObjectName="WAN01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup server has lost connection to WAN accelerator wan01.tech.local." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T09:15:42.909118+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=21234 HostID="1f005143-75e1-4575-9cfd-7f24bd79b0f3" ObjectID="90e5b18a-0dd8-4bb1-947a-23393985ec30" HostName="VBRSRV01" ObjectName="WAN01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup server has lost connection to WAN accelerator wan01.tech.local."] |
+
+

--- a/docs/events/event_23010.md
+++ b/docs/events/event_23010.md
@@ -1,0 +1,44 @@
+---
+title: "Job Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23010.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Job Created
+
+
+Sent when a user creates a new job. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 23010
+
+Event message details: <JobType> job <JobName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="1f36762-01bd-44a8-8422-29b9bc70183e" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="0" |
+| JobName | Job name. | JobName="Backup Job 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="71f36762-01bd-44a8-8422-29b9bc70183e" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup job 'Backup Job 01' has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:42:03.314729+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23010 JobID="71f36762-01bd-44a8-8422-29b9bc70183e" JobType="0" Platform="0" JobName="Backup Job 01" ChangesXML="<changes><object id="71f36762-01bd-44a8-8422-29b9bc70183e" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup job 'Backup Job 01' has been created."] |
+
+

--- a/docs/events/event_23050.md
+++ b/docs/events/event_23050.md
@@ -1,0 +1,44 @@
+---
+title: "Job Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23050.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Job Settings Updated
+
+
+Sent when a user updates job settings. For more information, see [Editing Job Settings](https://helpcenter.veeam.com/docs/backup/vsphere/editing_jobs.html).
+
+General Information
+
+Event ID: 23050
+
+Event message details: <JobType> job <JobName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="71f36762-01bd-44a8-8422-29b9bc70183e" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="0" |
+| JobName | Job name. | JobName="Backup Job 02" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="71f36762-01bd-44a8-8422-29b9bc70183e"><property name="Name" internal="Name" type="String"><old>Backup Job 02</old><new>Backup Job for main DC</new></property><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/23/2025 10:41 PM.</old><new>Main DC Job</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup job 'Backup Job 02' has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:42:30.060794+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23050 JobID="71f36762-01bd-44a8-8422-29b9bc70183e" JobType="0" Platform="0" JobName="Backup Job 02" ChangesXML="<changes><object id="71f36762-01bd-44a8-8422-29b9bc70183e"><property name="Name" internal="Name" type="String"><old>Backup Job 02</old><new>Backup Job for main DC</new></property><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/23/2025 10:41 PM.</old><new>Main DC Job</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup job 'Backup Job 02' has been modified."] |
+
+

--- a/docs/events/event_23090.md
+++ b/docs/events/event_23090.md
@@ -1,0 +1,44 @@
+---
+title: "Job Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23090.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Job Deleted
+
+
+Sent when a user deletes a job. For more information, see [Disabling and Deleting Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/disabling_jobs.html).
+
+General Information
+
+Event ID: 23090
+
+Event message details: <JobType> job <JobName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="1" |
+| JobName | Job name. | JobName="SureBackup Job 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 01' has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:24:04.456842+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23090 JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" JobType="3" Platform="1" JobName="SureBackup Job 01" ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 01' has been deleted."] |
+
+

--- a/docs/events/event_23110.md
+++ b/docs/events/event_23110.md
@@ -1,0 +1,44 @@
+---
+title: "Objects for Job Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23110.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Job Added
+
+
+Sent when a user adds objects to a job. For more information, see [Editing Job Settings](https://helpcenter.veeam.com/docs/backup/vsphere/editing_jobs.html).
+
+General Information
+
+Event ID: 23110
+
+Event message details: <N> objects has been created for <JobName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="3038588e-5d74-4df6-9fad-3eb6840ad317" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="VMware Servers Backup" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="e3f59198-46ab-4202-94ee-7310846e5bd6"><Property internal="Name" collection="False" type="CDumpedMemberInfo">Virtual Machine 01</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'1' objects has been created for 'VMware Servers Backup'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:26:34.116642+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23110 JobID="3038588e-5d74-4df6-9fad-3eb6840ad317" JobType="0" Platform="N\A" JobName="VMware Servers Backup" ChangesXML="<changes><object id="e3f59198-46ab-4202-94ee-7310846e5bd6"><Property internal="Name" collection="False" type="CDumpedMemberInfo">Virtual Machine 01</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'1' objects has been created for 'VMware Servers Backup'."] |
+
+

--- a/docs/events/event_23130.md
+++ b/docs/events/event_23130.md
@@ -1,0 +1,44 @@
+---
+title: "Objects for Job Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23130.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Job Changed
+
+
+Sent when a user changes objects for a job. For more information, see [Editing Job Settings](https://helpcenter.veeam.com/docs/backup/vsphere/editing_jobs.html).
+
+General Information
+
+Event ID: 23130
+
+Event message details: <N> objects has been modified for <JobName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="c0706a64-86fd-4616-8152-8e352dfc7371" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="VMware Servers Backup" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="d6bde872-65d9-4f43-9cc0-21ce92794b3d"><property name="Job objects order" internal="ObjectInJob.OrderNumber" type="Integer"><old>2</old><new>1</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'1' objects has been modified for 'VMware Servers Backup'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T10:27:29.391386+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23130 JobID="c0706a64-86fd-4616-8152-8e352dfc7371" JobType="0" Platform="N\A" JobName="VMware Servers Backup" ChangesXML="<changes><object id="d6bde872-65d9-4f43-9cc0-21ce92794b3d"><property name="Job objects order" internal="ObjectInJob.OrderNumber" type="Integer"><old>2</old><new>1</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'1' objects has been modified for 'VMware Servers Backup'."] |
+
+

--- a/docs/events/event_23210.md
+++ b/docs/events/event_23210.md
@@ -1,0 +1,44 @@
+---
+title: "SureBackup Job Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup Job Created
+
+
+Sent when a user creates a new SureBackup job. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 23210
+
+Event message details: SureBackup job <JobName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="SureBackup Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 1' has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:09:25.168674+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23210 JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" JobType="3" Platform="N\A" JobName="SureBackup Job 1" ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 1' has been created."] |
+
+

--- a/docs/events/event_23220.md
+++ b/docs/events/event_23220.md
@@ -1,0 +1,44 @@
+---
+title: "SureBackup Job Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23220.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup Job Settings Updated
+
+
+Sent when a user updates SureBackup job settings. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 23220
+
+Event message details: SureBackup job <JobName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="SureBackup Job 2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0"><property name="Name" internal="Name" type="String"><old>SureBackup Job 2</old><new>SureBackup Job Weekly</new></property></object></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 2' has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:23:23.259882+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23220 JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" JobType="3" Platform="N\A" JobName="SureBackup Job 2" ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0"><property name="Name" internal="Name" type="String"><old>SureBackup Job 2</old><new>SureBackup Job Weekly</new></property></object></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 2' has been modified."] |
+
+

--- a/docs/events/event_23230.md
+++ b/docs/events/event_23230.md
@@ -1,0 +1,44 @@
+---
+title: "SureBackup Job Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23230.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup Job Deleted
+
+
+Sent when a user deletes a SureBackup job. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 23230
+
+Event message details: SureBackup job <JobName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="SureBackup Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 1' has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:24:04.096800+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23230 JobID="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" JobType="3" Platform="N\A" JobName="SureBackup Job 1" ChangesXML="<changes><object id="7e15a2c2-9200-4c57-9608-fdeded8fb2b0" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 1' has been deleted."] |
+
+

--- a/docs/events/event_23310.md
+++ b/docs/events/event_23310.md
@@ -1,0 +1,44 @@
+---
+title: "Objects for SureBackup Job Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23310.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for SureBackup Job Added
+
+
+Sent when a user adds objects to a SureBackup job. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 23310
+
+Event message details: <N> objects has been linked for <JobName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="54c539af-a14e-453c-a390-1a3135f87cf9" |
+| JobType | Job type. | JobType="3" |
+| JobName | Job name. | JobName="SureBackup Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="3865bcb7-ad4b-450d-a805-a0b18e3c7457" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'1' objects has been linked for 'SureBackup Job 1'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T08:11:56.981053-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23310 JobID="54c539af-a14e-453c-a390-1a3135f87cf9" JobType="3" JobName="SureBackup Job 1" ChangesXML="<changes><object id="3865bcb7-ad4b-450d-a805-a0b18e3c7457" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'1' objects has been linked for 'SureBackup Job 1'."] |
+
+

--- a/docs/events/event_23320.md
+++ b/docs/events/event_23320.md
@@ -1,0 +1,44 @@
+---
+title: "Objects for SureBackup Job Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23320.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for SureBackup Job Deleted
+
+
+Sent when a user deletes objects from a SureBackup job. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 23320
+
+Event message details: <N> objects has been deleted from <JobName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="54c539af-a14e-453c-a390-1a3135f87cf9" |
+| JobType | Job type. | JobType="3" |
+| JobName | Job name. | JobName="SureBackup Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'1' objects has been deleted from 'SureBackup Job 1'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T08:12:13.340159-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23320 JobID="54c539af-a14e-453c-a390-1a3135f87cf9" JobType="3" JobName="SureBackup Job 1" ChangesXML="<changes><object id="3865bcb7-ad4b-450d-a805-a0b18e3c7457" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'1' objects has been deleted from 'SureBackup Job 1'."] |
+
+

--- a/docs/events/event_23410.md
+++ b/docs/events/event_23410.md
@@ -1,0 +1,44 @@
+---
+title: "Job Assigned as Secondary Destination"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23410.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Job Assigned as Secondary Destination
+
+
+Sent when a user assigns a job as a secondary destination. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 23410
+
+Event message details: <JobName> job has been assigned as secondary destination for <N> jobs
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="44851e67-9776-4a03-b61a-04f0968a1053" |
+| JobType | Job type. | JobType="65" |
+| Platform | Platform type. | Platform="8" |
+| JobName | Job name. | JobName="Backup Copy Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="6f805fcc-1e35-4c19-8661-398cc24bc050" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'Backup Copy Job 1' job has been assigned as secondary destination for '1' jobs." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T18:52:57.201080+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23410 JobID="44851e67-9776-4a03-b61a-04f0968a1053" JobType="65" Platform="8" JobName="Backup Copy Job 1" ChangesXML="<changes><object id="6f805fcc-1e35-4c19-8661-398cc24bc050" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'Backup Copy Job 1' job has been assigned as secondary destination for '1' jobs."] |
+
+

--- a/docs/events/event_23420.md
+++ b/docs/events/event_23420.md
@@ -1,0 +1,44 @@
+---
+title: "Job No Longer Used as Secondary Destination"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23420.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Job No Longer Used as Secondary Destination
+
+
+Sent when a user removes a job used as a secondary destination. For more information, see [Creating Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job.html).
+
+General Information
+
+Event ID: 23420
+
+Event message details: <JobName> job has been removed as secondary destination for <N> jobs
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="44851e67-9776-4a03-b61a-04f0968a1053" |
+| JobType | Job type. | JobType="65" |
+| Platform | Platform type. | Platform="8" |
+| JobName | Job name. | JobName="Backup Copy Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="6f805fcc-1e35-4c19-8661-398cc24bc050" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'Backup Copy Job 1' job has been removed as secondary destination for '1' jobs." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T18:53:13.101129+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23420 JobID="44851e67-9776-4a03-b61a-04f0968a1053" JobType="65" Platform="8" JobName="Backup Copy Job 1" ChangesXML="<changes><object id="6f805fcc-1e35-4c19-8661-398cc24bc050" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'Backup Copy Job 1' job has been removed as secondary destination for '1' jobs."] |
+
+

--- a/docs/events/event_23440.md
+++ b/docs/events/event_23440.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Job Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23440.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Job Created
+
+
+Sent when a user creates a new tape job. For more information, see [Creating Backup to Tape Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/creating_backup_to_tape_jobs.html).
+
+General Information
+
+Event ID: 23440
+
+Event message details: Tape job <JobName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="f23bdbd1-ef65-4f90-8f53-303406965dc1" |
+| JobType | Job type. | JobType="28" |
+| JobName | Job name. | JobName="Backup to Tape Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f23bdbd1-ef65-4f90-8f53-303406965dc1" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape job 'Backup to Tape Job 1' has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T10:47:36.790517+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23440 JobID="f23bdbd1-ef65-4f90-8f53-303406965dc1" JobType="28" JobName="Backup to Tape Job 1" ChangesXML="<changes><object id="f23bdbd1-ef65-4f90-8f53-303406965dc1" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape job 'Backup to Tape Job 1' has been created."] |
+
+

--- a/docs/events/event_23450.md
+++ b/docs/events/event_23450.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Job Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23450.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Job Settings Updated
+
+
+Sent when a user updates tape job settings. For more information, see [Creating Backup to Tape Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/creating_backup_to_tape_jobs.html).
+
+General Information
+
+Event ID: 23450
+
+Event message details: Tape job <JobName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="5fabd599-f80b-4646-b127-6b581e74fb6b" |
+| JobType | Job type. | JobType="28" |
+| JobName | Job name. | JobName="Backup to Tape Job 2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="5fabd599-f80b-4646-b127-6b581e74fb6b"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/23/2025 10:50 PM.</old><new>Main Tape Job</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape job 'Backup to Tape Job 2' has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:51:35.158794+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23450 JobID="5fabd599-f80b-4646-b127-6b581e74fb6b" JobType="28" JobName="Backup to Tape Job 2" ChangesXML="<changes><object id="5fabd599-f80b-4646-b127-6b581e74fb6b"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/23/2025 10:50 PM.</old><new>Main Tape Job</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape job 'Backup to Tape Job 2' has been modified."] |
+
+

--- a/docs/events/event_23490.md
+++ b/docs/events/event_23490.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Job Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23490.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Job Deleted
+
+
+Sent when a user deletes a tape job. For more information, see [Creating Backup to Tape Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/creating_backup_to_tape_jobs.html).
+
+General Information
+
+Event ID: 23490
+
+Event message details: Tape job <JobName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="f23bdbd1-ef65-4f90-8f53-303406965dc1" |
+| JobType | Job type. | JobType="28" |
+| JobName | Job name. | JobName="Backup to Tape Job 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f23bdbd1-ef65-4f90-8f53-303406965dc1" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape job 'Backup to Tape Job 1' has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:38:50.442191+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23490 JobID="f23bdbd1-ef65-4f90-8f53-303406965dc1" JobType="28" JobName="Backup to Tape Job 1" ChangesXML="<changes><object id="f23bdbd1-ef65-4f90-8f53-303406965dc1" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape job 'Backup to Tape Job 1' has been deleted."] |
+
+

--- a/docs/events/event_23610.md
+++ b/docs/events/event_23610.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Pool Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23610.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Pool Created
+
+
+Sent when a user adds a tape media pool to the backup infrastructure. For more information, see [Creating Media Pools](https://helpcenter.veeam.com/docs/backup/vsphere/creating_custom_media_pools.html).
+
+General Information
+
+Event ID: 23610
+
+Event message details: Tape media pool <TapeObjectName> has been created by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media pool ID. | TapeObjectID="84b3426e-496d-4031-8ea6-81be5d6c22a3" |
+| TapeObjectName | Media pool name. | TapeObjectName="Media Pool 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="84b3426e-496d-4031-8ea6-81be5d6c22a3" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape media pool Media Pool 1 has been created by user .\TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:31:57.041251+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23610 TapeObjectID="84b3426e-496d-4031-8ea6-81be5d6c22a3" TapeObjectName="Media Pool 1" ChangesXML="<changes><object id="84b3426e-496d-4031-8ea6-81be5d6c22a3" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape media pool Media Pool 1 has been created by user TECH\user1."] |
+
+

--- a/docs/events/event_23611.md
+++ b/docs/events/event_23611.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Vault Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23611.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Vault Created
+
+
+Sent when a user adds a tape media vault to the backup infrastructure.. For more information, see [Creating Vaults](https://helpcenter.veeam.com/docs/backup/vsphere/creating_media_vaults.html).
+
+General Information
+
+Event ID: 23611
+
+Event message details: Media vault <TapeObjectName> has been created by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media vault ID. | TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" |
+| TapeObjectName | Media vault name. | TapeObjectName="Media Vault 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Media vault Media Vault 1 has been created by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:28:57.501301+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23611 TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" TapeObjectName="Media Vault 1" ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Media vault Media Vault 1 has been created by user TECH\user1."] |
+
+

--- a/docs/events/event_23620.md
+++ b/docs/events/event_23620.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Pool Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23620.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Pool Updated
+
+
+Sent when a user updates tape media pool settings. For more information, see [Modifying Media Pools](https://helpcenter.veeam.com/docs/backup/vsphere/modifying_media_pools.html).
+
+General Information
+
+Event ID: 23620
+
+Event message details: Tape media pool <TapeObjectName> has been modified by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media pool ID. | TapeObjectID="e79e6a0e-f38b-489d-8be6-4c8ab7b9ec81" |
+| TapeObjectName | Media pool name. | TapeObjectName="HPE - Standard Pool" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="e79e6a0e-f38b-489d-8be6-4c8ab7b9ec81"><property name="Description" internal="Description" type="String"><old>Standard Media Pool with HPE cartridges NEW</old><new>Standard Media Pool with HPE cartridges</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape media pool HPE - Standard Pool has been modified by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:20:02.391099+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23620 TapeObjectID="e79e6a0e-f38b-489d-8be6-4c8ab7b9ec81" TapeObjectName="HPE - Standard Pool" ChangesXML="<changes><object id="e79e6a0e-f38b-489d-8be6-4c8ab7b9ec81"><property name="Description" internal="Description" type="String"><old>Standard Media Pool with HPE cartridges NEW</old><new>Standard Media Pool with HPE cartridges</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape media pool HPE - Standard Pool has been modified by user TECH\user1."] |
+
+

--- a/docs/events/event_23621.md
+++ b/docs/events/event_23621.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Vault Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23621.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Vault Updated
+
+
+Sent when a user updates tape media vault settings. For more information, see [Modifying Vaults](https://helpcenter.veeam.com/docs/backup/vsphere/managing_media_vaults.html).
+
+General Information
+
+Event ID: 23621
+
+Event message details: Media vault <TapeObjectName> has been modified by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media vault ID. | TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" |
+| TapeObjectName | Media vault name. | TapeObjectName="Veeam Media Vault 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c"><property internal="Protect" type="Boolean"><old>False</old><new>True</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Media vault Veeam Media Vault 1 has been modified by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:30:07.981318+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23621 TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" TapeObjectName="Veeam Media Vault 1" ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c"><property internal="Protect" type="Boolean"><old>False</old><new>True</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Media vault Veeam Media Vault 1 has been modified by user TECH\user1."] |
+
+

--- a/docs/events/event_23622.md
+++ b/docs/events/event_23622.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Medium Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23622.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Medium Updated
+
+
+Sent when a user enables or disables tape protection. For more information, see [Protecting Tapes](https://helpcenter.veeam.com/docs/backup/vsphere/protecting_tapes.html).
+
+General Information
+
+Event ID: 23622
+
+Event message details: Tape medium <TapeObjectName> has been modified by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Tape medium ID. | TapeObjectID="6e2d5920-cede-443f-aabd-e8072dc9f729" |
+| TapeObjectName | Tape medium name. | TapeObjectName="HPE009L2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="6e2d5920-cede-443f-aabd-e8072dc9f729" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape medium HPE009L2 has been modified by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:29.155486+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23632 TapeObjectID="6e2d5920-cede-443f-aabd-e8072dc9f729" TapeObjectName="HPE009L2" ChangesXML="<changes><object id="6e2d5920-cede-443f-aabd-e8072dc9f729" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape medium HPE009L2 has been modified by user TECH\user1."] |
+
+

--- a/docs/events/event_23623.md
+++ b/docs/events/event_23623.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Library Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23623.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Library Settings Updated
+
+
+Sent when a user updates tape library settings. For more information, see [Tape Libraries](https://helpcenter.veeam.com/docs/backup/vsphere/managing_library.html).
+
+General Information
+
+Event ID: 23623
+
+Event message details: Tape library <TapeObjectName> has been modified by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Tape library ID. | TapeObjectID="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" |
+| TapeObjectName | Tape library name. | TapeObjectName="IBM ULT3583-TL F210" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45"><property name="Name" internal="Name" type="String"><old>[default]</old><new>IBM ULT3583-TL F210</new></property><property internal="Enabled" type="Boolean"><old>True</old><new>False</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape library IBM ULT3583-TL F210 has been modified by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:09:04.883432+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23623 TapeObjectID="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" TapeObjectName="IBM ULT3583-TL F210" ChangesXML="<changes><object id="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45"><property name="Name" internal="Name" type="String"><old>[default]</old><new>IBM ULT3583-TL F210</new></property><property internal="Enabled" type="Boolean"><old>True</old><new>False</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape library IBM ULT3583-TL F210 has been modified by user TECH\user1."] |
+
+

--- a/docs/events/event_23630.md
+++ b/docs/events/event_23630.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Pool Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23630.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Pool Deleted
+
+
+Sent when a user deletes a tape media pool from the backup infrastructure. For more information, see [Removing Media Pools](https://helpcenter.veeam.com/docs/backup/vsphere/deleting_media_pools.html).
+
+General Information
+
+Event ID: 23630
+
+Event message details: Tape media pool <TapeObjectName> has been deleted by user <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media pool ID. | TapeObjectID="84b3426e-496d-4031-8ea6-81be5d6c22a3" |
+| TapeObjectName | Media pool name. | TapeObjectName="Media Pool 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="84b3426e-496d-4031-8ea6-81be5d6c22a3" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape media pool Media Pool 1 has been deleted by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:33:07.811264+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23630 TapeObjectID="84b3426e-496d-4031-8ea6-81be5d6c22a3" TapeObjectName="Media Pool 1" ChangesXML="<changes><object id="84b3426e-496d-4031-8ea6-81be5d6c22a3" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape media pool Media Pool 1 has been deleted by user TECH\user1."] |
+
+

--- a/docs/events/event_23631.md
+++ b/docs/events/event_23631.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Media Vault Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23631.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Media Vault Deleted
+
+
+Sent when a user deletes a tape media vault from the backup infrastructure. For more information, see [Removing Vaults](https://helpcenter.veeam.com/docs/backup/vsphere/removing_media_vault.html).
+
+General Information
+
+Event ID: 23631
+
+Event message details: Media vault <TapeObjectName> has been deleted by user <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Media vault ID. | TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" |
+| TapeObjectName | Media vault name. | TapeObjectName="Veeam Media Vault 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Media vault Veeam Media Vault 1 has been deleted by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:30:12.061748+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23631 TapeObjectID="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" TapeObjectName="Veeam Media Vault 1" ChangesXML="<changes><object id="36965f76-c35b-4be9-93e7-a8c0fa42ef6c" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Media vault Veeam Media Vault 1 has been deleted by user TECH\user1."] |
+
+

--- a/docs/events/event_23632.md
+++ b/docs/events/event_23632.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Medium Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23632.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Medium Deleted
+
+
+Sent when a user deletes a tape medium from a catalog. For more information, see [Removing Tapes from Catalog](https://helpcenter.veeam.com/docs/backup/vsphere/removing_tapes_from_catalog.html).
+
+General Information
+
+Event ID: 23632
+
+Event message details: Tape medium <TapeObjectName> has been deleted by user <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Tape medium ID. | TapeObjectID="6e2d5920-cede-443f-aabd-e8072dc9f729" |
+| TapeObjectName | Tape medium name. | TapeObjectName="HPE009L2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="6e2d5920-cede-443f-aabd-e8072dc9f729" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape medium HPE009L2 has been deleted by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T11:08:29.155486+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23632 TapeObjectID="6e2d5920-cede-443f-aabd-e8072dc9f729" TapeObjectName="HPE009L2" ChangesXML="<changes><object id="6e2d5920-cede-443f-aabd-e8072dc9f729" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape medium HPE009L2 has been deleted by user TECH\user1."] |
+
+

--- a/docs/events/event_23633.md
+++ b/docs/events/event_23633.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Library Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_23633.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Library Deleted
+
+
+Sent when a user deletes a tape library. For more information, see [Removing Tape Devices](https://helpcenter.veeam.com/docs/backup/vsphere/removing_tape_libraries.html).
+
+General Information
+
+Event ID: 23633
+
+Event message details: Tape library <TapeObjectName> has been deleted by user <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TapeObjectID | Tape library ID. | TapeObjectID="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" |
+| TapeObjectName | Tape library name. | TapeObjectName="IBM ULT3583-TL F210" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape library has been deleted by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:29:15.310006+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=23633 TapeObjectID="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" TapeObjectName="IBM ULT3583-TL F210" ChangesXML="<changes><object id="3dea29f1-fbf6-4a19-9f4e-725bd8ba8c45" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape library has been deleted by user TECH\user1."] |
+
+

--- a/docs/events/event_24010.md
+++ b/docs/events/event_24010.md
@@ -1,0 +1,44 @@
+---
+title: "License Installed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24010.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Installed
+
+
+Sent when a user installs a license key. For more information, see [Installing License](https://helpcenter.veeam.com/docs/backup/vsphere/install_license.html).
+
+General Information
+
+Event ID: 24010
+
+Event message details: <Type> License key for Veeam Backup and Replication <Edition> has been installed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="1" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="4" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="435" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="-1" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Evaluation License key for Veeam Backup and Replication EnterprisePlus has been installed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T10:20:38.744158-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24010 Type="1" Edition="4" DaysLeft="435" SupportLeft="-1" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Evaluation License key for Veeam Backup and Replication EnterprisePlus has been installed."] |
+
+

--- a/docs/events/event_24020.md
+++ b/docs/events/event_24020.md
@@ -1,0 +1,42 @@
+---
+title: "License Expiring"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24020.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Expiring
+
+
+Sent when a license key expires shortly. For more information, see [License Expiration](https://helpcenter.veeam.com/docs/backup/vsphere/license_grace.html).
+
+General Information
+
+Event ID: 24020
+
+Event message details: <Type> License key for Veeam Backup and Replication <Edition> is about to expire in <N> days
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="1" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="4" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="14" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="-1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Evaluation License key for Veeam Backup and Replication EnterprisePlus is about to expire in 14 days." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-19T06:44:45.761790-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24020 Type="1" Edition="4" DaysLeft="14" SupportLeft="-1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Evaluation License key for Veeam Backup and Replication EnterprisePlus is about to expire in 14 days."] |
+
+

--- a/docs/events/event_24030.md
+++ b/docs/events/event_24030.md
@@ -1,0 +1,42 @@
+---
+title: "License Expired"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24030.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Expired
+
+
+Sent when a license key has expired. For more information, see [License Expiration](https://helpcenter.veeam.com/docs/backup/vsphere/license_grace.html).
+
+General Information
+
+Event ID: 24030
+
+Event message details: <Type> License key for Veeam Backup and Replication <Edition> has expired
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="1" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="4" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="0" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="-1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Evaluation License key for Veeam Backup and Replication EnterprisePlus has expired." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:21:32.475555+00:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24030 Type="1" Edition="4" DaysLeft="0" SupportLeft="-1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Evaluation license key for Veeam Backup and Replication EnterprisePlus has expired."] |
+
+

--- a/docs/events/event_24040.md
+++ b/docs/events/event_24040.md
@@ -1,0 +1,42 @@
+---
+title: "License Support Expiring"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24040.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Support Expiring
+
+
+Sent when a support contract expires shortly. For more information, see [License Expiration](https://helpcenter.veeam.com/docs/backup/vsphere/license_grace.html).
+
+General Information
+
+Event ID: 24040
+
+Event message details: Support contract for Veeam Backup & Replication is about to expire in <N> days
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="4" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="3" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="435" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="14" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Support contract for Veeam Backup & Replication is about to expire in 14 days." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-09T07:03:29.194215-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24040 Type="4" Edition="3" DaysLeft="435" SupportLeft="14" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Support contract for Veeam Backup & Replication is about to expire in 14 days."] |
+
+

--- a/docs/events/event_24050.md
+++ b/docs/events/event_24050.md
@@ -1,0 +1,42 @@
+---
+title: "License Support Expired"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24050.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Support Expired
+
+
+Sent when a support contract has expired. For more information, see [License Expiration](https://helpcenter.veeam.com/docs/backup/vsphere/license_grace.html).
+
+General Information
+
+Event ID: 24050
+
+Event message details: Your support contract has expired. You can no longer use technical support or install product updates
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="4" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="3" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="435" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Your support contract has expired. You can no longer use technical support or install product updates." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-18T11:06:13.126645-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24050 Type="4" Edition="3" DaysLeft="435" SupportLeft="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Your support contract has expired. You can no longer use technical support or install product updates."] |
+
+

--- a/docs/events/event_24060.md
+++ b/docs/events/event_24060.md
@@ -1,0 +1,42 @@
+---
+title: "License Grace Period Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24060.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Grace Period Started
+
+
+Sent when a license key has expired and a grace period started. For more information, see [License Expiration](https://helpcenter.veeam.com/docs/backup/vsphere/license_grace.html).
+
+General Information
+
+Event ID: 24060
+
+Event message details: License grace period entered
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="6" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="3" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="0" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="-1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="License grace period entered." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-17T08:17:33.251129-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24060 Type="6" Edition="3" DaysLeft="0" SupportLeft="-1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="License grace period entered."] |
+
+

--- a/docs/events/event_24070.md
+++ b/docs/events/event_24070.md
@@ -1,0 +1,42 @@
+---
+title: "License Limit Exceeded"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24070.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Limit Exceeded
+
+
+Sent when the license limit is exceeded. For more information, see [Exceeding License Limit](https://helpcenter.veeam.com/docs/backup/vsphere/license_exceeding.html).
+
+General Information
+
+Event ID: 24070
+
+Event message details: You have exceeded your licensed limit of <N> instances by <N> and are no longer compliant with your Veeam licensing agreement. To avoid service interruptions from future growth, we recommend you deploy a license for at least <N> instances
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Type | License type. Possible values:   * 1 — Evaluation * 3 — NFR * 4 — Perpetual * 5 — Rental * 6 — Subscription * 7 — Promo | Type="6" |
+| Edition | License edition. Possible values:   * 1 — Standard * 3 — Enterprise * 4 — EnterprisePlus | Edition="3" |
+| DaysLeft | Number of days until license expiration. | DaysLeft="435" |
+| SupportLeft | Number of days until support expiration. | SupportLeft="-1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="You have exceeded your licensed limit of 20 instances by 10 and are no longer compliant with your Veeam licensing agreement. To avoid service interruptions from future growth, we recommend you deploy a license for at least 30 instances." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-18T08:17:43.739540-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24070 Type="6" Edition="3" DaysLeft="435" SupportLeft="-1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="You have exceeded your licensed limit of 20 instances by 10 and are no longer compliant with your Veeam licensing agreement. To avoid service interruptions from future growth, we recommend you deploy a license for at least 30 instances."] |
+
+

--- a/docs/events/event_24080.md
+++ b/docs/events/event_24080.md
@@ -1,0 +1,40 @@
+---
+title: "License Removed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24080.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Removed
+
+
+Sent when a user removes a license key. For more information, see [Removing License](https://helpcenter.veeam.com/docs/backup/vsphere/removing_license.html).
+
+General Information
+
+Event ID: 24080
+
+Event message details: <Type> license that was a part of the merged Veeam Backup & Replication license has been removed | All licenses have been removed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="All licenses have been removed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T18:45:21.488136+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24080 UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="All licenses have been removed."] |
+
+

--- a/docs/events/event_24110.md
+++ b/docs/events/event_24110.md
@@ -1,0 +1,40 @@
+---
+title: "Tenant Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24110.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Added
+
+
+Sent when a service provider adds a tenant account. For more information, see [Creating Tenant Accounts](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_tenant.html).
+
+General Information
+
+Event ID: 24110
+
+Event message details: Cloud Connect tenant <TenantName> <TenantID> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" |
+| TenantName | Tenant name. | TenantName="Tenant1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect tenant Tenant1 [aaebd83e-3d1f-423e-9204-21f783d1fcfb] has been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:42:03.442774+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24110 TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" TenantName="Tenant1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect tenant Tenant1 [aaebd83e-3d1f-423e-9204-21f783d1fcfb] has been created"] |
+
+

--- a/docs/events/event_24114.md
+++ b/docs/events/event_24114.md
@@ -1,0 +1,23 @@
+---
+title: "Tenant Password Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24114.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Password Changed
+
+
+Sent when a tenant changes a tenant account password. For more information, see [Changing Password for Tenant Account](https://helpcenter.veeam.com/docs/backup/cloud/cc_change_password.html).
+
+General Information
+
+Event ID: 24114
+
+Event message details: Cloud Connect tenant <TenantName> <TenantID> password has been updated by the tenant from backup server with InstallationId = <InstallationID>
+
+Severity: Info
+
+

--- a/docs/events/event_24120.md
+++ b/docs/events/event_24120.md
@@ -1,0 +1,40 @@
+---
+title: "Tenant Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24120.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Deleted
+
+
+Sent when a service provider deletes a tenant account. For more information, see [Deleting Tenant Accounts](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_delete_account.html).
+
+General Information
+
+Event ID: 24120
+
+Event message details: Cloud Connect tenant <TenantName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" |
+| TenantName | Tenant name. | TenantName="Tenant1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect tenant Tenant1 has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:59:13.733265+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24120 TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" TenantName="Tenant1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect tenant Tenant1 has been deleted"] |
+
+

--- a/docs/events/event_24130.md
+++ b/docs/events/event_24130.md
@@ -1,0 +1,43 @@
+---
+title: "Cloud Gateway Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24130.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Added
+
+
+Sent when a service provider adds a new cloud gateway to the Veeam Cloud Connect infrastructure. For more information, see [Adding Cloud Gateways](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_gateways.html).
+
+General Information
+
+Event ID: 24130
+
+Event message details: Cloud gateway <GatewayName> <GatewayID> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayID | Cloud gateway ID. | GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" |
+| GatewayName | Cloud gateway name. | GatewayName="VBRSRV01" |
+| ProxyServer | Proxy server name. | ProxyServer="proxysrv01.tech.local" |
+| Port | Proxy server port. | Port="6180" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway VBRSRV01 [5b69b400-6a50-4c9e-ad6b-653acaf7b173] has been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:37:58.616122+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24130 GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" GatewayName="VBRSRV01" ProxyServer="proxysrv01.tech.local" Port="6180" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway VBRSRV01 [5b69b400-6a50-4c9e-ad6b-653acaf7b173] has been created"] |
+
+

--- a/docs/events/event_24131.md
+++ b/docs/events/event_24131.md
@@ -1,0 +1,42 @@
+---
+title: "Cloud Gateway Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24131.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Settings Updated
+
+
+Sent when a service provider updates cloud gateway settings. For more information, see [Adding Cloud Gateways](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_gateways.html).
+
+General Information
+
+Event ID: 24131
+
+Event message details: Cloud gateway <GatewayName> <GatewayID> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayID | Description. | GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="5b69b400-6a50-4c9e-ad6b-653acaf7b173"><property internal="GateExternalFQDNorIp" type="String"><old>proxysrv01.tech.local</old><new>proxysrv02.tech.local</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway VBRSRV01 [5b69b400-6a50-4c9e-ad6b-653acaf7b173] has been modified" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:06:42.517325+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24131 GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" ChangesXML="<changes><object id="5b69b400-6a50-4c9e-ad6b-653acaf7b173"><property internal="GateExternalFQDNorIp" type="String"><old>proxysrv01.tech.local</old><new>proxysrv02.tech.local</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway VBRSRV01 [5b69b400-6a50-4c9e-ad6b-653acaf7b173] has been modified"] |
+
+

--- a/docs/events/event_24140.md
+++ b/docs/events/event_24140.md
@@ -1,0 +1,40 @@
+---
+title: "Cloud Gateway Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24140.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Deleted
+
+
+Sent when a service provider deletes a cloud gateway from the Veeam Cloud Connect infrastructure. For more information, see [Adding Cloud Gateways](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_gateways.html).
+
+General Information
+
+Event ID: 24140
+
+Event message details: Cloud gateway <GatewayName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayID | Cloud gateway ID. | GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" |
+| GatewayName | Cloud gateway name. | GatewayName="VBRSRV01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway VBRSRV01 has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:09:22.228210+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24140 GatewayID="5b69b400-6a50-4c9e-ad6b-653acaf7b173" GatewayName="VBRSRV01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway VBRSRV01 has been deleted"] |
+
+

--- a/docs/events/event_24141.md
+++ b/docs/events/event_24141.md
@@ -1,0 +1,41 @@
+---
+title: "Cloud Gateway Pool Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24141.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Pool Added
+
+
+Sent when a service provider adds a new cloud gateway pool to the Veeam Cloud Connect infrastructure. For more information, see [Configuring Cloud Gateway Pools](https://helpcenter.veeam.com/docs/backup/cloud/cloud_gateway_pool_add.html).
+
+General Information
+
+Event ID: 24141
+
+Event message details: Cloud gateway pool <GatewayPoolName> <GatewayPoolID> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayPoolID | Cloud gateway pool ID. | GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" |
+| GatewayPoolName | Cloud gateway pool name. | GatewayPoolName="Cloud gateway pool 1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway pool 'Cloud gateway pool 1' [0b463ec4-5965-41a9-bdd1-fc9834a55f7f] has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:10:22.436439+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24141 GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" GatewayPoolName="Cloud gateway pool 1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway pool 'Cloud gateway pool 1' [0b463ec4-5965-41a9-bdd1-fc9834a55f7f] has been created."] |
+
+

--- a/docs/events/event_24142.md
+++ b/docs/events/event_24142.md
@@ -1,0 +1,42 @@
+---
+title: "Cloud Gateway Pool Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24142.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Pool Settings Updated
+
+
+Sent when a service provider updates cloud gateway pool settings. For more information, see [Configuring Cloud Gateway Pools](https://helpcenter.veeam.com/docs/backup/cloud/cloud_gateway_pool_add.html).
+
+General Information
+
+Event ID: 24142
+
+Event message details: Cloud gateway pool <GatewayPoolName> <GatewayPoolID> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayPoolID | Cloud gateway pool ID. | GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" |
+| GatewayPoolName | Cloud gateway pool name. | GatewayPoolName="Cloud gateway pool 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="0b463ec4-5965-41a9-bdd1-fc9834a55f7f"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/20/2025 12:10 PM.</old><new>New cloud gateway pool.</new></property></object></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway pool 'Cloud gateway pool 1' [0b463ec4-5965-41a9-bdd1-fc9834a55f7f] has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:10:36.588735+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24142 GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" GatewayPoolName="Cloud gateway pool 1" ChangesXML="<changes><object id="0b463ec4-5965-41a9-bdd1-fc9834a55f7f"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/20/2025 12:10 PM.</old><new>New cloud gateway pool.</new></property></object></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway pool 'Cloud gateway pool 1' [0b463ec4-5965-41a9-bdd1-fc9834a55f7f] has been modified."] |
+
+

--- a/docs/events/event_24143.md
+++ b/docs/events/event_24143.md
@@ -1,0 +1,41 @@
+---
+title: "Cloud Gateway Pool Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24143.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Gateway Pool Deleted
+
+
+Sent when a service provider deletes a cloud gateway pool from the Veeam Cloud Connect infrastructure. For more information, see [Configuring Cloud Gateway Pools](https://helpcenter.veeam.com/docs/backup/cloud/cloud_gateway_pool_add.html).
+
+General Information
+
+Event ID: 24143
+
+Event message details: Cloud gateway pool <GatewayPoolName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| GatewayPoolID | Cloud gateway pool ID. | GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" |
+| GatewayPoolName | Cloud gateway pool name. | GatewayPoolName="Cloud gateway pool 1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud gateway pool 'Cloud gateway pool 1' has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:10:42.294591+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24143 GatewayPoolID="0b463ec4-5965-41a9-bdd1-fc9834a55f7f" GatewayName="Cloud gateway pool 1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud gateway pool 'Cloud gateway pool 1' has been deleted."] |
+
+

--- a/docs/events/event_24150.md
+++ b/docs/events/event_24150.md
@@ -1,0 +1,23 @@
+---
+title: "Tenant Quota Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24150.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Quota Added
+
+
+Sent when a service provider adds storage quota for a tenant account. For more information, see [Tenant Lease and Quota](https://helpcenter.veeam.com/docs/backup/cloud/lease_and_quota.html).
+
+General Information
+
+Event ID: 24150
+
+Event message details: Cloud tenant repository <QuotaName> <QuotaID> has been created
+
+Severity: Info
+
+

--- a/docs/events/event_24160.md
+++ b/docs/events/event_24160.md
@@ -1,0 +1,23 @@
+---
+title: "Tenant Quota Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24160.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Quota Changed
+
+
+Sent when a service provider changes storage quota for a tenant account. For more information, see [Tenant Lease and Quota](https://helpcenter.veeam.com/docs/backup/cloud/lease_and_quota.html).
+
+General Information
+
+Event ID: 24160
+
+Event message details: Cloud tenant repository <QuotaName> <QuotaID> has been changed
+
+Severity: Info
+
+

--- a/docs/events/event_24170.md
+++ b/docs/events/event_24170.md
@@ -1,0 +1,23 @@
+---
+title: "Tenant Quota Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24170.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Quota Deleted
+
+
+Sent when a service provider deletes storage quota for a tenant account. For more information, see [Tenant Lease and Quota](https://helpcenter.veeam.com/docs/backup/cloud/lease_and_quota.html).
+
+General Information
+
+Event ID: 24170
+
+Event message details: Cloud tenant repository <QuotaName> <QuotaID> has been deleted
+
+Severity: Warning
+
+

--- a/docs/events/event_24180.md
+++ b/docs/events/event_24180.md
@@ -1,0 +1,38 @@
+---
+title: "Cloud Connect Certificate Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_24180.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Connect Certificate Updated
+
+
+Sent when a service provider updates a Cloud Connect certificate. For more information, see [TLS Certificates](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_ssl.html).
+
+General Information
+
+Event ID: 24180
+
+Event message details: Cloud Connect certificate is being updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect certificate is being updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:36:56.061273+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=24180 VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect certificate is being updated"] |
+
+

--- a/docs/events/event_250.md
+++ b/docs/events/event_250.md
@@ -1,0 +1,48 @@
+---
+title: "Restore Task for VMware VM Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_250.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Task for VMware VM Finished
+
+
+Sent when a restore task session for VMware virtual machine is finished. For more information, see [Entire VM Restore](https://helpcenter.veeam.com/docs/backup/vsphere/full_recovery.html).
+
+General Information
+
+Event ID: 250
+
+Event message details: Restore for <VmName> has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" |
+| TaskSessionID | Task session ID. | TaskSessionID="a68fe936-7651-418c-b37d-5ce8bff05f99" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="0" |
+| SourceHostName | Source host name. | SourceHostName="pdc01.tech.local" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VmName | Machine name. | VmName="VMware Server 01" |
+| ClusterName | Cluster name. | ClusterName="pdc01.tech.local" |
+| ServerName | Server name. | ServerName="pdcsrv01.tech.local" |
+| DatastoreName | Datastore name. | DatastoreName="pdcsrv01-ds01-hdd" |
+| Destination | Destination details. | Destination="<datacenterRef>datacenter-3</datacenterRef><datacenterName>PDCSRV</datacenterName><datacenterPath>PDCSRV</datacenterPath><hostRef>host-35398</hostRef><datastoreRef>datastore-35419</datastoreRef><datastoreGuid>643e4a4c-f2273546-1572-3cecef8cb6e6</datastoreGuid><FullName>[pdcsrv01-ds01-hdd] VMware Server 01</FullName>" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore for 'VMware Server 01' has finished with Success state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:00:56.108954+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=250 JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" TaskSessionID="a68fe936-7651-418c-b37d-5ce8bff05f99" Status="0" SourceHostName="pdc01.tech.local" VmRef="vm-01" VmName="VMware Server 01" ClusterName="pdc01.tech.local" ServerName="pdcsrv01.tech.local" DatastoreName="pdcsrv01-ds01-hdd" Destination="<datacenterRef>datacenter-3</datacenterRef><datacenterName>PDCSRV</datacenterName><datacenterPath>PDCSRV</datacenterPath><hostRef>host-35398</hostRef><datastoreRef>datastore-35419</datastoreRef><datastoreGuid>643e4a4c-f2273546-1572-3cecef8cb6e6</datastoreGuid><FullName>[pdcsrv01-ds01-hdd] VMware Server 01</FullName>" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore for 'VMware Server 01' has finished with Success state."] |
+
+

--- a/docs/events/event_25000.md
+++ b/docs/events/event_25000.md
@@ -1,0 +1,40 @@
+---
+title: "Tenant State Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant State Changed
+
+
+Sent when a service provider enables or disables a tenant account. For more information, see [Disabling and Enabling Tenant Accounts](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_disable_account.html).
+
+General Information
+
+Event ID: 25000
+
+Event message details: Cloud Connect tenant <TenantName> state has been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" |
+| isDisabled | Defines whether a tenant account is disabled. | isDisabled="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect tenant Tenant1 has been disabled" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:58:35.351723+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25000 TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" isDisabled="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect tenant Tenant1 has been disabled"] |
+
+

--- a/docs/events/event_251.md
+++ b/docs/events/event_251.md
@@ -1,0 +1,46 @@
+---
+title: "Restore Task for Hyper-V VM FInished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_251.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Task for Hyper-V VM FInished
+
+
+Sent when a restore task session for Hyper-V virtual machine is finished. For more information, see [Entire VM Restore](https://helpcenter.veeam.com/docs/backup/hyperv/full_recovery.html).
+
+General Information
+
+Event ID: 251
+
+Event message details: Restore for <VmName> has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e54ed5f9-5aea-40e3-9bfb-4e9a464b1907" |
+| TaskSessionID | Task session ID. | TaskSessionID="d0c597d6-0294-45f3-abb8-6670235bfd58" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="0" |
+| SourceHostName | Source host name. | SourceHostName="hv01.tech.local" |
+| VmID | Machine reference ID. | VmID="49f7027c-e1b0-4075-bda0-28559129179e" |
+| VmName | Machine name. | VmName="Server 03" |
+| ServerName | Server name. | ServerName="hv01.tech.local" |
+| Location | Location path. | Location="C:\Hyper-V" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore for 'Server 03' has finished with Success state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:02:20.384033+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=251 JobSessionID="e54ed5f9-5aea-40e3-9bfb-4e9a464b1907" TaskSessionID="d0c597d6-0294-45f3-abb8-6670235bfd58" Status="0" SourceHostName="hv01.tech.local" VmID="49f7027c-e1b0-4075-bda0-28559129179e" VmName="Server 03" ServerName="hv01.tech.local" Location="C:\Hyper-V" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore for 'Server 03' has finished with Success state."] |
+
+

--- a/docs/events/event_25100.md
+++ b/docs/events/event_25100.md
@@ -1,0 +1,42 @@
+---
+title: "Tenant Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Updated
+
+
+Sent when a service provider updates tenant account settings. For more information, see [Managing Tenant Accounts](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_manage.html).
+
+General Information
+
+Event ID: 25100
+
+Event message details: Cloud Connect tenant <TenantName> <TenantID> has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" |
+| IsThrottlingEnabled | Defines whether network throttling is enabled. | IsThrottlingEnabled="False" |
+| ThrottlingSpeedLimit | Network throttling speed limit. | ThrottlingSpeedLimit="1" |
+| ThrottlingSpeedUnit | Network throttling speed unit. | ThrottlingSpeedUnit="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect tenant Tenant1 [aaebd83e-3d1f-423e-9204-21f783d1fcfb] has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T16:35:28.498957+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25100 TenantID="aaebd83e-3d1f-423e-9204-21f783d1fcfb" IsThrottlingEnabled="False" ThrottlingSpeedLimit="1" ThrottlingSpeedUnit="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect tenant Tenant1 [aaebd83e-3d1f-423e-9204-21f783d1fcfb] has been updated"] |
+
+

--- a/docs/events/event_25200.md
+++ b/docs/events/event_25200.md
@@ -1,0 +1,41 @@
+---
+title: "Subtenant Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Subtenant Added
+
+
+Sent when a tenant adds a subtenant account. For more information, see [Managing Subtenant Accounts on Tenant Side](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_subtenants_use.html).
+
+General Information
+
+Event ID: 25200
+
+Event message details: Cloud subtenant <SubtenantName> <SubtenantID> tenant ID: <TenantID> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SubtenantID | Subtenant ID. | SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" |
+| SubtenantName | Subtenant name. | SubtenantName="SubtenantUser1" |
+| TenantID | Tenant ID. | TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect subtenant SubtenantUser1 [6a139cc4-b9ce-48f1-994e-4f035bad7d26] [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:31:21.536612+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25200 SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" SubtenantName="SubtenantUser1" TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect subtenant SubtenantUser1 [6a139cc4-b9ce-48f1-994e-4f035bad7d26] [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been created"] |
+
+

--- a/docs/events/event_25210.md
+++ b/docs/events/event_25210.md
@@ -1,0 +1,41 @@
+---
+title: "Subtenant Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Subtenant Deleted
+
+
+Sent when a tenant deletes a subtenant account. For more information, see [Managing Subtenant Accounts on Tenant Side](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_subtenants_use.html).
+
+General Information
+
+Event ID: 25210
+
+Event message details: Cloud subtenant <SubtenantName> tenant ID: <TenantID> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SubtenantID | Subtenant ID. | SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" |
+| SubtenantName | Subtenant name. | SubtenantName="SubtenantUser1" |
+| TenantID | Tenant ID. | TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect subtenant SubtenantUser1 [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:35:50.044547+01:00 EY-12-1-0-2065 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25210 SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" SubtenantName="SubtenantUser1" TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect subtenant SubtenantUser1 [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been deleted"] |
+
+

--- a/docs/events/event_25220.md
+++ b/docs/events/event_25220.md
@@ -1,0 +1,41 @@
+---
+title: "Subtenant Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25220.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Subtenant Updated
+
+
+Sent when a tenant updates subtenant account settings. For more information, see [Managing Subtenant Accounts on Tenant Side](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_subtenants_use.html).
+
+General Information
+
+Event ID: 25220
+
+Event message details: Cloud subtenant <SubtenantName> <SubtenantID> tenant ID: <TenantID> has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SubtenantID | Subtenant ID. | SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" |
+| SubtenantName | Subtenant name. | SubtenantName="SubtenantUser1" |
+| TenantID | Tenant ID. | TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud Connect subtenant SubtenantUser1 [6a139cc4-b9ce-48f1-994e-4f035bad7d26] [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:35:31.954437+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25220 SubtenantID="6a139cc4-b9ce-48f1-994e-4f035bad7d26" SubtenantName="SubtenantUser1" TenantID="df5542a4-0fb0-4615-a8f7-64d28e34c160" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud Connect subtenant SubtenantUser1 [6a139cc4-b9ce-48f1-994e-4f035bad7d26] [tenant ID: df5542a4-0fb0-4615-a8f7-64d28e34c160] has been updated"] |
+
+

--- a/docs/events/event_25230.md
+++ b/docs/events/event_25230.md
@@ -1,0 +1,23 @@
+---
+title: "Subtenant State Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25230.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Subtenant State Changed
+
+
+Sent when a tenant enables or disables a subtenant account. For more information, see [Subtenant Account](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_subtenant_account.html).
+
+General Information
+
+Event ID: 25230
+
+Event message details: Cloud subtenant <SubtenantName> tenant ID: <TenantID> state has been changed
+
+Severity: Info
+
+

--- a/docs/events/event_25300.md
+++ b/docs/events/event_25300.md
@@ -1,0 +1,42 @@
+---
+title: "Credential Record Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Credential Record Added
+
+
+Sent when a user adds a new credential record. For more information, see [Credentials Manager](https://helpcenter.veeam.com/docs/backup/vsphere/credentials_manager.html).
+
+General Information
+
+Event ID: 25300
+
+Event message details: Credentials <AccountName> have been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| CredentialsId | Credential record ID. | CredentialsId="023adcf1-07fd-4883-be51-443afc2e49e6" |
+| AccountName | Account user name. | AccountName="user2" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Credentials user2 have been added" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:07:25.860688-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25300 CredentialsId="023adcf1-07fd-4883-be51-443afc2e49e6" AccountName="user2" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Credentials user2 have been added"] |
+
+

--- a/docs/events/event_25400.md
+++ b/docs/events/event_25400.md
@@ -1,0 +1,43 @@
+---
+title: "Credential Record Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Credential Record Updated
+
+
+Sent when a user updates a credential record. For more information, see [Credentials Manager](https://helpcenter.veeam.com/docs/backup/vsphere/credentials_manager.html).
+
+General Information
+
+Event ID: 25400
+
+Event message details: Credentials <AccountName> have been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| CredentialsId | Credential record ID. | CredentialsId="023adcf1-07fd-4883-be51-443afc2e49e6" |
+| AccountName | Account user name. | AccountName="user2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="023adcf1-07fd-4883-be51-443afc2e49e6"><property internal="CredentialsPassword" type="String"><old>\*\*\*</old><new>\*\*\*\*</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Credentials user2 have been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T08:00:57.606233-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25400 CredentialsId="023adcf1-07fd-4883-be51-443afc2e49e6" AccountName="user2" ChangesXML="<changes><object id="023adcf1-07fd-4883-be51-443afc2e49e6"><property internal="CredentialsPassword" type="String"><old>\*\*\*</old><new>\*\*\*\*</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Credentials user2 have been updated"] |
+
+

--- a/docs/events/event_25500.md
+++ b/docs/events/event_25500.md
@@ -1,0 +1,42 @@
+---
+title: "Credential Record Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Credential Record Deleted
+
+
+Sent when a user deletes a credential record. For more information, see [Credentials Manager](https://helpcenter.veeam.com/docs/backup/vsphere/credentials_manager.html).
+
+General Information
+
+Event ID: 25500
+
+Event message details: Credentials <AccountName> have been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| CredentialsId | Credential record ID. | CredentialsId="023adcf1-07fd-4883-be51-443afc2e49e6" |
+| AccountName | Account user name. | AccountName="user2" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Credentials user2 have been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:07:36.617450-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25500 CredentialsID="023adcf1-07fd-4883-be51-443afc2e49e6" AccountName="user2" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Credentials user2 have been deleted"] |
+
+

--- a/docs/events/event_25600.md
+++ b/docs/events/event_25600.md
@@ -1,0 +1,38 @@
+---
+title: "Hypervisor Host Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hypervisor Host Added
+
+
+Sent when a user adds a hypervisor host to the backup infrastructure. For more information, see [Virtualization Servers and Hosts](https://helpcenter.veeam.com/docs/backup/vsphere/setup_add_server.html).
+
+General Information
+
+Event ID: 25600
+
+Event message details: Hypervisor host has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Hypervisor host has been added" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:37:19.096979+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25600 VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Hypervisor host has been added"] |
+
+

--- a/docs/events/event_25700.md
+++ b/docs/events/event_25700.md
@@ -1,0 +1,38 @@
+---
+title: "Hypervisor Host Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hypervisor Host Deleted
+
+
+Sent when a user deletes a hypervisor host from the backup infrastructure. For more information, see [Removing Servers](https://helpcenter.veeam.com/docs/backup/vsphere/remove_server.html).
+
+General Information
+
+Event ID: 25700
+
+Event message details: Hypervisor host has been deleted
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Hypervisor host has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:32:24.026422+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25700 VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Hypervisor host has been deleted"] |
+
+

--- a/docs/events/event_25800.md
+++ b/docs/events/event_25800.md
@@ -1,0 +1,38 @@
+---
+title: "Hypervisor Host Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hypervisor Host Settings Updated
+
+
+Sent when a user updates hypervisor host settings. For more information, see [Editing Server Settings](https://helpcenter.veeam.com/docs/backup/vsphere/edit_server.html).
+
+General Information
+
+Event ID: 25800
+
+Event message details: Hypervisor host has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Hypervisor host has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:37:19.096979+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25800 VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Hypervisor host has been updated"] |
+
+

--- a/docs/events/event_25900.md
+++ b/docs/events/event_25900.md
@@ -1,0 +1,41 @@
+---
+title: "Failover Plan Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_25900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Created
+
+
+Sent when a user creates a new failover plan for replication or CDP.
+
+General Information
+
+Event ID: 25900
+
+Event message details: New failover plan has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="a7bc6fe1-6097-4d88-b843-d041be8d9eeb" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="Failover plan 6" |
+| Platform | Platform ID. | Platform="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="New failover plan has been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:48:11.729900+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=25900 FailoverPlanID="a7bc6fe1-6097-4d88-b843-d041be8d9eeb" FailoverPlanName="Failover plan 6" Platform="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="New failover plan has been created"] |
+
+

--- a/docs/events/event_26000.md
+++ b/docs/events/event_26000.md
@@ -1,0 +1,40 @@
+---
+title: "Failover Plan Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Settings Updated
+
+
+Sent when a user updates a failover plan for replication or CDP.
+
+General Information
+
+Event ID: 26000
+
+Event message details: Failover plan has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="a7bc6fe1-6097-4d88-b843-d041be8d9eeb" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="Failover plan 6" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failover plan has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:48:31.134124+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26000 FailoverPlanID="a7bc6fe1-6097-4d88-b843-d041be8d9eeb" FailoverPlanName="Failover plan 6" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failover plan has been updated"] |
+
+

--- a/docs/events/event_26010.md
+++ b/docs/events/event_26010.md
@@ -1,0 +1,44 @@
+---
+title: "Target Location Does Not Match Source Location"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26010.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Target Location Does Not Match Source Location
+
+
+Sent when a user migrates infrastructure objects to a different location. For more information, see [Managing Locations](https://helpcenter.veeam.com/docs/backup/vsphere/locations.html).
+
+General Information
+
+Event ID: 26010
+
+Event message details: Potential data sovereignty violation: target <TargetName> location <TargetLocation> does not match source <ObjectName> location <SourceLocation>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ObjectName | Name of the infrastructure object. | ObjectName="VMware Server 01" |
+| SourceLocation | Source location of the infrastructure object. | SourceLocation="Italy" |
+| SourceLocationID | Source location ID of the infrastructure object. | SourceLocationID="3719a4bb-78be-514f-4caf-2a3a9a63b17c" |
+| TargetName | Name of the host in the target location. | TargetName="esxi01.tech.local" |
+| TargetLocation | Target location of the infrastructure object. | TargetLocation="Germany" |
+| TargetLocationID | Target location ID of the infrastructure object. | TargetLocationID="4260b7cc-35fd-498c-8bef-5e2e8e78a15b" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Potential data sovereignty violation: target esxi01.tech.local location (Germany) does not match source VMware Server 01 location (Italy)" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:52:13.085626+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26010 ObjectName="VMware Server 01" SourceLocation="Italy" SourceLocationID="3719a4bb-78be-514f-4caf-2a3a9a63b17c" TargetName="esxi01.tech.local" TargetLocation="Germany" TargetLocationID="4260b7cc-35fd-498c-8bef-5e2e8e78a15b" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Potential data sovereignty violation: target esxi01.tech.local location (Germany) does not match source VMware Server 01 location (Italy)"] |
+
+

--- a/docs/events/event_26100.md
+++ b/docs/events/event_26100.md
@@ -1,0 +1,40 @@
+---
+title: "Failover Plan Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Deleted
+
+
+Sent when a user deletes a failover plan for replication or CDP.
+
+General Information
+
+Event ID: 26100
+
+Event message details: Failover plan has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="61ff12d7-621b-49bc-944d-fb20e994aea4" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="VMware Failover Plan 03" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failover plan has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:46:52.880248+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26100 FailoverPlanID="61ff12d7-621b-49bc-944d-fb20e994aea4" FailoverPlanName="VMware Failover Plan 03" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failover plan has been deleted"] |
+
+

--- a/docs/events/event_26110.md
+++ b/docs/events/event_26110.md
@@ -1,0 +1,40 @@
+---
+title: "Failover Plan Failed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26110.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Failed
+
+
+Sent when a failover plan for replication or CDP fails.
+
+General Information
+
+Event ID: 26110
+
+Event message details: Failover plan was failed
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="Hyper-V Failover Plan 01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failover plan was failed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:05:36.456229+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26110 FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" FailoverPlanName="Hyper-V Failover Plan 01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failover plan was failed"] |
+
+

--- a/docs/events/event_26200.md
+++ b/docs/events/event_26200.md
@@ -1,0 +1,39 @@
+---
+title: "Hardware Plan Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hardware Plan Created
+
+
+Sent when a service provider creates a new hardware plan. For more information, see [Configuring Hardware Plans](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_configure_hardware_plan.html).
+
+General Information
+
+Event ID: 26200
+
+Event message details: New hardware plan has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HardwarePlanID | Hardware plan ID. | HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="New hardware plan has been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:24:59.324477+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26200 HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="New hardware plan has been created"] |
+
+

--- a/docs/events/event_26300.md
+++ b/docs/events/event_26300.md
@@ -1,0 +1,39 @@
+---
+title: "Hardware Plan Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hardware Plan Settings Updated
+
+
+Sent when a service provider updates hardware plan settings. For more information, see [Editing Hardware Plan Settings](https://helpcenter.veeam.com/docs/backup/cloud/hardware_plans_edit.html).
+
+General Information
+
+Event ID: 26300
+
+Event message details: Hardware plan has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HardwarePlanID | Hardware plan ID. | HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Hardware plan has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:25:23.310547+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26300 HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Hardware plan has been updated"] |
+
+

--- a/docs/events/event_26400.md
+++ b/docs/events/event_26400.md
@@ -1,0 +1,39 @@
+---
+title: "Hardware Plan Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Hardware Plan Deleted
+
+
+Sent when a service provider deletes a hardware plan. For more information, see [Removing Hardware Plans](https://helpcenter.veeam.com/docs/backup/cloud/hardware_plans_remove.html).
+
+General Information
+
+Event ID: 26400
+
+Event message details: Hardware plan has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HardwarePlanID | Hardware plan ID. | HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Hardware plan has been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:25:54.766544+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26400 HardwarePlanID="027fa05b-db1a-4784-bff9-f83ef164af7c" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Hardware plan has been deleted"] |
+
+

--- a/docs/events/event_26500.md
+++ b/docs/events/event_26500.md
@@ -1,0 +1,45 @@
+---
+title: "Extent State for Scale-Out Backup Repository Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Extent State for Scale-Out Backup Repository Changed
+
+
+Sent when a user switches the mode of the scale-out backup repository extent. For more information, see [Service Actions with Scale-Out Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/backup_repository_sobr_service.html).
+
+General Information
+
+Event ID: 26500
+
+Event message details: Scale-out backup repository extent state has been changed: <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ExtentID | Scale-out backup repository extent ID. | ExtentID="ea819566-bd5f-4ce7-8dc1-9fd2b48365a0" |
+| ExtentName | Scale-out backup repository extent name. | ExtentName="Scale-Out Extent 03" |
+| NewStatus | New state of the scale-out backup repository extent. Possible values:   * 1 — Pending maintenance * 2 — Maintenance mode * 8 — Sealed mode | NewStatus="2" |
+| TotalStatus | Final state of the scale-out backup repository extent. Possible values:   * 1 — Pending maintenance * 2 — Maintenance mode * 8 — Sealed mode | TotalStatus="2" |
+| OldStatus | Old state of the scale-out backup repository extent. Possible values:   * 1 — Pending maintenance * 2 — Maintenance mode * 8 — Sealed mode | OldStatus="1" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Scale-out backup repository extent state has been changed: MaintenancePending mode has been reset. Maintenance mode has been set." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:08:43.981854+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26500 ExtentID="ea819566-bd5f-4ce7-8dc1-9fd2b48365a0" ExtentName="Scale-Out Extent 03" NewStatus="2" TotalStatus="2" OldStatus="1" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Scale-out backup repository extent state has been changed: MaintenancePending mode has been reset. Maintenance mode has been set. "] |
+
+

--- a/docs/events/event_26510.md
+++ b/docs/events/event_26510.md
@@ -1,0 +1,39 @@
+---
+title: "Cloud Connect State Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26510.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Connect State Changed
+
+
+Sent when a service provider switches the mode for the SP backup server. For more information, see [Maintenance Mode](https://helpcenter.veeam.com/docs/backup/cloud/cc_maintenance_mode.html).
+
+General Information
+
+Event ID: 26510
+
+Event message details: Cloud connect state was changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| MaintenanceMode | Defines whether the maintenance mode for the SP backup server is enabled. | MaintenanceMode="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cloud connect state was changed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T08:46:02.759884+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26510 MaintenanceMode="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cloud connect state was changed"] |
+
+

--- a/docs/events/event_26600.md
+++ b/docs/events/event_26600.md
@@ -1,0 +1,40 @@
+---
+title: "Failover Plan Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Started
+
+
+Sent when a user starts a failover plan for replication or CDP.
+
+General Information
+
+Event ID: 26600
+
+Event message details: Failover plan was started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="Hyper-V Failover Plan 01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failover plan was started" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:03:22.544985+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26600 FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" FailoverPlanName="Hyper-V Failover Plan 01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failover plan was started"] |
+
+

--- a/docs/events/event_26700.md
+++ b/docs/events/event_26700.md
@@ -1,0 +1,40 @@
+---
+title: "Failover Plan Stopped"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Failover Plan Stopped
+
+
+Sent when a user stops a failover plan for replication or CDP.
+
+General Information
+
+Event ID: 26700
+
+Event message details: Failover plan was stopped
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FailoverPlanID | Failover plan ID. | FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" |
+| FailoverPlanName | Failover plan name. | FailoverPlanName="Hyper-V Failover Plan 01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failover plan was stopped" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:05:36.456229+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26700 FailoverPlanID="1e75b808-e4ed-4744-9ea8-374d78573ea2" FailoverPlanName="Hyper-V Failover Plan 01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failover plan was stopped"] |
+
+

--- a/docs/events/event_26800.md
+++ b/docs/events/event_26800.md
@@ -1,0 +1,43 @@
+---
+title: "Tenant Replica Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Replica Started
+
+
+Sent when a tenant starts the VM replica on the cloud host.
+
+General Information
+
+Event ID: 26800
+
+Event message details: Cloud replica <Name> was started by tenant <TenantID> on host <HostID>. <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="00dcf328-59f8-4860-962f-3e6b29c943b6" |
+| HostID | Server ID. | HostID="df247087-1ef9-49be-af85-6b5bacd7a3a3" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| Reason | Reason to perform the operation. | Reason="0" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Trying to start tenant replica" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T16:30:21.962008+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26800 TenantID="00dcf328-59f8-4860-962f-3e6b29c943b6" HostID="df247087-1ef9-49be-af85-6b5bacd7a3a3" VmRef="vm-01" Reason="0" Result="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Trying to start tenant replica"] |
+
+

--- a/docs/events/event_26900.md
+++ b/docs/events/event_26900.md
@@ -1,0 +1,44 @@
+---
+title: "Tenant Replica Stopped"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_26900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Replica Stopped
+
+
+Sent when a tenant stops the VM replica on the cloud host.
+
+General Information
+
+Event ID: 26900
+
+Event message details: Cloud replica <Name> was stopped by tenant <TenantID> on host <HostID>. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TenantID | Tenant ID. | TenantID="df3fe130-a8fd-4362-a378-c098b8a2c4a3" |
+| HostID | Server ID. | HostID="73197cd6-b1f0-4867-a1a5-8a43850e5edc" |
+| VmRef | Machine reference ID. | VmRef="7debeff1-3323-4acb-b651-c3720770d0ef" |
+| Reason | Reason to perform the operation. | Reason="0" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| FailureMessage | Operation failure message. | FailureMessage="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Trying to stop tenant replica" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T16:16:00.074642+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=26900 TenantID="df3fe130-a8fd-4362-a378-c098b8a2c4a3" HostID="73197cd6-b1f0-4867-a1a5-8a43850e5edc" VmRef="7debeff1-3323-4acb-b651-c3720770d0ef" Reason="0" Result="0" FailureMessage="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Trying to stop tenant replica"] |
+
+

--- a/docs/events/event_27000.md
+++ b/docs/events/event_27000.md
@@ -1,0 +1,23 @@
+---
+title: "Tenant Replica Permanent Failover Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27000.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tenant Replica Permanent Failover Started
+
+
+Sent when a tenant performs permanent failover to the VM replica on the cloud host. For more information, see [Permanent Failover](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_permanent_failover.html).
+
+General Information
+
+Event ID: 27000
+
+Event message details: Permanent failover was performed by tenant <TenantID> with cloud replica <Name> on host <HostID>
+
+Severity: Info
+
+

--- a/docs/events/event_27100.md
+++ b/docs/events/event_27100.md
@@ -1,0 +1,42 @@
+---
+title: "Wan Accelerator Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Wan Accelerator Added
+
+
+Sent when a user adds a new WAN accelerator to the backup infrastructure. For more information, see [Adding WAN Accelerators](https://helpcenter.veeam.com/docs/backup/vsphere/wan_add.html).
+
+General Information
+
+Event ID: 27100
+
+Event message details: WAN accelerator <AcceleratorName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AcceleratorID | WAN accelerator ID. | AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" |
+| AcceleratorName | WAN accelerator name. | AcceleratorName="WAN01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012" name="WAN01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="WAN accelerator WAN01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:04:46.981365+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27100 AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" AcceleratorName="WAN01" ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012" name="WAN01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="WAN accelerator WAN01 has been created."] |
+
+

--- a/docs/events/event_27200.md
+++ b/docs/events/event_27200.md
@@ -1,0 +1,42 @@
+---
+title: "Wan Accelerator Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Wan Accelerator Settings Updated
+
+
+Sent when a user updates WAN accelerator settings. For more information, see [Adding WAN Accelerators](https://helpcenter.veeam.com/docs/backup/vsphere/wan_add.html).
+
+General Information
+
+Event ID: 27200
+
+Event message details: WAN accelerator <AcceleratorName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AcceleratorID | WAN accelerator ID. | AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" |
+| AcceleratorName | WAN accelerator name. | AcceleratorName="WAN01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012"><property internal="MaxTasksCount" type="UInt16"><old>5</old><new>10</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="WAN accelerator WAN01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T21:59:15.049063+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27200 AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" AcceleratorName="WAN01" ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012"><property internal="MaxTasksCount" type="UInt16"><old>5</old><new>10</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="WAN Accelerator WAN01 has been modified."] |
+
+

--- a/docs/events/event_27300.md
+++ b/docs/events/event_27300.md
@@ -1,0 +1,42 @@
+---
+title: "Wan Accelerator Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Wan Accelerator Deleted
+
+
+Sent when a user deletes a WAN accelerator from the backup infrastructure. For more information, see [Removing WAN Accelerators](https://helpcenter.veeam.com/docs/backup/vsphere/wan_remove.html).
+
+General Information
+
+Event ID: 27300
+
+Event message details: WAN accelerator <AcceleratorName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AcceleratorID | WAN accelerator ID. | AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" |
+| AcceleratorName | WAN accelerator name. | AcceleratorName="WAN01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012"><property internal="MaxTasksCount" type="UInt16"><old>5</old><new>10</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="WAN accelerator WAN01 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:04:25.124128+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27300 AcceleratorID="8e24f2ce-6461-497a-87ca-190c03a9a012" AcceleratorName="WAN01" ChangesXML="<changes><object id="8e24f2ce-6461-497a-87ca-190c03a9a012" name="WAN01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="WAN Accelerator WAN01 has been deleted."] |
+
+

--- a/docs/events/event_27400.md
+++ b/docs/events/event_27400.md
@@ -1,0 +1,42 @@
+---
+title: "Service Provider Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Service Provider Added
+
+
+Sent when a tenant connects to a service provider. For more information, see [Connecting to Service Providers](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_sp.html).
+
+General Information
+
+Event ID: 27400
+
+Event message details: Service provider <ProviderName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProviderID | Service provider ID. | ProviderID="bc004bc2-f395-4a6f-92b9-7b727e8bb365" |
+| ProviderName | Service provider name. | ProviderName="sp-vbr-01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="bc004bc2-f395-4a6f-92b9-7b727e8bb365" name="sp-vbr-01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Service provider sp-vbr-01.tech.local has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-27T14:20:06.469347+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27400 ProviderID="bc004bc2-f395-4a6f-92b9-7b727e8bb365" ProviderName="sp-vbr-01.tech.local" ChangesXML="<changes><object id="bc004bc2-f395-4a6f-92b9-7b727e8bb365" name="sp-vbr-01.tech.local" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Service provider sp-vbr-01.tech.local has been created."] |
+
+

--- a/docs/events/event_27500.md
+++ b/docs/events/event_27500.md
@@ -1,0 +1,23 @@
+---
+title: "Service Provider Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27500.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Service Provider Updated
+
+
+Sent when a tenant updates service provider connection settings. For more information, see [Connecting to Service Providers](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_sp.html).
+
+General Information
+
+Event ID: 27500
+
+Event message details: Service provider <ProviderName> has been modified
+
+Severity: Info
+
+

--- a/docs/events/event_27600.md
+++ b/docs/events/event_27600.md
@@ -1,0 +1,23 @@
+---
+title: "Service Provider Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27600.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Service Provider Deleted
+
+
+Sent when a tenant deletes a connection with the service provider. For more information, see [Connecting to Service Providers](https://helpcenter.veeam.com/docs/backup/cloud/cloud_connect_sp.html).
+
+General Information
+
+Event ID: 27600
+
+Event message details: Service provider <ProviderName> has been deleted
+
+Severity: Warning
+
+

--- a/docs/events/event_27700.md
+++ b/docs/events/event_27700.md
@@ -1,0 +1,42 @@
+---
+title: "Backup Proxy Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Proxy Added
+
+
+Sent when a user adds a backup proxy to the backup infrastructure.
+
+General Information
+
+Event ID: 27700
+
+Event message details: Backup proxy <ProxyName> <Type> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProxyID | Backup proxy ID. | ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" |
+| ProxyName | Backup proxy name. | ProxyName="Backup Proxy" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f" name="Backup Proxy" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup proxy Backup Proxy (File) has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:11:12.314684+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27700 ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" ProxyName="Backup Proxy" ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f" name="Backup Proxy" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup proxy Backup Proxy (File) has been created."] |
+
+

--- a/docs/events/event_27800.md
+++ b/docs/events/event_27800.md
@@ -1,0 +1,42 @@
+---
+title: "Backup Proxy Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Proxy Settings Updated
+
+
+Sent when a user updates backup proxy settings.
+
+General Information
+
+Event ID: 27800
+
+Event message details: Backup proxy <ProxyName> <Type> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProxyID | Backup proxy ID. | ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" |
+| ProxyName | Backup proxy name. | ProxyName="Backup Proxy" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f"><property internal="MaxConcurentTasks" type="Integer"><old>2</old><new>4</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup proxy Backup Proxy (File) has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:07:39.197747+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27800 ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" ProxyName="Backup Proxy" ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f"><property internal="MaxConcurentTasks" type="Integer"><old>2</old><new>4</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup proxy Backup Proxy (File) has been modified."] |
+
+

--- a/docs/events/event_27900.md
+++ b/docs/events/event_27900.md
@@ -1,0 +1,42 @@
+---
+title: "Backup Proxy Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_27900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Proxy Deleted
+
+
+Sent when a user deletes a backup proxy from the backup infrastructure.
+
+General Information
+
+Event ID: 27900
+
+Event message details: Backup proxy <ProxyName> <Type> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProxyID | Backup proxy ID. | ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" |
+| ProxyName | Backup proxy name. | ProxyName="Backup Proxy" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f" name="Backup Proxy" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup proxy Backup Proxy (File) has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:09:01.694756+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=27900 ProxyID="50cbf622-129e-482a-9197-d67e5bb1fb1f" ProxyName="Backup Proxy" ChangesXML="<changes><object id="50cbf622-129e-482a-9197-d67e5bb1fb1f" name="Backup Proxy" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup proxy Backup Proxy (File) has been deleted."] |
+
+

--- a/docs/events/event_28000.md
+++ b/docs/events/event_28000.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Repository Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Repository Added
+
+
+Sent when a user adds a backup repository to the backup infrastructure. For more information, see [Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/backup_repository.html).
+
+General Information
+
+Event ID: 28000
+
+Event message details: Backup repository <RepositoryName> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Backup repository ID. | RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" |
+| Type | Backup repository type. | Type="0" |
+| RepositoryName | Backup repository name. | RepositoryName="Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" name="Backup Repository 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup repository Backup Repository 01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:12:36.708794+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28000 RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" Type="0" RepositoryName="Backup Repository 01" ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" name="Backup Repository 01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup repository Backup Repository 01 has been created."] |
+
+

--- a/docs/events/event_28100.md
+++ b/docs/events/event_28100.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Repository Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Repository Settings Updated
+
+
+Sent when a user updates backup repository settings. For more information, see [Editing Settings of Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/backup_repo_edit.html).
+
+General Information
+
+Event ID: 28100
+
+Event message details: Backup repository <RepositoryName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Backup repository ID. | RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" |
+| Type | Backup repository type. | Type="0" |
+| RepositoryName | Backup repository name. | RepositoryName="Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/10/2025 10:12 PM.</old><new>New backup repository</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup repository Backup Repository 01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:13:06.867404+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28100 RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" Type="0" RepositoryName="Backup Repository 01" ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 03/10/2025 10:12 PM.</old><new>New backup repository</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup repository Backup Repository 01 has been modified."] |
+
+

--- a/docs/events/event_28200.md
+++ b/docs/events/event_28200.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Repository Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Repository Deleted
+
+
+Sent when a user deletes a backup repository from the backup infrastructure. For more information, see [Removing Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/repo_delete.html).
+
+General Information
+
+Event ID: 28200
+
+Event message details: Backup repository <RepositoryName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Backup repository ID. | RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" |
+| Type | Backup repository type. | Type="0" |
+| RepositoryName | Backup repository name. | RepositoryName="Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" name="Backup Repository 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup repository Backup Repository 01 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:13:16.765411+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28200 RepositoryID="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" Type="0" RepositoryName="Backup Repository 01" ChangesXML="<changes><object id="ed8c61cc-77f0-4f40-b73e-8c92d4a6fb11" name="Backup Repository 01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup repository Backup Repository 01 has been deleted."] |
+
+

--- a/docs/events/event_28300.md
+++ b/docs/events/event_28300.md
@@ -1,0 +1,43 @@
+---
+title: "Host Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Host Added
+
+
+Sent when a user adds a managed server to the backup infrastructure. For more information, see [Virtualization Servers and Hosts](https://helpcenter.veeam.com/docs/backup/vsphere/setup_add_server.html).
+
+General Information
+
+Event ID: 28300
+
+Event message details: Host <Name> <Type> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Server ID. | HostID="2e945306-9f71-4938-9d06-5601db286300" |
+| Type | Server type. | Type="7" |
+| Name | Server name. | Name="hv01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="2e945306-9f71-4938-9d06-5601db286300" name="hv01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Host hv01.tech.local (HvServer) has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:21:51.747079+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28300 HostID="2e945306-9f71-4938-9d06-5601db286300" Type="7" Name="hv01.tech.local" ChangesXML="<changes><object id="2e945306-9f71-4938-9d06-5601db286300" name="hv01.tech.local" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Host hv01.tech.local (HvServer) has been created."] |
+
+

--- a/docs/events/event_28400.md
+++ b/docs/events/event_28400.md
@@ -1,0 +1,43 @@
+---
+title: "Host Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Host Settings Updated
+
+
+Sent when a user updates managed server settings. For more information, see [Editing Server Settings](https://helpcenter.veeam.com/docs/backup/vsphere/edit_server.html).
+
+General Information
+
+Event ID: 28400
+
+Event message details: Host <Name> <Type> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Server ID. | HostID="bab66900-8ec2-4602-a1cf-b08c5372f889" |
+| Type | Server type. | Type="1" |
+| Name | Server name. | Name="vcenter.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="bab66900-8ec2-4602-a1cf-b08c5372f889"><property name="Description" internal="Description" type="String"><old>vCenter Server 01</old><new>vCenter Server 02</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Host vcenter.tech.local (VC) has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:30:58.110055+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28400 HostID="bab66900-8ec2-4602-a1cf-b08c5372f889" Type="1" Name="vcenter.tech.local" ChangesXML="<changes><object id="bab66900-8ec2-4602-a1cf-b08c5372f889"><property name="Description" internal="Description" type="String"><old>vCenter Server 01</old><new>vCenter Server 02</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Host vcenter.tech.local (VC) has been modified."] |
+
+

--- a/docs/events/event_28500.md
+++ b/docs/events/event_28500.md
@@ -1,0 +1,43 @@
+---
+title: "Host Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Host Deleted
+
+
+Sent when a user deletes a managed server from the backup infrastructure. For more information, see [Removing Servers](https://helpcenter.veeam.com/docs/backup/vsphere/remove_server.html).
+
+General Information
+
+Event ID: 28500
+
+Event message details: Host <Name> <Type> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostID | Server ID. | HostID="2e945306-9f71-4938-9d06-5601db286300" |
+| Type | Server type. | Type="7" |
+| Name | Server name. | Name="hv01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="2e945306-9f71-4938-9d06-5601db286300" name="hv01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Host hv01.tech.local (HvServer) has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T21:55:35.011114+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28500 HostID="2e945306-9f71-4938-9d06-5601db286300" Type="7" Name="hv01.tech.local" ChangesXML="<changes><object id="2e945306-9f71-4938-9d06-5601db286300" name="hv01.tech.local" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Host hv01.tech.local (HvServer) has been deleted."] |
+
+

--- a/docs/events/event_28600.md
+++ b/docs/events/event_28600.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Server Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Server Added
+
+
+Sent when a user adds a tape server to the backup infrastructure. For more information, see [Adding Tape Servers](https://helpcenter.veeam.com/docs/backup/vsphere/adding_tape_server.html).
+
+General Information
+
+Event ID: 28600
+
+Event message details: Tape server <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Tape server ID. | ID="7f291c52-4eb5-4242-bbe1-400d78b11cc9" |
+| Name | Tape server name. | Name="TAPESRV01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7f291c52-4eb5-4242-bbe1-400d78b11cc9" name="TAPESRV01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape server TAPESRV01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:35:38.373972+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28600 ID="7f291c52-4eb5-4242-bbe1-400d78b11cc9" Name="TAPESRV01" ChangesXML="<changes><object id="7f291c52-4eb5-4242-bbe1-400d78b11cc9" name="TAPESRV01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape server TAPESRV01 has been created."] |
+
+

--- a/docs/events/event_28650.md
+++ b/docs/events/event_28650.md
@@ -1,0 +1,43 @@
+---
+title: "NDMP Server Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28650.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# NDMP Server Added
+
+
+Sent when a user adds an NDMP server to the backup infrastructure. For more information, see [Adding NDMP Servers](https://helpcenter.veeam.com/docs/backup/vsphere/adding_ndmp_servers.html).
+
+General Information
+
+Event ID: 28650
+
+Event message details: NDMP server <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ServerID | NDMP server ID. | ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" |
+| Name | NDMP server name. | Name="ndmp01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f" name="ndmp01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="NDMP server ndmp01.tech.local has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:56:08.831295+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28650 ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" Name="ndmp01.tech.local" ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f" name="ndmp01.tech.local" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="NDMP server ndmp01.tech.local has been created."] |
+
+

--- a/docs/events/event_28700.md
+++ b/docs/events/event_28700.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Server Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Server Settings Updated
+
+
+Sent when a user updates tape server settings. For more information, see [Modifying Tape Servers](https://helpcenter.veeam.com/docs/backup/vsphere/managing_tapeservers.html).
+
+General Information
+
+Event ID: 28700
+
+Event message details: Tape server <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Tape server ID. | ID="f59836aa-2316-4450-8c27-8f133c893db5" |
+| Name | Tape server name. | Name="TAPESRV01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f59836aa-2316-4450-8c27-8f133c893db5"><property name="Description" internal="Description" type="String"><old>Created by Powershell at 03/23/2025 8:50:16 AM.</old><new>Main Tape Server</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape server TAPESRV01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:32:38.142734+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28700 ID="f59836aa-2316-4450-8c27-8f133c893db5" Name="TAPESRV01" ChangesXML="<changes><object id="f59836aa-2316-4450-8c27-8f133c893db5"><property name="Description" internal="Description" type="String"><old>Created by Powershell at 03/23/2025 8:50:16 AM.</old><new>Main Tape Server</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape server TAPESRV01 has been modified."] |
+
+

--- a/docs/events/event_28750.md
+++ b/docs/events/event_28750.md
@@ -1,0 +1,43 @@
+---
+title: "NDMP Server Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28750.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# NDMP Server Settings Updated
+
+
+Sent when a user updates NDMP server settings. For more information, see [Adding NDMP Servers](https://helpcenter.veeam.com/docs/backup/vsphere/adding_ndmp_servers.html).
+
+General Information
+
+Event ID: 28750
+
+Event message details: NDMP server <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ServerID | NDMP server ID. | ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" |
+| Name | NDMP server name. | Name="ndmp01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f"><property internal="Options" type="String"><old>&lt;NdmpServerOptions&gt;&lt;IsAutoSelectProxy&gt;True&lt;/IsAutoSelectProxy&gt;&lt;Port&gt;10000&lt;/Port&gt;&lt;ProxyHostId&gt;00000000-0000-0000-0000-000000000000&lt;/ProxyHostId&gt;&lt;/NdmpServerOptions&gt;</old><new>&lt;NdmpServerOptions&gt;&lt;IsAutoSelectProxy&gt;False&lt;/IsAutoSelectProxy&gt;&lt;Port&gt;10000&lt;/Port&gt;&lt;ProxyHostId&gt;6745a759-2205-4cd2-b172-8ec8f7e60ef8&lt;/ProxyHostId&gt;&lt;/NdmpServerOptions&gt;</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="NDMP server ndmp01.tech.local has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:56:46.814872+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28750 ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" Name="ndmp01.tech.local" ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f"><property internal="Options" type="String"><old>&lt;NdmpServerOptions&gt;&lt;IsAutoSelectProxy&gt;True&lt;/IsAutoSelectProxy&gt;&lt;Port&gt;10000&lt;/Port&gt;&lt;ProxyHostId&gt;00000000-0000-0000-0000-000000000000&lt;/ProxyHostId&gt;&lt;/NdmpServerOptions&gt;</old><new>&lt;NdmpServerOptions&gt;&lt;IsAutoSelectProxy&gt;False&lt;/IsAutoSelectProxy&gt;&lt;Port&gt;10000&lt;/Port&gt;&lt;ProxyHostId&gt;6745a759-2205-4cd2-b172-8ec8f7e60ef8&lt;/ProxyHostId&gt;&lt;/NdmpServerOptions&gt;</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="NDMP server ndmp01.tech.local has been modified."] |
+
+

--- a/docs/events/event_28800.md
+++ b/docs/events/event_28800.md
@@ -1,0 +1,43 @@
+---
+title: "Tape Server Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Tape Server Deleted
+
+
+Sent when a user deletes a tape server from the backup infrastructure. For more information, see [Removing Tape Servers](https://helpcenter.veeam.com/docs/backup/vsphere/remove_tapeserver.html).
+
+General Information
+
+Event ID: 28800
+
+Event message details: Tape server <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Tape server ID. | ID="f59836aa-2316-4450-8c27-8f133c893db5" |
+| Name | Tape server name. | Name="TAPESRV01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f59836aa-2316-4450-8c27-8f133c893db5" name="TAPESRV01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Tape server TAPESRV01 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:33:28.358818+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28800 ID="f59836aa-2316-4450-8c27-8f133c893db5" Type="0" Name="TAPESRV01" ChangesXML="<changes><object id="f59836aa-2316-4450-8c27-8f133c893db5" name="TAPESRV01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Tape server TAPESRV01 has been deleted."] |
+
+

--- a/docs/events/event_28850.md
+++ b/docs/events/event_28850.md
@@ -1,0 +1,43 @@
+---
+title: "NDMP Server Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28850.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# NDMP Server Deleted
+
+
+Sent when a user deletes an NDMP server from the backup infrastructure. For more information, see [Adding NDMP Servers](https://helpcenter.veeam.com/docs/backup/vsphere/adding_ndmp_servers.html).
+
+General Information
+
+Event ID: 28850
+
+Event message details: NDMP server <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ServerID | NDMP server ID. | ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" |
+| Name | NDMP server name. | Name="ndmp01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f" name="ndmp01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="NDMP server ndmp01.tech.local has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:56:08.831295+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28850 ServerID="01ef77d6-0233-4a57-adb8-bb31af97d50f" Name="ndmp01.tech.local" ChangesXML="<changes><object id="01ef77d6-0233-4a57-adb8-bb31af97d50f" name="ndmp01.tech.local" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="NDMP server ndmp01.tech.local has been deleted."] |
+
+

--- a/docs/events/event_28900.md
+++ b/docs/events/event_28900.md
@@ -1,0 +1,43 @@
+---
+title: "File Share Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Share Added
+
+
+Sent when a user adds a file share to the backup infrastructure. For more information, see [Adding File Share](https://helpcenter.veeam.com/docs/backup/vsphere/adding_file_share.html).
+
+General Information
+
+Event ID: 28900
+
+Event message details: File share <Name> <Type> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileShareID | File share ID. | FileShareID="4217959b-60e9-4ea9-94b7-be7c7899328e" |
+| Type | File share type. | Type="23" |
+| Name | File share name. | Name="\\fs1\Folder" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="4217959b-60e9-4ea9-94b7-be7c7899328e" name="\\fs1\Folder" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File share \\fs1\Folder (CifsShare) has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T08:49:46.340478+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28900 FileShareID="4217959b-60e9-4ea9-94b7-be7c7899328e" Type="23" Name="\\fs1\Folder" ChangesXML="<changes><object id="4217959b-60e9-4ea9-94b7-be7c7899328e" name="\\fs1\Folder" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File share \\fs1\Folder (CifsShare) has been created."] |
+
+

--- a/docs/events/event_28910.md
+++ b/docs/events/event_28910.md
@@ -1,0 +1,43 @@
+---
+title: "File Share Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28910.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Share Settings Updated
+
+
+Sent when a user updates file share settings. For more information, see [Adding File Share](https://helpcenter.veeam.com/docs/backup/vsphere/adding_file_share.html).
+
+General Information
+
+Event ID: 28910
+
+Event message details: File share <Name> <Type> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileShareID | File share ID. | FileShareID="5b55651b-d16a-4e6f-97b7-61ca1f528c3e" |
+| Type | File share type. | Type="27" |
+| Name | File share name. | Name="\\fileshare" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="5b55651b-d16a-4e6f-97b7-61ca1f528c3e"><property internal="NasFileShareCacheRepository" type="String"><old>Default Backup Repository</old><new>Backup Repository 1</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File share \\fileshare (CifsServer) has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:45:12.753270+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28910 FileShareID="5b55651b-d16a-4e6f-97b7-61ca1f528c3e" Type="27" Name="\\fileshare" ChangesXML="<changes><object id="5b55651b-d16a-4e6f-97b7-61ca1f528c3e"><property internal="NasFileShareCacheRepository" type="String"><old>Default Backup Repository</old><new>Backup Repository 1</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File share \\fileshare (CifsServer) has been modified."] |
+
+

--- a/docs/events/event_28920.md
+++ b/docs/events/event_28920.md
@@ -1,0 +1,43 @@
+---
+title: "File Share Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28920.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Share Deleted
+
+
+Sent when a user deletes a file share from the backup infrastructure. For more information, see [Adding File Share](https://helpcenter.veeam.com/docs/backup/vsphere/adding_file_share.html).
+
+General Information
+
+Event ID: 28920
+
+Event message details: File share <Name> <Type> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileShareID | File share ID. | FileShareID="4217959b-60e9-4ea9-94b7-be7c7899328e" |
+| Type | File share type. | Type="27" |
+| Name | File share name. | Name="\\fs1\Folder" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="4217959b-60e9-4ea9-94b7-be7c7899328e" name="\\fs1\Folder" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File share \\fs1\Folder (CifsShare) has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:34:29.391715+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28920 FileShareID="4217959b-60e9-4ea9-94b7-be7c7899328e" Type="27" Name="\\fs1\Folder" ChangesXML="<changes><object id="4217959b-60e9-4ea9-94b7-be7c7899328e" name="\\fs1\Folder" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File share \\fs1\Folder (CifsShare) has been deleted."] |
+
+

--- a/docs/events/event_28930.md
+++ b/docs/events/event_28930.md
@@ -1,0 +1,42 @@
+---
+title: "File Server Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28930.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Server Added
+
+
+Sent when a user adds a file server to the backup infrastructure. For more information, see [Adding File Server](https://helpcenter.veeam.com/docs/backup/vsphere/adding_managed_server_file_share.html).
+
+General Information
+
+Event ID: 28930
+
+Event message details: File server <Name> has been created
+
+Severity:
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileServerID | File server ID. | FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" |
+| Name | File server name. | Name="fs01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5" name="fs01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File server fs01.tech.local has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:10:25.399211+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28930 FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" Name="fs01.tech.local" ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5" name="fs01.tech.local" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File server fs01.tech.local has been created."] |
+
+

--- a/docs/events/event_28940.md
+++ b/docs/events/event_28940.md
@@ -1,0 +1,42 @@
+---
+title: "File Server Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28940.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Server Settings Updated
+
+
+Sent when a user updates file server settings. For more information, see [Adding File Server](https://helpcenter.veeam.com/docs/backup/vsphere/adding_managed_server_file_share.html).
+
+General Information
+
+Event ID: 28940
+
+Event message details: File server <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileServerID | File server ID. | FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" |
+| Name | File server name. | Name="fs01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5"><property internal="FileServerRepository" type="String"><old>Default Backup Repository</old><new>Single Storage Repository</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File server fs01.tech.local has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:12:18.702671+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28940 FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" Name="fs01.tech.local" ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5"><property internal="FileServerRepository" type="String"><old>Default Backup Repository</old><new>Single Storage Repository</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File server fs01.tech.local has been modified."] |
+
+

--- a/docs/events/event_28950.md
+++ b/docs/events/event_28950.md
@@ -1,0 +1,42 @@
+---
+title: "File Server Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28950.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Server Deleted
+
+
+Sent when a user deletes a file server from the backup infrastructure. For more information, see [Adding File Server](https://helpcenter.veeam.com/docs/backup/vsphere/adding_managed_server_file_share.html).
+
+General Information
+
+Event ID: 28950
+
+Event message details: File server <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| FileServerID | File server ID. | FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" |
+| Name | File server name. | Name="fs01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5" name="fs01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="File server fs01.tech.local has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:12:23.831008+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28950 FileServerID="13d18599-ecd6-4cee-8014-09b0f2bc42a5" Name="fs01.tech.local" ChangesXML="<changes><object id="13d18599-ecd6-4cee-8014-09b0f2bc42a5" name="fs01.tech.local" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="File server fs01.tech.local has been deleted."] |
+
+

--- a/docs/events/event_28960.md
+++ b/docs/events/event_28960.md
@@ -1,0 +1,42 @@
+---
+title: "Object Storage Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28960.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Storage Added
+
+
+Sent when a user adds an object storage repository to the backup infrastructure. For more information, see [Adding Object Storage Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/new_object_storage.html).
+
+General Information
+
+Event ID: 28960
+
+Event message details: Object storage <Name> <Type> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Object storage ID. | StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" |
+| Type | Storage type. | Type="32" |
+| Name | Object storage name. | Name="OBJST 01" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage OBJST 01 (S3CompatibleBucket) has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T17:04:51.183621+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28960 StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" Type="32" Name="OBJST 01" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage OBJST 01 (S3CompatibleBucket) has been created."] |
+
+

--- a/docs/events/event_28970.md
+++ b/docs/events/event_28970.md
@@ -1,0 +1,43 @@
+---
+title: "Object Storage Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28970.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Storage Settings Updated
+
+
+Sent when a user updates object storage repository settings. For more information, see [Managing Object Storage Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_object_storage_repo_data.html).
+
+General Information
+
+Event ID: 28970
+
+Event message details: Object storage <Name> <Type> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Object storage ID. | StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" |
+| Type | Storage type. | Type="32" |
+| Name | Object storage name. | Name="OBJST 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="b3f21f99-0318-4e07-b2fc-148384c87ebc"><property name="Name" internal="Name" type="String"><old>OBJST 01</old><new>OBJST OLD 01</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage OBJST 01 (S3CompatibleBucket) has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:51:20.620651+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28970 StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" Type="32" Name="OBJST 01" ChangesXML="<changes><object id="b3f21f99-0318-4e07-b2fc-148384c87ebc"><property name="Name" internal="Name" type="String"><old>OBJST 01</old><new>OBJST OLD 01</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage OBJST 01 (S3CompatibleBucket) has been modified."] |
+
+

--- a/docs/events/event_28980.md
+++ b/docs/events/event_28980.md
@@ -1,0 +1,42 @@
+---
+title: "Object Storage Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_28980.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Storage Deleted
+
+
+Sent when a user deletes an object storage repository from the backup infrastructure. For more information, see [Managing Object Storage Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_object_storage_repo_data.html).
+
+General Information
+
+Event ID: 28980
+
+Event message details: Object storage <Name> <Type> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Object storage ID. | StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" |
+| Type | Storage type. | Type="32" |
+| Name | Object storage name. | Name="OBJST 01" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage OBJST 01 (S3CompatibleBucket) has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:55:41.333008+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=28980 StorageID="b3f21f99-0318-4e07-b2fc-148384c87ebc" Type="32" Name="OBJST 01" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage OBJST 01 (S3CompatibleBucket) has been deleted."] |
+
+

--- a/docs/events/event_290_40290.md
+++ b/docs/events/event_290_40290.md
@@ -1,0 +1,41 @@
+---
+title: "Restore Session Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_290_40290.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Session Finished
+
+
+Sent when a restore session is finished. For more information, see [Data Recovery](https://helpcenter.veeam.com/docs/backup/vsphere/data_recovery.html).
+
+General Information
+
+Event ID: 290, 40290
+
+Event message details: The restore session has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="The restore session has finished with Success state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:00:56.171367+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40290 JobSessionID="bc7a15bb-8be7-41a8-a308-c4f76b43a255" Result="0" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="The restore session has finished with Success state."] |
+
+

--- a/docs/events/event_29100.md
+++ b/docs/events/event_29100.md
@@ -1,0 +1,42 @@
+---
+title: "Protection Group Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Protection Group Added
+
+
+Sent when a user adds a new protection group. For more information, see [Creating Protection Groups](https://helpcenter.veeam.com/docs/backup/agents/protection_group_add.html).
+
+General Information
+
+Event ID: 29100
+
+Event message details: Protection Group <ProtectionGroupName> has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4" name="Protection Group 1" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 has been added." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:08:58.557264+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29100 ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4" name="Protection Group 1" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 has been added."] |
+
+

--- a/docs/events/event_29110.md
+++ b/docs/events/event_29110.md
@@ -1,0 +1,42 @@
+---
+title: "Protection Group Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29110.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Protection Group Settings Updated
+
+
+Sent when a user updates protection group settings. For more information, see [Editing Protection Group Settings](https://helpcenter.veeam.com/docs/backup/agents/protection_group_edit.html).
+
+General Information
+
+Event ID: 29110
+
+Event message details: Protection Group <ProtectionGroupName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4"><property name="Name" internal="Name" type="String"><old>Protection Group 1</old><new>Protection Group 2</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:09:21.103996+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29110 ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4"><property name="Name" internal="Name" type="String"><old>Protection Group 1</old><new>Protection Group 2</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 has been modified."] |
+
+

--- a/docs/events/event_29120.md
+++ b/docs/events/event_29120.md
@@ -1,0 +1,42 @@
+---
+title: "Protection Group Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29120.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Protection Group Deleted
+
+
+Sent when a user deletes a protection group. For more information, see [Removing Protection Group](https://helpcenter.veeam.com/docs/backup/agents/protection_group_remove.html).
+
+General Information
+
+Event ID: 29120
+
+Event message details: Protection Group <ProtectionGroupName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4" name="Protection Group 1" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:14:25.513981+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29120 ProtectionGroupID="a00d024f-1820-404c-9088-0ddbf962f7b4" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="a00d024f-1820-404c-9088-0ddbf962f7b4" name="Protection Group 1" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 has been deleted."] |
+
+

--- a/docs/events/event_29130.md
+++ b/docs/events/event_29130.md
@@ -1,0 +1,42 @@
+---
+title: "Objects for Protection Group Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29130.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Protection Group Added
+
+
+Sent when a user adds objects to a protection group. For more information, see [Creating Protection Groups](https://helpcenter.veeam.com/docs/backup/agents/protection_group_add.html).
+
+General Information
+
+Event ID: 29130
+
+Event message details: Protection Group <ProtectionGroupName> scope has been increased
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="1b788032-74f2-43da-b636-3416db8f8aeb"><Property internal="Name" collection="False" type="CDumpedMemberInfo">10.10.10.50</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 scope has been increased." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:18:38.585462+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29130 ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="1b788032-74f2-43da-b636-3416db8f8aeb"><Property internal="Name" collection="False" type="CDumpedMemberInfo">10.10.10.50</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 scope has been increased."] |
+
+

--- a/docs/events/event_29140.md
+++ b/docs/events/event_29140.md
@@ -1,0 +1,42 @@
+---
+title: "Objects for Protection Group Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29140.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Protection Group Changed
+
+
+Sent when a user changes objects for a protection group. For more information, see [Creating Protection Groups](https://helpcenter.veeam.com/docs/backup/agents/protection_group_add.html).
+
+General Information
+
+Event ID: 29140
+
+Event message details: Protection Group <ProtectionGroupName> scope has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="c54e5a60-0cc0-432f-a675-d4de8b413602"><property internal="EpContainerItemOptionsCredentials" type="String"><old>WINSRV01\Administrator</old><new>mySSHaccount</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 scope has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:16:01.707169+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29140 ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="c54e5a60-0cc0-432f-a675-d4de8b413602"><property internal="EpContainerItemOptionsCredentials" type="String"><old>WINSRV01\Administrator</old><new>mySSHaccount</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 scope has been modified."] |
+
+

--- a/docs/events/event_29150.md
+++ b/docs/events/event_29150.md
@@ -1,0 +1,42 @@
+---
+title: "Objects for Protection Group Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29150.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Protection Group Deleted
+
+
+Sent when a user deletes objects from a protection group. For more information, see [Creating Protection Groups](https://helpcenter.veeam.com/docs/backup/agents/protection_group_add.html).
+
+General Information
+
+Event ID: 29150
+
+Event message details: Protection Group <ProtectionGroupName> scope has been decreased
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProtectionGroupID | Protection group ID. | ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" |
+| ProtectionGroupName | Protection group name. | ProtectionGroupName="Protection Group 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="5251e11e-1fad-452c-aad7-ef2ce3481bce"><Property internal="Name" collection="False" type="CDumpedMemberInfo">srv01.tech.local</Property></object><object id="1929aa07-8784-42e0-a603-50579e54960d"><Property internal="Name" collection="False" type="CDumpedMemberInfo">srv02.tech.local</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Protection Group Protection Group 1 scope has been decreased." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:18:14.609370+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29150 ProtectionGroupID="3fd6fb98-c3e0-4626-9a1c-d7b45df04560" ProtectionGroupName="Protection Group 1" ChangesXML="<changes><object id="5251e11e-1fad-452c-aad7-ef2ce3481bce"><Property internal="Name" collection="False" type="CDumpedMemberInfo">srv01.tech.local</Property></object><object id="1929aa07-8784-42e0-a603-50579e54960d"><Property internal="Name" collection="False" type="CDumpedMemberInfo">srv02.tech.local</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Protection Group Protection Group 1 scope has been decreased."] |
+
+

--- a/docs/events/event_29700.md
+++ b/docs/events/event_29700.md
@@ -1,0 +1,44 @@
+---
+title: "Archive Object Storage Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Archive Object Storage Added
+
+
+Sent when a user adds an object storage repository as an archive repository to the backup infrastructure. For more information, see [Archive Tier](https://helpcenter.veeam.com/docs/backup/vsphere/archive_tier.html) and [Backup Infrastructure for Unstructured Data Backup](https://helpcenter.veeam.com/docs/backup/vsphere/unstructured_data_backup_infrastructure.html).
+
+General Information
+
+Event ID: 29700
+
+Event message details: Object storage repository <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ArchiveRepositoryID | Archive repository ID. | ArchiveRepositoryID="0be4b8f2-f565-4c35-b5b7-6bf5e4008131" |
+| Type | Archive repository type. | Type="14" |
+| Name | Archive repository name. | Name="Object storage repository 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="0be4b8f2-f565-4c35-b5b7-6bf5e4008131" name="Object storage repository 1" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage repository Object storage repository 1 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:25:59.318751+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29700 ArchiveRepositoryID="0be4b8f2-f565-4c35-b5b7-6bf5e4008131" Type="14" Name="Object storage repository 1" ChangesXML="<changes><object id="0be4b8f2-f565-4c35-b5b7-6bf5e4008131" name="Object storage repository 1" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage repository Object storage repository 1 has been created."] |
+
+

--- a/docs/events/event_29800.md
+++ b/docs/events/event_29800.md
@@ -1,0 +1,44 @@
+---
+title: "Archive Object Storage Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Archive Object Storage Settings Updated
+
+
+Sent when a user updates archive object storage repository settings. For more information, see [Archive Tier](https://helpcenter.veeam.com/docs/backup/vsphere/archive_tier.html) and [Backup Infrastructure for Unstructured Data Backup](https://helpcenter.veeam.com/docs/backup/vsphere/unstructured_data_backup_infrastructure.html).
+
+General Information
+
+Event ID: 29800
+
+Event message details: Object storage repository <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ArchiveRepositoryID | Archive repository ID. | ArchiveRepositoryID="2c263893-778a-477a-9256-28861b769055" |
+| Type | Archive repository type. | Type="27" |
+| Name | Archive repository name. | Name="Object Storage Repository MINIO" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="2c263893-778a-477a-9256-28861b769055"><property name="Name" internal="Name" type="String"><old>Object Storage Repository</old><new>Object Storage Repository MINIO</new></property><property name="Description" internal="Description" type="String"><old>MinIO Server (local)</old><new>My MinIO Server</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage repository Object Storage Repository MINIO has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:23:01.055733+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29800 ArchiveRepositoryID="2c263893-778a-477a-9256-28861b769055" Type="27" Name="Object Storage Repository MINIO" ChangesXML="<changes><object id="2c263893-778a-477a-9256-28861b769055"><property name="Name" internal="Name" type="String"><old>Object Storage Repository</old><new>Object Storage Repository MINIO</new></property><property name="Description" internal="Description" type="String"><old>MinIO Server (local)</old><new>My MinIO Server</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage repository Object Storage Repository MINIO has been modified."] |
+
+

--- a/docs/events/event_29900.md
+++ b/docs/events/event_29900.md
@@ -1,0 +1,44 @@
+---
+title: "Archive Object Storage Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_29900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Archive Object Storage Deleted
+
+
+Sent when a user deletes an archive object storage repository from the backup infrastructure. For more information, see [Archive Tier](https://helpcenter.veeam.com/docs/backup/vsphere/archive_tier.html) and [Backup Infrastructure for Unstructured Data Backup](https://helpcenter.veeam.com/docs/backup/vsphere/unstructured_data_backup_infrastructure.html).
+
+General Information
+
+Event ID: 29900
+
+Event message details: Object storage repository <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ArchiveRepositoryID | Archive repository ID. | ArchiveRepositoryID="2c263893-778a-477a-9256-28861b769055" |
+| Type | Archive repository type. | Type="27" |
+| Name | Archive repository name. | Name="Object Storage Repository MINIO" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="2c263893-778a-477a-9256-28861b769055" name="Object Storage Repository MINIO" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage repository Object Storage Repository MINIO has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:24:35.190306+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=29900 ArchiveRepositoryID="2c263893-778a-477a-9256-28861b769055" Type="27" Name="Object Storage Repository MINIO" ChangesXML="<changes><object id="2c263893-778a-477a-9256-28861b769055" name="Object Storage Repository MINIO" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage repository Object Storage Repository MINIO has been deleted."] |
+
+

--- a/docs/events/event_30000.md
+++ b/docs/events/event_30000.md
@@ -1,0 +1,43 @@
+---
+title: "Scale-Out Backup Repository Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Scale-Out Backup Repository Added
+
+
+Sent when a user adds a scale-out backup repository to the backup infrastructure. For more information, see [Adding Scale-Out Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/sobr_add.html).
+
+General Information
+
+Event ID: 30000
+
+Event message details: Scale-out backup repository <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Scale-out backup repository ID. | RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" |
+| Name | Scale-out backup repository name. | Name="Scale-out Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f" name="Scale-out Backup Repository 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Scale-out backup repository Scale-out Backup Repository 01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:17:57.351447+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30000 RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" Name="Scale-out Backup Repository 01" ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f" name="Scale-out Backup Repository 01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Scale-out backup repository Scale-out Backup Repository 01 has been created."] |
+
+

--- a/docs/events/event_30100.md
+++ b/docs/events/event_30100.md
@@ -1,0 +1,43 @@
+---
+title: "Scale-Out Backup Repository Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Scale-Out Backup Repository Settings Updated
+
+
+Sent when a user updates scale-out backup repository settings. For more information, see [Managing Scale-Out Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_sobr_data.html).
+
+General Information
+
+Event ID: 30100
+
+Event message details: Scale-out backup repository <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Scale-out backup repository ID. | RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" |
+| Name | Scale-out backup repository name. | Name="Scale-out Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f"><property name="Name" internal="Name" type="String"><old>Scale-Out Backup Repository 01</old><new>Scale-Out Backup Repository 02</new></property><property internal="PerformFullBackupWhenRequiredExtentIsOffline" type="Boolean"><old>False</old><new>True</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Scale-out backup repository Scale-Out Repository Backup 01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:17:03.523116+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30100 RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" Name="Scale-Out Backup Repository 01" ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f"><property name="Name" internal="Name" type="String"><old>Scale-Out Backup Repository 01</old><new>Scale-Out Backup Repository 02</new></property><property internal="PerformFullBackupWhenRequiredExtentIsOffline" type="Boolean"><old>False</old><new>True</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Scale-out backup repository Scale-Out Repository Backup 01 has been modified."] |
+
+

--- a/docs/events/event_30200.md
+++ b/docs/events/event_30200.md
@@ -1,0 +1,43 @@
+---
+title: "Scale-Out Backup Repository Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Scale-Out Backup Repository Deleted
+
+
+Sent when a user deletes a scale-out backup repository from the backup infrastructure. For more information, see [Managing Scale-Out Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_sobr_data.html).
+
+General Information
+
+Event ID: 30200
+
+Event message details: Scale-out backup repository <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | Scale-out backup repository ID. | RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" |
+| Name | Scale-out backup repository name. | Name="Scale-out Backup Repository 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f" name="Scale-out Backup Repository 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Scale-out backup repository Scale-out Backup Repository 01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:17:57.351447+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30200 RepositoryID="92269bc8-7e4b-4c68-bf66-466279d1467f" Name="Scale-out Backup Repository 01" ChangesXML="<changes><object id="92269bc8-7e4b-4c68-bf66-466279d1467f" name="Scale-out Backup Repository 01" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Scale-out backup repository Scale-out Backup Repository 01 has been deleted."] |
+
+

--- a/docs/events/event_30300.md
+++ b/docs/events/event_30300.md
@@ -1,0 +1,43 @@
+---
+title: "Application Group Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Application Group Added
+
+
+Sent when a user adds a new application group. For more information, see [Application Group](https://helpcenter.veeam.com/docs/backup/vsphere/application_group.html).
+
+General Information
+
+Event ID: 30300
+
+Event message details: Application group <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AppGroupID | Application group ID. | AppGroupID="3fb3b982-8db2-45f4-87ce-83efaef2e763" |
+| Name | Application group name. | Name="Application Group 3" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="3fb3b982-8db2-45f4-87ce-83efaef2e763" name="Application Group 3" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application group Application Group 3 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:46:43.995143+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30300 AppGroupID="3fb3b982-8db2-45f4-87ce-83efaef2e763" Name="Application Group 3" ChangesXML="<changes><object id="3fb3b982-8db2-45f4-87ce-83efaef2e763" name="Application Group 3" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application group Application Group 3 has been created."] |
+
+

--- a/docs/events/event_30400.md
+++ b/docs/events/event_30400.md
@@ -1,0 +1,43 @@
+---
+title: "Application Group Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Application Group Settings Updated
+
+
+Sent when a user updates application group settings. For more information, see [Application Group](https://helpcenter.veeam.com/docs/backup/vsphere/application_group.html).
+
+General Information
+
+Event ID: 30400
+
+Event message details: Application group <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AppGroupID | Application group ID. | AppGroupID="653ee5c7-9f84-4456-8930-3ddf9ade2460" |
+| Name | Application group name. | Name="App Group - HyperV" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="653ee5c7-9f84-4456-8930-3ddf9ade2460"><ObjectsInJob><added /><modified><item><property internal="SbVerificationOptionsMaximumAllowedBootTime" type="Integer"><old>600</old><new>60</new></property></modified><deleted /></ObjectsInJob></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application group App Group - HyperV has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:10:06.775799+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30400 AppGroupID="653ee5c7-9f84-4456-8930-3ddf9ade2460" Name="App Group - HyperV" ChangesXML="<changes><object id="653ee5c7-9f84-4456-8930-3ddf9ade2460"><ObjectsInJob><added /><modified><item><property internal="SbVerificationOptionsMaximumAllowedBootTime" type="Integer"><old>600</old><new>60</new></property></modified><deleted /></ObjectsInJob></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application group App Group - HyperV has been modified."] |
+
+

--- a/docs/events/event_30500.md
+++ b/docs/events/event_30500.md
@@ -1,0 +1,43 @@
+---
+title: "Application Group Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Application Group Deleted
+
+
+Sent when a user deletes an application group. For more information, see [Application Group](https://helpcenter.veeam.com/docs/backup/vsphere/application_group.html).
+
+General Information
+
+Event ID: 30500
+
+Event message details: Application group <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AppGroupID | Application group ID. | AppGroupID="3fb3b982-8db2-45f4-87ce-83efaef2e763" |
+| Name | Application group name. | Name="Application Group 3" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="3fb3b982-8db2-45f4-87ce-83efaef2e763" name="Application Group 3" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application group Application Group 3 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:47:39.797826+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30500 AppGroupID="3fb3b982-8db2-45f4-87ce-83efaef2e763" Name="Application Group 3" ChangesXML="<changes><object id="3fb3b982-8db2-45f4-87ce-83efaef2e763" name="Application Group 3" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application group Application Group 3 has been deleted."] |
+
+

--- a/docs/events/event_30600.md
+++ b/docs/events/event_30600.md
@@ -1,0 +1,43 @@
+---
+title: "Virtual Lab Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Virtual Lab Added
+
+
+Sent when a user adds a new virtual lab to the backup infrastructure. For more information, see [Creating Virtual Lab](https://helpcenter.veeam.com/docs/backup/vsphere/create_vlab.html).
+
+General Information
+
+Event ID: 30600
+
+Event message details: Virtual lab <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VirtualLabID | Virtual lab ID. | VirtualLabID="0400eb56-5ebd-4096-8b07-d57493328377" |
+| Name | Virtual lab name. | Name="Virtual Lab 4" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="0400eb56-5ebd-4096-8b07-d57493328377" name="Virtual Lab 4" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Virtual lab Virtual Lab 4 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:37:50.329529+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30600 VirtualLabID="0400eb56-5ebd-4096-8b07-d57493328377" Name="Virtual Lab 4" ChangesXML="<changes><object id="0400eb56-5ebd-4096-8b07-d57493328377" name="Virtual Lab 4" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Virtual lab Virtual Lab 4 has been created."] |
+
+

--- a/docs/events/event_30700.md
+++ b/docs/events/event_30700.md
@@ -1,0 +1,43 @@
+---
+title: "Virtual Lab Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Virtual Lab Settings Updated
+
+
+Sent when a user updates virtual lab settings. For more information, see [Editing and Deleting Virtual Labs](https://helpcenter.veeam.com/docs/backup/vsphere/vlab_edit_delete.html).
+
+General Information
+
+Event ID: 30700
+
+Event message details: Virtual lab <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VirtualLabID | Virtual lab ID. | VirtualLabID="19e2886f-f908-42bd-a1fe-bd19df1167a0" |
+| Name | Virtual lab name. | Name="Hyper-V Virtual lab 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="19e2886f-f908-42bd-a1fe-bd19df1167a0"><property internal="NetworkConfigurationType" type="ENetworkConfigurationType"><old>Basic</old><new>Advanced</new></property><property internal="IPv6.Enabled" type="Boolean"><old>False</old><new>True</new></property><property internal="IPv6. Obtain an address automatically" type="Boolean"><old /><new>True</new></property><property internal="IPv6. Obtain DNS server address automatically" type="Boolean"><old /><new>True</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Virtual lab Hyper-V Virtual lab 01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:07:30.007851+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30700 VirtualLabID="19e2886f-f908-42bd-a1fe-bd19df1167a0" Name="Hyper-V Virtual lab 01" ChangesXML="<changes><object id="19e2886f-f908-42bd-a1fe-bd19df1167a0"><property internal="NetworkConfigurationType" type="ENetworkConfigurationType"><old>Basic</old><new>Advanced</new></property><property internal="IPv6.Enabled" type="Boolean"><old>False</old><new>True</new></property><property internal="IPv6. Obtain an address automatically" type="Boolean"><old /><new>True</new></property><property internal="IPv6. Obtain DNS server address automatically" type="Boolean"><old /><new>True</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Virtual lab Hyper-V Virtual lab 01 has been modified."] |
+
+

--- a/docs/events/event_30800.md
+++ b/docs/events/event_30800.md
@@ -1,0 +1,43 @@
+---
+title: "Virtual Lab Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_30800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Virtual Lab Deleted
+
+
+Sent when a user deletes a virtual lab from the backup infrastructure. For more information, see [Editing and Deleting Virtual Labs](https://helpcenter.veeam.com/docs/backup/vsphere/vlab_edit_delete.html).
+
+General Information
+
+Event ID: 30800
+
+Event message details: Virtual lab <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| VirtualLabID | Virtual lab ID. | VirtualLabID="0400eb56-5ebd-4096-8b07-d57493328377" |
+| Name | Virtual lab name. | Name="Virtual Lab 4" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="0400eb56-5ebd-4096-8b07-d57493328377" name="Virtual Lab 4" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Virtual lab Virtual Lab 4 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:40:01.751379+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=30800 VirtualLabID="0400eb56-5ebd-4096-8b07-d57493328377" Name="Virtual Lab 4" ChangesXML="<changes><object id="0400eb56-5ebd-4096-8b07-d57493328377" name="Virtual Lab 4" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Virtual lab Virtual Lab 4 has been deleted."] |
+
+

--- a/docs/events/event_310.md
+++ b/docs/events/event_310.md
@@ -1,0 +1,44 @@
+---
+title: "SureBackup Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_310.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup Job Started
+
+
+Sent when a user starts a SureBackup job session. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 310
+
+Event message details: SureBackup job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="5d899b75-448e-4a1a-a0b7-851f06e818fd" |
+| JobID | Job ID. | JobID="edc5270e-9cc4-4700-aff2-eff08302315c" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="1" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 1' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T13:31:32.217805+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=310 JobSessionID="5d899b75-448e-4a1a-a0b7-851f06e818fd" JobID="edc5270e-9cc4-4700-aff2-eff08302315c" JobType="3" Platform="1" Flags="1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 1' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_31000.md
+++ b/docs/events/event_31000.md
@@ -1,0 +1,40 @@
+---
+title: "General Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# General Settings Updated
+
+
+Sent when a user updates general settings for Veeam Backup & Replication. For more information, see [Configuring General Settings](https://helpcenter.veeam.com/docs/backup/vsphere/backup_settings.html).
+
+General Information
+
+Event ID: 31000
+
+Event message details: Backup server general options have been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><property internal="SyslogReportingEnabled" type="Boolean"><old>False</old><new>True</new></property><property internal="SyslogReportingHost" type="String"><old /><new>192.168.0.1</new></property><property internal="SyslogReportingPort" type="Integer"><old /><new>514</new></property><property internal="SyslogReportingProtocol" type="SyslogProtocol"><old /><new>Udp</new></property><property internal="SyslogReportingCertificateThumbprint" type="String"><old /><new></new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup server general options have been changed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-19T09:47:57.308160-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31000 ChangesXML="<changes><object><property internal="SyslogReportingEnabled" type="Boolean"><old>False</old><new>True</new></property><property internal="SyslogReportingHost" type="String"><old /><new>192.168.0.1</new></property><property internal="SyslogReportingPort" type="Integer"><old /><new>514</new></property><property internal="SyslogReportingProtocol" type="SyslogProtocol"><old /><new>Udp</new></property><property internal="SyslogReportingCertificateThumbprint" type="String"><old /><new></new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup server general options have been changed"] |
+
+

--- a/docs/events/event_31100.md
+++ b/docs/events/event_31100.md
@@ -1,0 +1,40 @@
+---
+title: "Global Settings for Network Traffic Rules Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global Settings for Network Traffic Rules Updated
+
+
+Sent when a user updates global settings for network traffic rules. For more information, see [Managing Upload Streams](https://helpcenter.veeam.com/docs/backup/vsphere/enabling_multithreaded_transfer.html).
+
+General Information
+
+Event ID: 31100
+
+Event message details: Backup server global network traffic rules have been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><property internal="DownloadStreamCount" type="Integer"><old>5</old><new>7</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup server global network traffic rules have been changed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T12:38:05.702527+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31100 ID="0" Name="0" ChangesXML="<changes><object><property internal="DownloadStreamCount" type="Integer"><old>5</old><new>7</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup server global network traffic rules have been changed"] |
+
+

--- a/docs/events/event_31200.md
+++ b/docs/events/event_31200.md
@@ -1,0 +1,43 @@
+---
+title: "User or Group Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# User or Group Added
+
+
+Sent when a user adds a new user or a new user group. For more information, see [Configuring Users](https://helpcenter.veeam.com/docs/backup/vsphere/configuring_users.html).
+
+General Information
+
+Event ID: 31200
+
+Event message details: User or group <UserName> | <GroupName> has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | User ID or group ID. | ID="94ef735b-c211-4734-8cf8-70bf175491ae" |
+| Name | User name or group name. | Name="TECH\user2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="User or group TECH\user2 has been added." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:09:25.501631-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31200 ID="94ef735b-c211-4734-8cf8-70bf175491ae" Name="TECH\user2" ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="User or group TECH\user2 has been added."] |
+
+

--- a/docs/events/event_31210.md
+++ b/docs/events/event_31210.md
@@ -1,0 +1,43 @@
+---
+title: "Adding User or Group Failed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Adding User or Group Failed
+
+
+Sent when a user cannot add a new user or a new user group. For more information, see [Configuring Users](https://helpcenter.veeam.com/docs/backup/vsphere/configuring_users.html).
+
+General Information
+
+Event ID: 31210
+
+Event message details: Failed to add a user or a group: <UserName> | <GroupName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | User ID or group ID. | ID="94ef735b-c211-4734-8cf8-70bf175491ae" |
+| Name | User name or group name. | Name="TECH\user2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failed to add a user or a group: [TECH\user2]" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:33:09.110877+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31210 ID="94ef735b-c211-4734-8cf8-70bf175491ae" Name="TECH\user2" ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failed to add a user or a group: [TECH\user2]"] |
+
+

--- a/docs/events/event_31300.md
+++ b/docs/events/event_31300.md
@@ -1,0 +1,42 @@
+---
+title: "Custom Role Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31300.html"
+last_updated: "12/12/2025"
+product_version: "13.0.1.1071"
+---
+
+# Custom Role Added
+
+
+Sent when a user adds a new custom role. For more information, see [Configuring Roles](configure_roles.md).
+
+General Information
+
+Event ID: 31300
+
+Event message details: Custom user role <Name> has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Custom role ID. | ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" |
+| Name | Custom role name. | Name="Custom Role 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<Property internal="Name" collection="False" type="String">Custom Role 1</Property><Property internal="Description" collection="False" type="String">Created by TECH\user1 at 05.12.2025 17:55.</Property><Property internal="CustomRoleBackupOperator" collection="False" type="Boolean">True</Property><Property internal="CustomRoleRestoreOperator" collection="False" type="Boolean">False</Property><Property internal="CustomRoleInventoryScope" collection="False" type="Boolean">False</Property><Property internal="CustomRoleRepositoryScope" collection="False" type="Boolean">False</Property><Property internal="CustomRoleBackupScope" collection="False" type="Integer">0</Property><Property internal="CustomRoleRestoreOptions" collection="False" type="Boolean">False</Property><Property internal="CustomRoleRestoreTargetScope" collection="False" type="Integer">0</Property><Property internal="CustomRoleRestoreToOriginalAllowed" collection="False" type="Boolean">True</Property>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Custom user role Custom Role 1 has been added." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:06:17.301853-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31300 ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" Name="Custom Role 1" ChangesXML="<Property internal="Name" collection="False" type="String">Custom Role 1</Property><Property internal="Description" collection="False" type="String">Created by TECH\user1 at 05.12.2025 17:55.</Property><Property internal="CustomRoleBackupOperator" collection="False" type="Boolean">True</Property><Property internal="CustomRoleRestoreOperator" collection="False" type="Boolean">False</Property><Property internal="CustomRoleInventoryScope" collection="False" type="Boolean">False</Property><Property internal="CustomRoleRepositoryScope" collection="False" type="Boolean">False</Property><Property internal="CustomRoleBackupScope" collection="False" type="Integer">0</Property><Property internal="CustomRoleRestoreOptions" collection="False" type="Boolean">False</Property><Property internal="CustomRoleRestoreTargetScope" collection="False" type="Integer">0</Property><Property internal="CustomRoleRestoreToOriginalAllowed" collection="False" type="Boolean">True</Property>" UserFullInfo="<ModifiedUserInfo fullName=".\veeamadmin" loginType="0" />" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Custom user role Custom Role 1 has been added."] |
+
+

--- a/docs/events/event_31310.md
+++ b/docs/events/event_31310.md
@@ -1,0 +1,42 @@
+---
+title: "Custom Role Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31310.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Custom Role Updated
+
+
+Sent when a user updates a custom role. For more information, see [Configuring Roles](configure_roles.md).
+
+General Information
+
+Event ID: 31310
+
+Event message details: Custom user role <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Custom role ID. | ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" |
+| Name | Custom role name. | Name="Custom Role 1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="4b17d237-f063-45b3-99e2-6977b50c9c9e"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 05.12.2025 17:55.</old><new>Custom role for audit</new></property></object></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Custom user role Custom Role 1 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:35:11.015294-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31310 ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" Name="Custom Role 1" ChangesXML="<changes><object id="4b17d237-f063-45b3-99e2-6977b50c9c9e"><property name="Description" internal="Description" type="String"><old>Created by TECH\user1 at 05.12.2025 17:55.</old><new>Custom role for audit</new></property></object></changes>" UserFullInfo="<ModifiedUserInfo fullName=".\veeamadmin" loginType="0" />" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Custom user role Custom Role 1 has been modified."] |
+
+

--- a/docs/events/event_31320.md
+++ b/docs/events/event_31320.md
@@ -1,0 +1,41 @@
+---
+title: "Custom Role Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31320.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Custom Role Deleted
+
+
+Sent when a user deletes a custom role. For more information, see [Configuring Roles](configure_roles.md).
+
+General Information
+
+Event ID: 31320
+
+Event message details: Custom user role <Name> has been deleted
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Custom role ID. | ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" |
+| Name | Custom role name. | Name="Custom Role 1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Custom user role Custom Role 1 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:44:08.401633-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31320 ID="4b17d237-f063-45b3-99e2-6977b50c9c9e" Name="Custom Role 1" UserFullInfo="<ModifiedUserInfo fullName=".\veeamadmin" loginType="0" />" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Custom user role Custom Role 1 has been deleted."] |
+
+

--- a/docs/events/event_31400.md
+++ b/docs/events/event_31400.md
@@ -1,0 +1,43 @@
+---
+title: "User or Group Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# User or Group Deleted
+
+
+Sent when a user deletes a user or a user group. For more information, see [Configuring Users](https://helpcenter.veeam.com/docs/backup/vsphere/configuring_users.html).
+
+General Information
+
+Event ID: 31400
+
+Event message details: User or group <UserName> | <GroupName> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | User ID or group ID. | ID="94ef735b-c211-4734-8cf8-70bf175491ae" |
+| Name | User name or group name. | Name="TECH\user2" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="User or group TECH\user2 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T08:49:10.238346-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31400 ID="94ef735b-c211-4734-8cf8-70bf175491ae" Name="TECH\user2" ChangesXML="<changes><object id="94ef735b-c211-4734-8cf8-70bf175491ae" name="TECH\user2" assignedRoleName="Veeam Backup Viewer" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="User or group TECH\user2 has been deleted."] |
+
+

--- a/docs/events/event_31500.md
+++ b/docs/events/event_31500.md
@@ -1,0 +1,41 @@
+---
+title: "Configuration Backup Job Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Configuration Backup Job Settings Updated
+
+
+Sent when a user updates configuration backup job settings. For more information, see [Creating Configuration Backups](https://helpcenter.veeam.com/docs/backup/vsphere/export_vbr_config.html).
+
+General Information
+
+Event ID: 31500
+
+Event message details: Configuration backup job has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="99d1bf3d-e2e0-4bec-b2b3-820c0b87d212"><property name="Configuration backup retention" internal="ConfigurationBackupRetentionPolicy" type="Integer"><old>10</old><new>15</new></property><property name="Run the job daily option" internal="ScheduleOptions.OptionsDaily.Enabled" type="Boolean"><old>True</old><new>False</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Configuration job has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:43:30.872099+00:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31500 ChangesXML="<changes><object id="99d1bf3d-e2e0-4bec-b2b3-820c0b87d212"><property name="Configuration backup retention" internal="ConfigurationBackupRetentionPolicy" type="Integer"><old>10</old><new>15</new></property><property name="Run the job daily option" internal="ScheduleOptions.OptionsDaily.Enabled" type="Boolean"><old>True</old><new>False</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Configuration job has been modified."] |
+
+

--- a/docs/events/event_31600.md
+++ b/docs/events/event_31600.md
@@ -1,0 +1,43 @@
+---
+title: "Encryption Password Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Encryption Password Added
+
+
+Sent when a user adds a new encryption password. For more information, see [Password Manager](https://helpcenter.veeam.com/docs/backup/vsphere/password_manager.html).
+
+General Information
+
+Event ID: 31600
+
+Event message details: Encryption password <Hint> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Hint | Password hint. | Hint="New encryption password" |
+| ID | Password ID. | ID="ad359169-b802-49ab-b3ea-b52d23461844" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes />" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Encryption password New encryption password has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:50:32.154007-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31600 Hint="New encryption password" ID="ad359169-b802-49ab-b3ea-b52d23461844" ChangesXML="<changes />" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Encryption password New encryption password has been created."] |
+
+

--- a/docs/events/event_31700.md
+++ b/docs/events/event_31700.md
@@ -1,0 +1,43 @@
+---
+title: "Encryption Password Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Encryption Password Updated
+
+
+Sent when a user updates an encryption password. For more information, see [Password Manager](https://helpcenter.veeam.com/docs/backup/vsphere/password_manager.html).
+
+General Information
+
+Event ID: 31700
+
+Event message details: Encryption password <Hint> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Hint | Password hint. | Hint="New encryption password" |
+| ID | Password ID. | ID="ad359169-b802-49ab-b3ea-b52d23461844" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="023adcf1-07fd-4883-be51-443afc2e49e6"><property internal="CredentialsPassword" type="String"><old>\*\*\*</old><new>\*\*\*\*</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Encryption password New encryption password has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-10T06:07:38.638154-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31700 Hint="New encryption password" ID="ad359169-b802-49ab-b3ea-b52d23461844" ChangesXML="<changes><object id="ad359169-b802-49ab-b3ea-b52d23461844"><property internal="EncryptionPasswordHint" type="String"><old>Newencryption password</old><new>Newencryption password DC2</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Encryption password New encryption password has been modified."] |
+
+

--- a/docs/events/event_31800.md
+++ b/docs/events/event_31800.md
@@ -1,0 +1,43 @@
+---
+title: "Encryption Password Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Encryption Password Deleted
+
+
+Sent when a user deletes an encryption password. For more information, see [Password Manager](https://helpcenter.veeam.com/docs/backup/vsphere/password_manager.html).
+
+General Information
+
+Event ID: 31800
+
+Event message details: Encryption password <Hint> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Hint | Password hint. | Hint="New encryption password" |
+| ID | Password ID. | ID="ad359169-b802-49ab-b3ea-b52d23461844" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes />" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Encryption password New encryption password has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:50:39.765370-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31800 Hint="New encryption password" ID="ad359169-b802-49ab-b3ea-b52d23461844" ChangesXML="<changes />" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Encryption password New encryption password has been deleted."] |
+
+

--- a/docs/events/event_31850.md
+++ b/docs/events/event_31850.md
@@ -1,0 +1,41 @@
+---
+title: "Encryption Password Verified"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31850.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Encryption Password Verified
+
+
+Sent when a user verifies an encryption password. For more information, see [Verifying Passwords](password_manager_verify.md).
+
+General Information
+
+Event ID: 31850
+
+Event message details: Saved encryption password matches | does not match the provided password. <ID>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ID | Password ID. | ID="ad359169-b802-49ab-b3ea-b52d23461844" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| PasswordMatched | Defines whether the entered password matches the stored one. | PasswordMatched="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Saved encryption password matches the provided password. (ad359169-b802-49ab-b3ea-b52d23461844)" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:50:39.765370-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31850 ID="ad359169-b802-49ab-b3ea-b52d23461844" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" PasswordMatched="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Saved encryption password matches the provided password. (ad359169-b802-49ab-b3ea-b52d23461844)"] |
+
+

--- a/docs/events/event_31900.md
+++ b/docs/events/event_31900.md
@@ -1,0 +1,43 @@
+---
+title: "SSH Credentials Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_31900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SSH Credentials Changed
+
+
+Sent when a user updates settings for SSH credentials. For more information, see [SSH Credentials](https://helpcenter.veeam.com/docs/backup/vsphere/credentials_manager_linux.html).
+
+General Information
+
+Event ID: 31900
+
+Event message details: SSH options for credentials <RelatedCredsID> have been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RelatedCredsID | Credential record ID. | RelatedCredsID="14404f22-5aa1-4602-baa8-dfe058ff7256" |
+| RelatedCredsName | Account user name. | RelatedCredsName="admin" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="14404f22-5aa1-4602-baa8-dfe058ff7256"><property internal="CredentialsElevateRoot" type="Boolean"><old>True</old><new>False</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SSH options for credentials 14404f22-5aa1-4602-baa8-dfe058ff7256 have been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:28:25.813410+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=31900 RelatedCredsID="14404f22-5aa1-4602-baa8-dfe058ff7256" RelatedCredsName="admin" ChangesXML="<changes><object id="14404f22-5aa1-4602-baa8-dfe058ff7256"><property internal="CredentialsElevateRoot" type="Boolean"><old>True</old><new>False</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SSH options for credentials 14404f22-5aa1-4602-baa8-dfe058ff7256 have been updated"] |
+
+

--- a/docs/events/event_32000.md
+++ b/docs/events/event_32000.md
@@ -1,0 +1,44 @@
+---
+title: "External Repository Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# External Repository Added
+
+
+Sent when a user adds an external repository to the backup infrastructure. For more information, see [External Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/external_repository.html).
+
+General Information
+
+Event ID: 32000
+
+Event message details: External repository <RepositoryName> <Type> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | External repository ID. | RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" |
+| Type | External repository type. | Type="0" |
+| RepositoryName | External repository name. | RepositoryName="Azure External Repository" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6" name="Azure External Repository" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="External repository Azure External Repository (AzureStorageExternal) has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T08:49:41.527965+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32000 RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" Type="0" RepositoryName="Azure External Repository" ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6" name="Azure External Repository" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="External repository Azure External Repository (AzureStorageExternal) has been created."] |
+
+

--- a/docs/events/event_32100.md
+++ b/docs/events/event_32100.md
@@ -1,0 +1,44 @@
+---
+title: "External Repository Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# External Repository Settings Updated
+
+
+Sent when a user updates external repository settings. For more information, see [Managing External Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_external_repositories.html).
+
+General Information
+
+Event ID: 32100
+
+Event message details: External repository <RepositoryName> <Type> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | External repository ID. | RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" |
+| Type | External repository type. | Type="0" |
+| RepositoryName | External repository name. | RepositoryName="Azure External Repository" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6"><property name="Description" internal="Description" type="String"><old>Azure External Repository</old><new>Azure Repository 01</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="External repository Azure External Repository (AzureStorageExternal) has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:30:12.596249+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32100 RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" Type="0" RepositoryName="Azure External Repository" ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6"><property name="Description" internal="Description" type="String"><old>Azure External Repository</old><new>Azure Repository 01</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="External repository Azure External Repository (AzureStorageExternal) has been modified."] |
+
+

--- a/docs/events/event_32120.md
+++ b/docs/events/event_32120.md
@@ -1,0 +1,44 @@
+---
+title: "Objects for Job Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32120.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects for Job Deleted
+
+
+Sent when a user deletes objects from a job. For more information, see [Editing Job Settings](https://helpcenter.veeam.com/docs/backup/vsphere/editing_jobs.html).
+
+General Information
+
+Event ID: 32120
+
+Event message details: <N> objects has been deleted for <JobName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobID | Job ID. | JobID="3038588e-5d74-4df6-9fad-3eb6840ad317" |
+| JobType | Job type. | JobType="0" |
+| Platform | Platform type. | Platform="N\A" |
+| JobName | Job name. | JobName="VMware Servers Backup" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="e3f59198-46ab-4202-94ee-7310846e5bd6"><Property internal="Name" collection="False" type="CDumpedMemberInfo">Virtual Machine 01</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="'1' objects has been deleted for 'VMware Servers Backup'." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:27:54.901512+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32120 JobID="3038588e-5d74-4df6-9fad-3eb6840ad317" JobType="0" Platform="N\A" JobName="VMware Servers Backup" ChangesXML="<changes><object id="e3f59198-46ab-4202-94ee-7310846e5bd6"><Property internal="Name" collection="False" type="CDumpedMemberInfo">Virtual Machine 01</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="'1' objects has been deleted for 'VMware Servers Backup'."] |
+
+

--- a/docs/events/event_32200.md
+++ b/docs/events/event_32200.md
@@ -1,0 +1,44 @@
+---
+title: "External Repository Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# External Repository Deleted
+
+
+Sent when a user deletes an external repository from the backup infrastructure. For more information, see [Managing External Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/managing_external_repositories.html).
+
+General Information
+
+Event ID: 32200
+
+Event message details: External repository <RepositoryName> <Type> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryID | External repository ID. | RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" |
+| Type | External repository type. | Type="0" |
+| RepositoryName | External repository name. | RepositoryName="Azure External Repository" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6" name="Azure External Repository" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="External repository Azure External Repository (AzureStorageExternal) has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T17:14:16.384737+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32200 RepositoryID="80a40f31-2907-432f-8eb7-c434b53571a6" Type="0" RepositoryName="Azure External Repository" ChangesXML="<changes><object id="80a40f31-2907-432f-8eb7-c434b53571a6" name="Azure External Repository" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="External repository Azure External Repository (AzureStorageExternal) has been deleted."] |
+
+

--- a/docs/events/event_32300.md
+++ b/docs/events/event_32300.md
@@ -1,0 +1,40 @@
+---
+title: "Global Network Traffic Rules Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global Network Traffic Rules Added
+
+
+Sent when a user adds new global network traffic rules. For more information, see [Managing Network Traffic](https://helpcenter.veeam.com/docs/backup/vsphere/managing_network_traffic.html).
+
+General Information
+
+Event ID: 32300
+
+Event message details: <N> global network traffic rules have been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule"><Property internal="FirstDiapason" collection="False" type="CIPDiapason">192.168.0.1 - 192.168.0.255</Property><Property internal="SecondDiapason" collection="False" type="CIPDiapason">192.168.0.1 - 192.168.0.255</Property><Property internal="IsEncryptionEnabled" collection="False" type="Boolean">True</Property><Property internal="IsThrottlingEnabled" collection="False" type="Boolean">False</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 global network traffic rules have been created" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:41:34.905404+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32300 ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule"><Property internal="FirstDiapason" collection="False" type="CIPDiapason">192.168.0.1 - 192.168.0.255</Property><Property internal="SecondDiapason" collection="False" type="CIPDiapason">192.168.0.1 - 192.168.0.255</Property><Property internal="IsEncryptionEnabled" collection="False" type="Boolean">True</Property><Property internal="IsThrottlingEnabled" collection="False" type="Boolean">False</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 global network traffic rules have been created"] |
+
+

--- a/docs/events/event_32400.md
+++ b/docs/events/event_32400.md
@@ -1,0 +1,40 @@
+---
+title: "Global Network Traffic Rules Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global Network Traffic Rules Deleted
+
+
+Sent when a user deletes global network traffic rules. For more information, see [Managing Network Traffic](https://helpcenter.veeam.com/docs/backup/vsphere/managing_network_traffic.html).
+
+General Information
+
+Event ID: 32400
+
+Event message details: <N> global network traffic rules have been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 global network traffic rules have been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:43:23.129096+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32400 ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 global network traffic rules have been deleted"] |
+
+

--- a/docs/events/event_32500.md
+++ b/docs/events/event_32500.md
@@ -1,0 +1,40 @@
+---
+title: "Global Network Traffic Rules Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global Network Traffic Rules Updated
+
+
+Sent when a user updates global network traffic rules. For more information, see [Managing Network Traffic](https://helpcenter.veeam.com/docs/backup/vsphere/managing_network_traffic.html).
+
+General Information
+
+Event ID: 32500
+
+Event message details: <N> global network traffic rules have been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule"><property internal="SecondDiapason" type="CIPDiapason"><old>192.168.0.1 - 192.168.0.255</old><new>192.168.0.1</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 global network traffic rules have been modified" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:43:08.274786+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32500 ChangesXML="<changes><object id="88cbb56d-2b05-4d24-b0ee-9042c9e06368" name="My New Rule"><property internal="SecondDiapason" type="CIPDiapason"><old>192.168.0.1 - 192.168.0.255</old><new>192.168.0.1</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 global network traffic rules have been modified"] |
+
+

--- a/docs/events/event_32600.md
+++ b/docs/events/event_32600.md
@@ -1,0 +1,40 @@
+---
+title: "Preferred Networks Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Preferred Networks Updated
+
+
+Sent when a user enables or disables preferred networks for global network traffic rules. For more information, see [Specifying Preferred Networks](https://helpcenter.veeam.com/docs/backup/vsphere/select_backup_network.html).
+
+General Information
+
+Event ID: 32600
+
+Event message details: Global network traffic options have been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><property internal="UseNetworks" type="Boolean"><old>False</old><new>True</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Global network traffic options have been changed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:23:14.893526+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32600 ChangesXML="<changes><object><property internal="UseNetworks" type="Boolean"><old>False</old><new>True</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Global network traffic options have been changed"] |
+
+

--- a/docs/events/event_32700.md
+++ b/docs/events/event_32700.md
@@ -1,0 +1,40 @@
+---
+title: "Preferred Networks Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Preferred Networks Added
+
+
+Sent when a user adds preferred networks for global network traffic rules. For more information, see [Specifying Preferred Networks](https://helpcenter.veeam.com/docs/backup/vsphere/select_backup_network.html).
+
+General Information
+
+Event ID: 32700
+
+Event message details: <N> networks traffic rules have been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><Property internal="CIDR" collection="False" type="String">10.10.8.0/22</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 networks traffic rules have been added" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:23:14.941512+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32700 ChangesXML="<changes><object><Property internal="CIDR" collection="False" type="String">10.10.8.0/22</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 networks traffic rules have been added"] |
+
+

--- a/docs/events/event_32800.md
+++ b/docs/events/event_32800.md
@@ -1,0 +1,40 @@
+---
+title: "Preferred Networks Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Preferred Networks Deleted
+
+
+Sent when a user deletes preferred networks for global network traffic rules. For more information, see [Specifying Preferred Networks](https://helpcenter.veeam.com/docs/backup/vsphere/select_backup_network.html).
+
+General Information
+
+Event ID: 32800
+
+Event message details: <N> networks traffic rules have been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><Property internal="CIDR" collection="False" type="String">10.10.8.0/22</Property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 networks traffic rules have been deleted" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:25:14.663540+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32800 ChangesXML="<changes><object><Property internal="CIDR" collection="False" type="String">10.10.8.0/22</Property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 networks traffic rules have been deleted"] |
+
+

--- a/docs/events/event_32900.md
+++ b/docs/events/event_32900.md
@@ -1,0 +1,42 @@
+---
+title: "Component Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_32900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Component Updated
+
+
+Sent when a user upgrades infrastructure components. For more information, see [Upgrading Infrastructure Components](https://helpcenter.veeam.com/docs/backup/vsphere/components_update.html).
+
+General Information
+
+Event ID: 32900
+
+Event message details: Component <ComponentDisplayName> on the host <HostName> has been updated
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| HostName | Component hostname. | HostName="srv01.tech.local" |
+| ComponentDisplayName | Component name. | ComponentDisplayName="Transport" |
+| Result | Defines whether the operation was successfully performed. | Result="True" |
+| IsInstallOrUpgrade | Defines whether the component was installed or upgraded. | IsInstallOrUpgrade="True" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Component [Transport] on the host [srv01.tech.local] has been updated" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:21:04.997292+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=32900 HostName="srv01.tech.local" ComponentDisplayName="Transport" Result="True" IsInstallOrUpgrade="True" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Component [Transport] on the host [srv01.tech.local] has been updated"] |
+
+

--- a/docs/events/event_33000.md
+++ b/docs/events/event_33000.md
@@ -1,0 +1,44 @@
+---
+title: "Wan Accelerator Cache Populated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_33000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Wan Accelerator Cache Populated
+
+
+Sent when a user populates WAN accelerator cache. For more information, see [Manual Population of Global Cache](https://helpcenter.veeam.com/docs/backup/vsphere/wan_population.html).
+
+General Information
+
+Event ID: 33000
+
+Event message details: Cache of WAN accelerator <WanAcceleratorName> has been populated
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| WanAcceleratorID | WAN accelerator ID. | WanAcceleratorID="d4022991-76f8-4024-8c8f-b8192e0a8278" |
+| WanAcceleratorName | WAN accelerator name. | WanAcceleratorName="WAN01" |
+| SessionID | Session ID. | SessionID="c9295f57-f801-44ac-a55c-d3a31f1309dc" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cache of WAN accelerator WAN01 has been populated." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:24:28.569688+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=33000 WanAcceleratorID="d4022991-76f8-4024-8c8f-b8192e0a8278" WanAcceleratorName="WAN01" SessionID="c9295f57-f801-44ac-a55c-d3a31f1309dc" Result="0" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cache of WAN accelerator WAN01 has been populated."] |
+
+

--- a/docs/events/event_33001.md
+++ b/docs/events/event_33001.md
@@ -1,0 +1,42 @@
+---
+title: "Wan Accelerator Cache Cleared"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_33001.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Wan Accelerator Cache Cleared
+
+
+Sent when a user clears WAN accelerator cache. For more information, see [Clearing Global Cache](https://helpcenter.veeam.com/docs/backup/vsphere/wan_clear_cache.html).
+
+General Information
+
+Event ID: 33001
+
+Event message details: Cache of WAN accelerator <WanAcceleratorName> has been cleared
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| WanAcceleratorID | WAN accelerator ID. | WanAcceleratorID="d4022991-76f8-4024-8c8f-b8192e0a8278" |
+| WanAcceleratorName | WAN accelerator name. | WanAcceleratorName="WAN01" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Cache of WAN accelerator WAN01 has been cleared." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:22:48.947655+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=33001 WanAcceleratorID="d4022991-76f8-4024-8c8f-b8192e0a8278" WanAcceleratorName="WAN01" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Cache of WAN accelerator WAN01 has been cleared."] |
+
+

--- a/docs/events/event_350.md
+++ b/docs/events/event_350.md
@@ -1,0 +1,52 @@
+---
+title: "Verification Task for VMware VM Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_350.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Verification Task for VMware VM Finished
+
+
+Sent when a verification task for a VMware VM is finished. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 350
+
+Event message details: VM <VmName> verification task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="d434e91a-ae68-4987-80a4-3d0169ff71b6" |
+| JobID | Job ID. | JobID="21874156-34b0-4316-94ae-fb05b2f67ec4" |
+| JobType | Job type. | JobType="3" |
+| TaskSessionID | Task session ID. | TaskSessionID="1469602e-d5e0-4262-bfbf-02b2a7c88259" |
+| TaskSessionType | Task session type. | TaskSessionType="1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| OibID | Machine ID. | OibID="d844fe29-818d-4da6-8adb-f9b6759d241a" |
+| IsSureReplica | Defines whether the task is SureReplica. | IsSureReplica="False" |
+| HostName | Host name. | HostName="srv01.tech.local" |
+| ESXName | ESXi host name. | ESXName="esx01.tech.local" |
+| FolderRef | Folder reference ID. | FolderRef="group-v01" |
+| VmLocation | Machine location. | VmLocation="srv01.tech.local\" |
+| VmName | Machine name. | VmName="VM01" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM [VM01] verification task has finished with [Success] state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T03:53:30.899608-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=350 JobSessionID="d434e91a-ae68-4987-80a4-3d0169ff71b6" JobID="21874156-34b0-4316-94ae-fb05b2f67ec4" JobType="3" TaskSessionID="1469602e-d5e0-4262-bfbf-02b2a7c88259" TaskSessionType="1" Result="0" OibID="d844fe29-818d-4da6-8adb-f9b6759d241a" IsSureReplica="False" HostName="srv01.tech.local" ESXName="esx01.tech.local" FolderRef="group-v01" VmLocation="srv01.tech.local\" VmName="VM01" VmRef="vm-01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM [VM01] verification task has finished with [Success] state."] |
+
+

--- a/docs/events/event_351.md
+++ b/docs/events/event_351.md
@@ -1,0 +1,52 @@
+---
+title: "Validation Task for VMware VM Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_351.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Validation Task for VMware VM Finished
+
+
+Sent when a validation task for a VMware VM is finished. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 351
+
+Event message details: VM <VmName> validation task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="4467f18a-d9e1-4fcf-ae1d-f635eb26cbe9" |
+| JobID | Job ID. | JobID="21874156-34b0-4316-94ae-fb05b2f67ec4" |
+| JobType | Job type. | JobType="3" |
+| TaskSessionID | Task session ID. | TaskSessionID="4cf4d768-18f6-4189-afa1-6f5375dd561c" |
+| TaskSessionType | Task session type. | TaskSessionType="1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="2" |
+| OibID | Machine ID. | OibID="d844fe29-818d-4da6-8adb-f9b6759d241a" |
+| IsSureReplica | Defines whether the task is SureReplica. | IsSureReplica="False" |
+| HostName | Host name. | HostName="srv01.tech.local" |
+| ESXName | ESXi host name. | ESXName="esx01.tech.local" |
+| FolderRef | Folder reference ID. | FolderRef="group-v01" |
+| VmLocation | Machine location. | VmLocation="srv01.tech.local\" |
+| VmName | Machine name. | VmName="VM01" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM [VM01] validation task has finished with [Failed] state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T04:43:21.493700-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=351 JobSessionID="4467f18a-d9e1-4fcf-ae1d-f635eb26cbe9" JobID="21874156-34b0-4316-94ae-fb05b2f67ec4" JobType="3" TaskSessionID="4cf4d768-18f6-4189-afa1-6f5375dd561c" TaskSessionType="1" Result="1" OibID="d844fe29-818d-4da6-8adb-f9b6759d241a" IsSureReplica="False" HostName="srv01.tech.local" ESXName="esx01.tech.local" FolderRef="group-v01" VmLocation="srv01.tech.local\" VmName="VM01" VmRef="vm-01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM [VM01] validation task has finished with [Failed] state."] |
+
+

--- a/docs/events/event_360.md
+++ b/docs/events/event_360.md
@@ -1,0 +1,50 @@
+---
+title: "Verification Task for Hyper-V VM Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_360.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Verification Task for Hyper-V VM Finished
+
+
+Sent when a verification task for a Hyper-V VM is finished. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 360
+
+Event message details: VM <VmName> verification task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="da83c52f-a52b-41f6-a524-39d3d743e7b6" |
+| JobID | Job ID. | JobID="cc7a04c3-2215-4be0-a96c-f0c059ddffe3" |
+| JobType | Job type. | JobType="3" |
+| TaskSessionID | Task session ID. | TaskSessionID="f1e40437-5e16-4baf-9621-da980df22d9e" |
+| TaskSessionType | Task session type. | TaskSessionType="1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| OibID | Machine ID. | OibID="3f36cedd-42e8-4362-87d1-5670b754673a" |
+| IsSureReplica | Defines whether the task is SureReplica. | IsSureReplica="False" |
+| HostName | Host name. | HostName="hvsrv01.tech.local" |
+| VmLocation | Machine location. | VmLocation="C:\ClusterStorage\Volume1\VMs\VM01" |
+| VmName | Machine name. | VmName="VM01" |
+| VmID | Machine ID. | VmID="2c508117-f5aa-44dc-889f-6476b406f777" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM [VM01] verification task has finished with [Success] state." |
+
+Syslog Message Examplehvsrv
+
+|  |
+| --- |
+| 1 2025-11-24T03:39:04.043853-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=360 JobSessionID="da83c52f-a52b-41f6-a524-39d3d743e7b6" JobID="cc7a04c3-2215-4be0-a96c-f0c059ddffe3" JobType="3" TaskSessionID="f1e40437-5e16-4baf-9621-da980df22d9e" TaskSessionType="1" Result="1" OibID="3f36cedd-42e8-4362-87d1-5670b754673a" IsSureReplica="False" HostName="hvsrv01.tech.local" VmLocation="C:\ClusterStorage\Volume1\VMs\VM01" VmName="VM01" VmID="2c508117-f5aa-44dc-889f-6476b406f777" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM [VM01] verification task has finished with [Success] state."] |
+
+

--- a/docs/events/event_36011.md
+++ b/docs/events/event_36011.md
@@ -1,0 +1,42 @@
+---
+title: "Recovery Token Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36011.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Recovery Token Created
+
+
+Sent when a user creates a new recovery token. For more information, see [Creating Recovery Tokens](https://helpcenter.veeam.com/docs/backup/plugins/application_backups_recovery_token.html).
+
+General Information
+
+Event ID: 36011
+
+Event message details: Recovery token has been created. <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TokenID | Recovery token ID. | TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" |
+| RepoAccessGroupID | Group ID with repository access permissions. | RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| ExpirationUTC | Date and time when a token expires. | ExpirationUTC="03/21/2025 15:17:57" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Recovery token has been created. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1, Expiration Date UTC: 2025-11-21T15:17:57.9575216Z" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T17:18:00.084349+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36011 TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" InitiatorName="TECH\user1" ExpirationUTC="03/21/2025 15:17:57" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Recovery token has been created. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1, Expiration Date UTC: 2025-11-21T15:17:57.9575216Z"] |
+
+

--- a/docs/events/event_36012.md
+++ b/docs/events/event_36012.md
@@ -1,0 +1,42 @@
+---
+title: "Recovery Token Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36012.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Recovery Token Updated
+
+
+Sent when a user updates a recovery token. For more information, see [Creating Recovery Tokens](https://helpcenter.veeam.com/docs/backup/plugins/application_backups_recovery_token.html).
+
+General Information
+
+Event ID: 36012
+
+Event message details: Recovery token has been updated. <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TokenID | Recovery token ID. | TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" |
+| RepoAccessGroupID | Group ID with repository access permissions. | RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| ExpirationUTC | Date and time when a token expires. | ExpirationUTC="03/21/2025 15:17:57" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Recovery token has been updated. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1, Expiration Date UTC: 2025-11-21T15:17:57.9575216Z" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T10:15:35.454625+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36012 TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" InitiatorName="TECH\user1" ExpirationUTC="03/21/2025 08:14:34" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Recovery token has been updated. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1, Expiration Date UTC: 2025-11-21T15:17:57.9575216Z"] |
+
+

--- a/docs/events/event_36013.md
+++ b/docs/events/event_36013.md
@@ -1,0 +1,41 @@
+---
+title: "Recovery Token Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36013.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Recovery Token Deleted
+
+
+Sent when a user deletes a recovery token. For more information, see [Creating Recovery Tokens](https://helpcenter.veeam.com/docs/backup/plugins/application_backups_recovery_token.html).
+
+General Information
+
+Event ID: 36013
+
+Event message details: Recovery token has been removed. <Details>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TokenID | Recovery token ID. | TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" |
+| RepoAccessGroupID | Group ID with repository access permissions. | RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Recovery token has been removed. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:15:52.803522+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36013 TokenID="f58aa63d-b0fe-4b93-b89d-161a6f406a80" RepoAccessGroupID="1bd5ee14-5947-483a-8c8f-49af909ce300" InitiatorName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Recovery token has been removed. Token ID: f58aa63d-b0fe-4b93-b89d-161a6f406a80, Access list: 1bd5ee14-5947-483a-8c8f-49af909ce300, Initiator: TECH\user1"] |
+
+

--- a/docs/events/event_36014.md
+++ b/docs/events/event_36014.md
@@ -1,0 +1,41 @@
+---
+title: "Authentication with Recovery Token Succeeded"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36014.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Authentication with Recovery Token Succeeded
+
+
+Sent when a recovery token successfully authenticated and got access to the backup. For more information, see [Creating Recovery Tokens](https://helpcenter.veeam.com/docs/backup/plugins/application_backups_recovery_token.html).
+
+General Information
+
+Event ID: 36014
+
+Event message details: Recovery token has been authenticated. <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| TokenID | Recovery token ID. | TokenID="d696fa5a-48c0-4888-b6be-fd395b438ecb" |
+| RepoAccessGroupID | Group ID with repository access permissions. | RepoAccessGroupID="bb2b8dcc-1553-405d-907b-6e7aae3211a0" |
+| Endpoint | Machine where the attempt was detected. | Endpoint="172.25.195.66:55442" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Recovery token has been authenticated. Token ID: d696fa5a-48c0-4888-b6be-fd395b438ecb, Access list: bb2b8dcc-1553-405d-907b-6e7aae3211a0, Client: 172.25.195.66:55442" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T05:37:17.768636-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36014 TokenID="d696fa5a-48c0-4888-b6be-fd395b438ecb" RepoAccessGroupID="bb2b8dcc-1553-405d-907b-6e7aae3211a0" Endpoint="172.25.195.66:55442" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Recovery token has been authenticated. Token ID: d696fa5a-48c0-4888-b6be-fd395b438ecb, Access list: bb2b8dcc-1553-405d-907b-6e7aae3211a0, Client: 172.25.195.66:55442"] |
+
+

--- a/docs/events/event_36021.md
+++ b/docs/events/event_36021.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Job for Application Backup Policy Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36021.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Job for Application Backup Policy Started
+
+
+Sent when a user starts a backup job session for the application backup policy. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36021
+
+Event message details: Application Backup Policy job <JobName> has been started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="494ea824-e31a-454f-972d-6e67320d7945" |
+| JobID | Job ID. | JobID="524df5b3-dafe-4e1c-9844-9c3f0bd9a0c9" |
+| JobType | Job type. | JobType="12100" |
+| Platform | Platform type. | Platform="8" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application Backup Policy job 'RMAN Policy 1' has been started." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T13:22:11.755106+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36021 JobSessionID="494ea824-e31a-454f-972d-6e67320d7945" JobID="524df5b3-dafe-4e1c-9844-9c3f0bd9a0c9" JobType="12100" Platform="8" Flags="0" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application Backup Policy job 'RMAN Policy 1' has been started."] |
+
+

--- a/docs/events/event_36022.md
+++ b/docs/events/event_36022.md
@@ -1,0 +1,46 @@
+---
+title: "Backup Job for Application Backup Policy Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36022.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Job for Application Backup Policy Finished
+
+
+Sent when a backup job session for the application backup policy is finished. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36022
+
+Event message details: Application Backup Policy job <JobName> finished with <State>. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="494ea824-e31a-454f-972d-6e67320d7945" |
+| JobID | Job ID. | JobID="524df5b3-dafe-4e1c-9844-9c3f0bd9a0c9" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="12100" |
+| Platform | Platform type. | Platform="8" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="RMAN Policy 1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application Backup Policy job 'RMAN Policy 1' finished with Success. All objects have been backed up successfully." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T14:22:55.259126+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36022 JobSessionID="494ea824-e31a-454f-972d-6e67320d7945" JobID="524df5b3-dafe-4e1c-9844-9c3f0bd9a0c9" JobResult="0" JobType="12100" Platform="8" WillBeRetried="False" JobName="RMAN Policy 1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application Backup Policy job 'RMAN Policy 1' finished with Success. All objects have been backed up successfully."] |
+
+

--- a/docs/events/event_36023.md
+++ b/docs/events/event_36023.md
@@ -1,0 +1,41 @@
+---
+title: "Backup Task for Application Backup Policy Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36023.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Task for Application Backup Policy Started
+
+
+Sent when a user starts a backup task session for the application backup policy. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36023
+
+Event message details: Backup of <DatabaseName> with <PolicyName> policy has been started. <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| PolicyName | Application backup policy name. | PolicyName="Sap Hana Policy 1" |
+| DatabaseName | Database name. | DatabaseName="HANA/HXE/TENANT1" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup of HANA/HXE/TENANT1 with Sap Hana Policy 1 policy has been started. Initiator: TECH\user1" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T13:25:50.051991+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36023 PolicyName="Sap Hana Policy 1" DatabaseName="HANA/HXE/TENANT1" InitiatorName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup of HANA/HXE/TENANT1 with Sap Hana Policy 1 policy has been started. Initiator: TECH\user1"] |
+
+

--- a/docs/events/event_36024.md
+++ b/docs/events/event_36024.md
@@ -1,0 +1,40 @@
+---
+title: "Backup Task for Application Backup Policy Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36024.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Task for Application Backup Policy Finished
+
+
+Sent when a backup task session for the application backup policy is finished. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36024
+
+Event message details: Backup of <DatabaseName> with <PolicyName> policy has been completed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| PolicyName | Application backup policy name. | PolicyName="Sap Hana Policy 1" |
+| DatabaseName | Database name. | DatabaseName="HANA/HXE/TENANT1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup of HANA/HXE/TENANT1 with Sap Hana Policy 1 policy has been completed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T13:25:50.426981+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36024 PolicyName="Sap Hana Policy 1" DatabaseName="HANA/HXE/TENANT1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup of HANA/HXE/TENANT1 with Sap Hana Policy 1 policy has been completed"] |
+
+

--- a/docs/events/event_36025.md
+++ b/docs/events/event_36025.md
@@ -1,0 +1,44 @@
+---
+title: "Log Backup Job for Application Backup Policy Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36025.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Log Backup Job for Application Backup Policy Started
+
+
+Sent when a user starts a log backup job session for the application backup policy. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36025
+
+Event message details: Application Log Backup job <JobName> has been started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="1c601bf1-dad4-4df8-b61a-cc788ae1a184" |
+| JobID | Job ID. | JobID="0c173857-3d6f-44b0-8111-79b132d3203c" |
+| JobType | Job type. | JobType="12101" |
+| Platform | Platform type. | Platform="8" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application Log Backup job 'RMAN Policy Logs Backup 1' has been started." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T13:22:10.989490+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36025 JobSessionID="1c601bf1-dad4-4df8-b61a-cc788ae1a184" JobID="0c173857-3d6f-44b0-8111-79b132d3203c" JobType="12101" Platform="8" Flags="0" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application Log Backup job 'RMAN Policy Logs Backup 1' has been started."] |
+
+

--- a/docs/events/event_36026.md
+++ b/docs/events/event_36026.md
@@ -1,0 +1,46 @@
+---
+title: "Log Backup Job for Application Backup Policy Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36026.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Log Backup Job for Application Backup Policy Finished
+
+
+Sent when a log backup job session for the application backup policy is finished. For more information, see [Working with Application Policies](https://helpcenter.veeam.com/docs/backup/plugins/application_policies.html).
+
+General Information
+
+Event ID: 36026
+
+Event message details: Application Log Backup job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="7af23aa7-63ff-4dd3-a3f1-e93ccc4e7ebe" |
+| JobID | Job ID. | JobID="48a10967-3051-4088-870a-84f5cb92ad4d" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="2" |
+| JobType | Job type. | JobType="12101" |
+| Platform | Platform type. | Platform="8" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Sap Hana Policy Log Backup 1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Application Log Backup job 'Sap Hana Policy Log Backup 1' finished with Failed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T14:24:53.493499+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36026 JobSessionID="7af23aa7-63ff-4dd3-a3f1-e93ccc4e7ebe" JobID="48a10967-3051-4088-870a-84f5cb92ad4d" JobResult="2" JobType="12101" Platform="8" WillBeRetried="False" JobName="Sap Hana Policy Log Backup 1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Application Log Backup job 'Sap Hana Policy Log Backup 1' finished with Failed."] |
+
+

--- a/docs/events/event_361.md
+++ b/docs/events/event_361.md
@@ -1,0 +1,50 @@
+---
+title: "Validation Task for Hyper-V VM Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_361.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Validation Task for Hyper-V VM Finished
+
+
+Sent when a validation task for a Hyper-V VM is finished. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 361
+
+Event message details: VM <VmName> validation task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="da83c52f-a52b-41f6-a524-39d3d743e7b6" |
+| JobID | Job ID. | JobID="cc7a04c3-2215-4be0-a96c-f0c059ddffe3" |
+| JobType | Job type. | JobType="3" |
+| TaskSessionID | Task session ID. | TaskSessionID="f1e40437-5e16-4baf-9621-da980df22d9e" |
+| TaskSessionType | Task session type. | TaskSessionType="1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| OibID | Machine ID. | OibID="3f36cedd-42e8-4362-87d1-5670b754673a" |
+| IsSureReplica | Defines whether the task is SureReplica. | IsSureReplica="False" |
+| HostName | Host name. | HostName="hvsrv01.tech.local" |
+| VmLocation | Machine location. | VmLocation="C:\ClusterStorage\Volume1\VMs\VM01" |
+| VmName | Machine name. | VmName="VM01" |
+| VmID | Machine ID. | VmID="2c508117-f5aa-44dc-889f-6476b406f777" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM [VM01] validation task has finished with [Success] state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T03:39:04.043853-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=361 JobSessionID="da83c52f-a52b-41f6-a524-39d3d743e7b6" JobID="cc7a04c3-2215-4be0-a96c-f0c059ddffe3" JobType="3" TaskSessionID="f1e40437-5e16-4baf-9621-da980df22d9e" TaskSessionType="1" Result="1" OibID="3f36cedd-42e8-4362-87d1-5670b754673a" IsSureReplica="False" HostName="hvsrv01.tech.local" VmLocation="C:\ClusterStorage\Volume1\VMs\VM01" VmName="VM01" VmID="2c508117-f5aa-44dc-889f-6476b406f777" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM [VM01] validation task has finished with [Success] state."] |
+
+

--- a/docs/events/event_36100.md
+++ b/docs/events/event_36100.md
@@ -1,0 +1,23 @@
+---
+title: "Generic Event for External Infrastructure Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36100.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Generic Event for External Infrastructure Created
+
+
+Sent when a generic event for an external infrastructure is created.
+
+General Information
+
+Event ID: 36100
+
+Event message details: Generic event for external infrastructure service was created
+
+Severity: Info
+
+

--- a/docs/events/event_36200.md
+++ b/docs/events/event_36200.md
@@ -1,0 +1,23 @@
+---
+title: "Connection with Managed Proxy Established"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36200.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection with Managed Proxy Established
+
+
+Sent when a connection between a managed proxy and an external infrastructure is established.
+
+General Information
+
+Event ID: 36200
+
+Event message details: Connection from managed proxy <ProxyID> to infrastructure <InfrastructureID> has been established
+
+Severity: Info
+
+

--- a/docs/events/event_36300.md
+++ b/docs/events/event_36300.md
@@ -1,0 +1,23 @@
+---
+title: "Connection with Managed Proxy Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36300.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection with Managed Proxy Lost
+
+
+Sent when a connection between a managed proxy and an external infrastructure is lost.
+
+General Information
+
+Event ID: 36300
+
+Event message details: Connection from managed proxy <ProxyID> to infrastructure <InfrastructureID> has been lost
+
+Severity: Warning
+
+

--- a/docs/events/event_36400.md
+++ b/docs/events/event_36400.md
@@ -1,0 +1,40 @@
+---
+title: "Connection with Platform Service Established"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection with Platform Service Established
+
+
+Sent when a connection between the Platform Service and an external infrastructure is established.
+
+General Information
+
+Event ID: 36400
+
+Event message details: Connection from platform service to infrastructure <InfrastructureID> has been established
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InfrastructureID | External infrastructure ID. | InfrastructureID="00060777-c811-9ac3-040b-ac1f6b3b984e" |
+| CreationTimeUTC | Connection creation time. | CreationTimeUTC="03/20/2025 09:41:34" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Connection from platform service to infrastructure 00060777-c811-9ac3-040b-ac1f6b3b984e has been established" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T10:41:34.053209+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36400 InfrastructureID="00060777-c811-9ac3-040b-ac1f6b3b984e" CreationTimeUTC="03/20/2025 09:41:34" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Connection from platform service to infrastructure 00060777-c811-9ac3-040b-ac1f6b3b984e has been established"] |
+
+

--- a/docs/events/event_36500.md
+++ b/docs/events/event_36500.md
@@ -1,0 +1,40 @@
+---
+title: "Connection with Platform Service Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection with Platform Service Lost
+
+
+Sent when a connection between the Platform Service and an external infrastructure is lost.
+
+General Information
+
+Event ID: 36500
+
+Event message details: Connection from platform service to infrastructure <InfrastructureID> has been lost
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InfrastructureID | External infrastructure ID. | InfrastructureID="00060777-c811-9ac3-040b-ac1f6b3b984e" |
+| CreationTimeUTC | Connection creation time. | CreationTimeUTC="03/20/2025 09:41:34" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Connection from platform service to infrastructure 00060777-c811-9ac3-040b-ac1f6b3b984e has been lost" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T10:41:34.053209+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36400 InfrastructureID="00060777-c811-9ac3-040b-ac1f6b3b984e" CreationTimeUTC="03/20/2025 09:41:34" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Connection from platform service to infrastructure 00060777-c811-9ac3-040b-ac1f6b3b984e has been lost"] |
+
+

--- a/docs/events/event_36600.md
+++ b/docs/events/event_36600.md
@@ -1,0 +1,23 @@
+---
+title: "Connection from Platform Service to Managed Proxy Established"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36600.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection from Platform Service to Managed Proxy Established
+
+
+Sent when a connection between the Platform Service and a managed proxy is established.
+
+General Information
+
+Event ID: 36600
+
+Event message details: Connection from platform service to managed proxy <ProxyID> has been established
+
+Severity: Info
+
+

--- a/docs/events/event_36700.md
+++ b/docs/events/event_36700.md
@@ -1,0 +1,23 @@
+---
+title: "Connection from Platform Service to Managed Proxy Lost"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36700.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Connection from Platform Service to Managed Proxy Lost
+
+
+Sent when a connection between the Platform Service and a managed proxy is lost.
+
+General Information
+
+Event ID: 36700
+
+Event message details: Connection from platform service to managed proxy <ProxyID> has been lost
+
+Severity: Warning
+
+

--- a/docs/events/event_36800.md
+++ b/docs/events/event_36800.md
@@ -1,0 +1,23 @@
+---
+title: "Data Synchronization Interrupted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36800.html"
+last_updated: "12/1/2025"
+product_version: "13.0.1.1071"
+---
+
+# Data Synchronization Interrupted
+
+
+Sent when data synchronization between the Platform Service and a managed proxy is interrupted.
+
+General Information
+
+Event ID: 36800
+
+Event message details: Data synchronization between platform service and managed proxy <ProxyID> interrupted
+
+Severity: Warning
+
+

--- a/docs/events/event_36900.md
+++ b/docs/events/event_36900.md
@@ -1,0 +1,40 @@
+---
+title: "Data Synchronization Resumed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_36900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Data Synchronization Resumed
+
+
+Sent when data synchronization between the Platform Service and a managed proxy is resumed.
+
+General Information
+
+Event ID: 36900
+
+Event message details: Data synchronization between platform service and managed proxy <ProxyID> continued
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ProxyID | Managed proxy ID. | ProxyID="865e1e7a-d436-4d13-ae51-f9bb1cee6190" |
+| CreationTimeUTC | Connection creation time. | CreationTimeUTC="03/20/2025 09:41:19" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Data synchronization between platform service and managed proxy 865e1e7a-d436-4d13-ae51-f9bb1cee6190 continued" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T10:41:19.318790+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=36900 ProxyID="865e1e7a-d436-4d13-ae51-f9bb1cee6190" CreationTimeUTC="03/20/2025 09:41:19" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Data synchronization between platform service and managed proxy 865e1e7a-d436-4d13-ae51-f9bb1cee6190 continued"] |
+
+

--- a/docs/events/event_390.md
+++ b/docs/events/event_390.md
@@ -1,0 +1,46 @@
+---
+title: "SureBackup Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_390.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup Job Finished
+
+
+Sent when a SureBackup job session is finished. For more information, see [SureBackup Job](https://helpcenter.veeam.com/docs/backup/vsphere/surebackup_job.html).
+
+General Information
+
+Event ID: 390
+
+Event message details: SureBackup job <JobName> finished with <State>. <Details>
+
+Severity: Info, Waring, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="5d899b75-448e-4a1a-a0b7-851f06e818fd" |
+| JobID | Job ID. | JobID="edc5270e-9cc4-4700-aff2-eff08302315c" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="2" |
+| JobType | Job type. | JobType="3" |
+| Platform | Platform type. | Platform="1" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="SureBackup Job 1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SureBackup job 'SureBackup Job 1' finished with Failed. Job details: Failed to connect to proxy appliance VM using IPv4 address." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T13:35:32.709942+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=390 JobSessionID="5d899b75-448e-4a1a-a0b7-851f06e818fd" JobID="edc5270e-9cc4-4700-aff2-eff08302315c" JobResult="2" JobType="3" Platform="1" WillBeRetried="False" JobName="SureBackup Job 1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="SureBackup job 'SureBackup Job 1' finished with Failed. Job details: Failed to connect to proxy appliance VM using IPv4 address."] |
+
+

--- a/docs/events/event_40001.md
+++ b/docs/events/event_40001.md
@@ -1,0 +1,39 @@
+---
+title: "Configuration Database Connected"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40001.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Configuration Database Connected
+
+
+Sent when the Veeam Backup Service starts and connects to the configuration database. For more information, see [Veeam Backup & Replication Configuration Database](https://helpcenter.veeam.com/docs/backup/vsphere/backup_database.html).
+
+General Information
+
+Event ID: 40001
+
+Event message details: Veeam Backup & Replication service is connected to configuration database: <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InstallationId | Installation ID of the configuration database. | InstallationId="0a9cb275-1d74-449a-ba84-fc3c6e105a55 |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Veeam Backup and Replication service is connected to configuration database: Server name: localhost:5432 Database name: VeeamBackup Authentication: SQL server Installation ID: {0a9cb275-1d74-449a-ba84-fc3c6e105a55}" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:50:39.643266+00:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40001 InstallationId="0a9cb275-1d74-449a-ba84-fc3c6e105a55" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Veeam Backup and Replication service is connected to configuration database: Server name: localhost:5432 Database name: VeeamBackup Authentication: SQL server Installation ID: {0a9cb275-1d74-449a-ba84-fc3c6e105a55}"] |
+
+

--- a/docs/events/event_40002.md
+++ b/docs/events/event_40002.md
@@ -1,0 +1,42 @@
+---
+title: "Storage Management Session Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40002.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Management Session Finished
+
+
+Sent when a job session related to extent and data management of scale-out backup repositories is finished. For more information, see [Scale-Out Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/backup_repository_sobr.html).
+
+General Information
+
+Event ID: 40002
+
+Event message details: The storage management session for repository <RepositoryName> has finished: <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RepositoryName | Scale-out backup repository name. | RepositoryName="Scale-out Backup Repository 01" |
+| JobType | Job type. | JobType="5" |
+| Result | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| ArchivePolicy | Data transfer policy set for the archive tier. Possible values:   * 0 — Not set * 1 — Move policy * 2 — Copy policy | ArchivePolicy="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="The storage management session for repository Scale-out Backup Repository 01 has finished: Success Repository name: Scale-out Backup Repository 01 Job type: Offload Session result: Success Mode: CopyNewBackupFiles" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T12:20:36.450818+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40002 RepositoryName="Scale-out Backup Repository 01" ArchivePolicy="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="The storage management session for repository Scale-out Backup Repository 01 has finished: Success Repository name: Scale-out Backup Repository 01 Job type: Offload Session result: Success Mode: CopyNewBackupFiles"] |
+
+

--- a/docs/events/event_40100.md
+++ b/docs/events/event_40100.md
@@ -1,0 +1,39 @@
+---
+title: "Veeam Backup & Replication Console Launched"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40100.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Veeam Backup & Replication Console Launched
+
+
+Sent when a user opens the Veeam Backup & Replication console. For more information, see [Logging in to Veeam Backup & Replication](https://helpcenter.veeam.com/docs/backup/vsphere/logon_to_console.html).
+
+General Information
+
+Event ID: 40100
+
+Event message details: Veeam Backup & Replication console has been launched
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Veeam Backup & Replication console has been launched." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:26:55.924420+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40100 UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Veeam Backup & Replication console has been launched."] |
+
+

--- a/docs/events/event_40101.md
+++ b/docs/events/event_40101.md
@@ -1,0 +1,39 @@
+---
+title: "Veeam Backup & Replication Console Closed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40101.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Veeam Backup & Replication Console Closed
+
+
+Sent when a user closes the Veeam Backup & Replication console.
+
+General Information
+
+Event ID: 40101
+
+Event message details: Veeam Backup & Replication console has been closed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Veeam Backup & Replication console has been closed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:56:40.409611+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40101 UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Veeam Backup & Replication console has been closed."] |
+
+

--- a/docs/events/event_40200.md
+++ b/docs/events/event_40200.md
@@ -1,0 +1,39 @@
+---
+title: "Multi-Factor Authentication Enabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Multi-Factor Authentication Enabled
+
+
+Sent when a user enables multi-factor authentication for all users. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40200
+
+Event message details: Multi-factor authentication has been enabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Multi-factor authentication has been enabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:38:59.558880-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40200 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Multi-factor authentication has been enabled by TECH\user1."] |
+
+

--- a/docs/events/event_40201.md
+++ b/docs/events/event_40201.md
@@ -1,0 +1,39 @@
+---
+title: "Multi-Factor Authentication Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40201.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Multi-Factor Authentication Disabled
+
+
+Sent when a user disables multi-factor authentication for all users. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40201
+
+Event message details: Multi-factor authentication has been disabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Multi-factor authentication has been disabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:53:22.190063-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40201 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Multi-factor authentication has been disabled by TECH\user1."] |
+
+

--- a/docs/events/event_40202.md
+++ b/docs/events/event_40202.md
@@ -1,0 +1,39 @@
+---
+title: "Multi-Factor Authentication Token Revoked"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40202.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Multi-Factor Authentication Token Revoked
+
+
+Sent when a user revokes a multi-factor authentication token for another user. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40202
+
+Event message details: Multi-factor authentication token has been reset for <UserName> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Multi-factor authentication token has been reset for TECH\user2 by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-10T08:06:37.196702-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40202 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Multi-factor authentication token has been reset for TECH\user2 by TECH\user1."] |
+
+

--- a/docs/events/event_40203.md
+++ b/docs/events/event_40203.md
@@ -1,0 +1,39 @@
+---
+title: "Multi-Factor Authentication for User Enabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40203.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Multi-Factor Authentication for User Enabled
+
+
+Sent when a user enables multi-factor authentication for a specific user if it is not used as a service account anymore. For more information, see [DIsabling MFA for Service Accounts](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html#disabling-mfa-for-service-accounts).
+
+General Information
+
+Event ID: 40203
+
+Event message details: Multi-factor authentication has been enabled for <UserName> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Multi-factor authentication has been enabled for TECH\user2 by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-19T06:06:51.123756-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40203 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Multi-factor authentication has been enabled for TECH\user2 by TECH\user1."] |
+
+

--- a/docs/events/event_40204.md
+++ b/docs/events/event_40204.md
@@ -1,0 +1,39 @@
+---
+title: "Multi-Factor Authentication for User Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40204.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Multi-Factor Authentication for User Disabled
+
+
+Sent when a user disables multi-factor authentication for a specific user if it is used as a service account. For more information, see [DIsabling MFA for Service Accounts](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html#disabling-mfa-for-service-accounts).
+
+General Information
+
+Event ID: 40204
+
+Event message details: Multi-factor authentication has been disabled for <UserName> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Multi-factor authentication has been disabled for TECH\user2 by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:52:28.777565-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40204 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Multi-factor authentication has been disabled for TECH\user2 by TECH\user1."] |
+
+

--- a/docs/events/event_40205.md
+++ b/docs/events/event_40205.md
@@ -1,0 +1,41 @@
+---
+title: "Invalid Code for Multi-Factor Authentication Entered"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40205.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Invalid Code for Multi-Factor Authentication Entered
+
+
+Sent when a user enters an invalid multi-factor authentication confirmation code. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40205
+
+Event message details: Invalid MFA code has been entered for <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| Endpoint | Mobile device where the attempt was detected. | Endpoint="[::1]:52182" |
+| SID | User security identifier. | SID="S-1-5-21-670747961-1840839389-3357612639-1134" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Invalid MFA code has been entered for TECH\user1" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:42:34.783406-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40205 UserName="TECH\user1" Endpoint="[::1]:52182" SID="S-1-5-21-670747961-1840839389-3357612639-1134" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Invalid MFA code has been entered for TECH\user1"] |
+
+

--- a/docs/events/event_40206.md
+++ b/docs/events/event_40206.md
@@ -1,0 +1,41 @@
+---
+title: "Allowed Attempts for Multi-Factor Authentication Exceeded"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40206.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Allowed Attempts for Multi-Factor Authentication Exceeded
+
+
+Sent when a user exceeds the allowed number of attempts for multi-factor authentication. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40206
+
+Event message details: User <UserName> has been locked out by entering too many invalid MFA codes
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| Endpoint | Mobile device where the attempt was detected. | Endpoint="[::1]:52182" |
+| SID | User security identifier. | SID="S-1-5-21-670747961-1840839389-3357612639-1134" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="User TECH\user1 has been locked out by entering too many invalid MFA codes." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T20:50:33.367146+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40206 UserName="TECH\user1" Endpoint="[::1]:52785" SID="S-1-5-21-670747961-1840839389-3357612639-1134" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="User TECH\user1 has been locked out by entering too many invalid MFA codes."] |
+
+

--- a/docs/events/event_40207.md
+++ b/docs/events/event_40207.md
@@ -1,0 +1,41 @@
+---
+title: "Code for Multi-Factor Authentication Already Used"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40207.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Code for Multi-Factor Authentication Already Used
+
+
+Sent when a user enters a multi-factor authentication confirmation code that has already been validated. For more information, see [Multi-Factor Authentication](https://helpcenter.veeam.com/docs/backup/vsphere/mfa.html).
+
+General Information
+
+Event ID: 40207
+
+Event message details: An attempt to use already validated MFA code has been performed for <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| Endpoint | Mobile device where the attempt was detected. | Endpoint="[::1]:52182" |
+| SID | User security identifier. | SID="S-1-5-21-670747961-1840839389-3357612639-1134" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="An attempt to use already validated MFA code has been performed for TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-29T16:32:04.193345+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40207 UserName="TECH\user1" Endpoint="[::1]:52785" SID="S-1-5-21-670747961-1840839389-3357612639-1134" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="An attempt to use already validated MFA code has been performed for TECH\user1."] |
+
+

--- a/docs/events/event_40300.md
+++ b/docs/events/event_40300.md
@@ -1,0 +1,40 @@
+---
+title: "Logs Export Session Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Logs Export Session Finished
+
+
+Sent when a logs export session is finished. For more information, see [Exporting Logs](https://helpcenter.veeam.com/docs/backup/vsphere/exporting_logs.html).
+
+General Information
+
+Event ID: 40300
+
+Event message details: Support logs export has been completed. Result: <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| LogExportSpecXML | Session data in the XML format. | LogExportSpecXML="<LogsExportJobSpec><NeedToCompress>True</NeedToCompress><LogsFilter><SelectByInterval>True</SelectByInterval><Select4Jobs>False</Select4Jobs><Select4Hosts>True</Select4Hosts><Select4Objects>False</Select4Objects><Select4ViClusters>False</Select4ViClusters><Select4EpAgents>False</Select4EpAgents><Select4Tenants>False</Select4Tenants><Select4ScaleOutRepos>False</Select4ScaleOutRepos><CollectPostgreSqlLogs>False</CollectPostgreSqlLogs><JobIds /><HostIds><Id>6745a759-2205-4cd2-b172-8ec8f7e60ef8</Id></HostIds><ObjectIds /><ViClusterIds /><EpAgentIds /><TenantIds /><ScaleOutReposIds /><Interval><Min>03/30/2025 07:01:31</Min><Max>12/31/9999 23:59:59</Max></Interval></LogsFilter><OutputDir>C:\Temp\Logs</OutputDir></LogsExportJobSpec> |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. Includes the following result states: Success, Warning, Failed. | Description="Support logs export has been completed. Result: Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T07:02:03.572923+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40300 LogExportSpecXML="<LogsExportJobSpec><NeedToCompress>True</NeedToCompress><LogsFilter><SelectByInterval>True</SelectByInterval><Select4Jobs>False</Select4Jobs><Select4Hosts>True</Select4Hosts><Select4Objects>False</Select4Objects><Select4ViClusters>False</Select4ViClusters><Select4EpAgents>False</Select4EpAgents><Select4Tenants>False</Select4Tenants><Select4ScaleOutRepos>False</Select4ScaleOutRepos><CollectPostgreSqlLogs>False</CollectPostgreSqlLogs><JobIds /><HostIds><Id>6745a759-2205-4cd2-b172-8ec8f7e60ef8</Id></HostIds><ObjectIds /><ViClusterIds /><EpAgentIds /><TenantIds /><ScaleOutReposIds /><Interval><Min>03/30/2025 07:01:31</Min><Max>12/31/9999 23:59:59</Max></Interval></LogsFilter><OutputDir>C:\Temp\Logs</OutputDir></LogsExportJobSpec> UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Support logs export has been completed. Result: Success."] |
+
+

--- a/docs/events/event_40400.md
+++ b/docs/events/event_40400.md
@@ -1,0 +1,40 @@
+---
+title: "Global VM Exclusions Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global VM Exclusions Added
+
+
+Sent when a user adds new global VM exclusions. For more information, see [Configuring Global VM Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/global_exclusion.html).
+
+General Information
+
+Event ID: 40400
+
+Event message details: <N> objects have been added into the global exclusions list
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" /><object id="8d31e5b8-d9aa-4645-be84-91b81d7adff7" name="Virtual Machine 02" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="2 objects have been added into the global exclusions list." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T07:29:44.729398-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40400 ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" /><object id="8d31e5b8-d9aa-4645-be84-91b81d7adff7" name="Virtual Machine 02" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="2 objects have been added into the global exclusions list."] |
+
+

--- a/docs/events/event_40500.md
+++ b/docs/events/event_40500.md
@@ -1,0 +1,40 @@
+---
+title: "Global VM Exclusions Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global VM Exclusions Deleted
+
+
+Sent when a user deletes global VM exclusions. For more information, see [Configuring Global VM Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/global_exclusion.html).
+
+General Information
+
+Event ID: 40500
+
+Event message details: <N> objects have been removed from the global exclusions list
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" /><object id="8d31e5b8-d9aa-4645-be84-91b81d7adff7" name="Virtual Machine 02" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="2 objects have been removed from the global exclusions list." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T14:57:29.932152+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40500 ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" /><object id="8d31e5b8-d9aa-4645-be84-91b81d7adff7" name="Virtual Machine 02" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="2 objects have been removed from the global exclusions list."] |
+
+

--- a/docs/events/event_40600.md
+++ b/docs/events/event_40600.md
@@ -1,0 +1,40 @@
+---
+title: "Global VM Exclusions Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Global VM Exclusions Changed
+
+
+Sent when a user updates global VM exclusions. For more information, see [Configuring Global VM Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/global_exclusion.html).
+
+General Information
+
+Event ID: 40600
+
+Event message details: Global exclusions list has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" OldNote="" NewNote="Important VM" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Global exclusions list has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T14:55:55.588220+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40600 ChangesXML="<changes><object id="f9432f88-e3a7-4c42-a14f-032c360fe845" name="Virtual Machine 01" OldNote="" NewNote="Important VM" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Global exclusions list has been modified."] |
+
+

--- a/docs/events/event_40700.md
+++ b/docs/events/event_40700.md
@@ -1,0 +1,40 @@
+---
+title: "Configuration Backup Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Configuration Backup Job Finished
+
+
+Sent when a configuration backup job session is finished. For more information, see [Creating Configuration Backups](https://helpcenter.veeam.com/docs/backup/vsphere/export_vbr_config.html).
+
+General Information
+
+Event ID: 40700
+
+Event message details: Configuration backup has been completed. Result: <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ConfigurationBackupSpecXML | Session data in the XML format. | ConfigurationBackupSpecXML="<ConfigurationBackupJobSpec><RepositoryId>88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec</RepositoryId><RepositoryName>Default Backup Repository</RepositoryName><RetentionPolicy>15</RetentionPolicy><StorageEncryptionEnabled>True</StorageEncryptionEnabled><StorageCryptoKeyId>370aeb6f-9ba5-47d4-a074-b148bc6a2162</StorageCryptoKeyId></ConfigurationBackupJobSpec>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. Includes the following result states: Success, Warning, Failed. | Description="Configuration backup has been completed. Result: Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-03T10:00:37.272866+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40700 ConfigurationBackupSpecXML="<ConfigurationBackupJobSpec><RepositoryId>88788f9e-d8f5-4eb4-bc4f-9b3f5403bcec</RepositoryId><RepositoryName>Default Backup Repository</RepositoryName><RetentionPolicy>15</RetentionPolicy><StorageEncryptionEnabled>True</StorageEncryptionEnabled><StorageCryptoKeyId>370aeb6f-9ba5-47d4-a074-b148bc6a2162</StorageCryptoKeyId></ConfigurationBackupJobSpec>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Configuration backup has been completed. Result: Success."] |
+
+

--- a/docs/events/event_40800.md
+++ b/docs/events/event_40800.md
@@ -1,0 +1,39 @@
+---
+title: "Configuration Restore Session Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Configuration Restore Session Finished
+
+
+Sent when the configuration restore session is finished. For more information, see [Restoring Configuration Database](https://helpcenter.veeam.com/docs/backup/vsphere/vbr_config_restore.html).
+
+General Information
+
+Event ID: 40800
+
+Event message details: Configuration restore has been performed
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Configuration restore has been performed" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T12:00:57.605759+00:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40800 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Configuration restore has been performed"] |
+
+

--- a/docs/events/event_40900.md
+++ b/docs/events/event_40900.md
@@ -1,0 +1,39 @@
+---
+title: "Location Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40900.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Location Added
+
+
+Sent when a user adds new locations for infrastructure objects. For more information, see [Managing Locations](https://helpcenter.veeam.com/docs/backup/vsphere/locations.html).
+
+General Information
+
+Event ID: 40900
+
+Event message details: Location <LocationName> has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Location Germany has been added." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:47:04.679903+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40900 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Location Germany has been added."] |
+
+

--- a/docs/events/event_40901.md
+++ b/docs/events/event_40901.md
@@ -1,0 +1,40 @@
+---
+title: "Location Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40901.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Location Settings Updated
+
+
+Sent when a user updates location settings. For more information, see [Managing Locations](https://helpcenter.veeam.com/docs/backup/vsphere/locations.html).
+
+General Information
+
+Event ID: 40901
+
+Event message details: Location <LocationName> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object oldLocationName="Germany" newLocationName="Germany 01" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Location Germany 01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:47:17.773291+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40901 ChangesXML="<changes><object oldLocationName="Germany" newLocationName="Germany 01" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Location Germany 01 has been modified."] |
+
+

--- a/docs/events/event_40902.md
+++ b/docs/events/event_40902.md
@@ -1,0 +1,39 @@
+---
+title: "Location Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40902.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Location Deleted
+
+
+Sent when a user deletes locations for infrastructure objects. For more information, see [Managing Locations](https://helpcenter.veeam.com/docs/backup/vsphere/locations.html).
+
+General Information
+
+Event ID: 40902
+
+Event message details: Location <LocationName> has been removed
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Location Germany 01 has been removed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:47:32.632213+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40902 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Location Germany 01 has been removed."] |
+
+

--- a/docs/events/event_40903.md
+++ b/docs/events/event_40903.md
@@ -1,0 +1,40 @@
+---
+title: "Object Location Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_40903.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Location Changed
+
+
+Sent when a user assigns another location to the infrastructure object. For more information, see [Creating and Assigning Locations to Infrastructure Objects](https://helpcenter.veeam.com/docs/backup/vsphere/locations_create.html).
+
+General Information
+
+Event ID: 40903
+
+Event message details: Object location has been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object oldLocationName="Germany 01" newLocationName="Germany 01" objectName="Single Storage Repository" /></changes>" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object location has been changed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:47:17.867030+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=40903 ChangesXML="<changes><object oldLocationName="Germany 01" newLocationName="Germany 01" objectName="Single Storage Repository" /></changes>" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object location has been changed."] |
+
+

--- a/docs/events/event_410.md
+++ b/docs/events/event_410.md
@@ -1,0 +1,44 @@
+---
+title: "Backup Copy Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_410.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Copy Job Started
+
+
+Sent when a user starts a backup copy job session. For more information, see [Backup Copy](https://helpcenter.veeam.com/docs/backup/vsphere/backup_copy.html).
+
+General Information
+
+Event ID: 410
+
+Event message details: Backup Copy job <JobName> has been started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="11ce771c-54f1-444a-ae1a-ee76c96eabe9" |
+| JobID | Job ID. | JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" |
+| JobType | Job type. | JobType="13003" |
+| Platform | Platform type. | Platform="11" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup Copy job 'Fileshare SMB backup (Copy) 1' has been started." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:11:25.904092+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=410 JobSessionID="11ce771c-54f1-444a-ae1a-ee76c96eabe9" JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" JobType="13003" Platform="11" Flags="0" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup Copy job 'Fileshare SMB backup (Copy) 1' has been started."] |
+
+

--- a/docs/events/event_41000.md
+++ b/docs/events/event_41000.md
@@ -1,0 +1,40 @@
+---
+title: "Downloading Backup Metadata Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Downloading Backup Metadata Started
+
+
+Sent when a user starts downloading metadata for the unstructured data backup. For more information, see [Restoring Backup Files from Archive Repository](https://helpcenter.veeam.com/docs/backup/vsphere/restore_files_from_archive.html).
+
+General Information
+
+Event ID: 41000
+
+Event message details: NAS backup metadata download has been started for backup <JobName> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Session ID. | SessionID="6b06890f-0164-48aa-acf5-e6cc9360160a" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="NAS backup metadata download has been started for backup File Backup Job 1 by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:49:38.735755+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41000 SessionID="6b06890f-0164-48aa-acf5-e6cc9360160a" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="NAS backup metadata download has been started for backup File Backup Job 1 by TECH\user1."] |
+
+

--- a/docs/events/event_41001.md
+++ b/docs/events/event_41001.md
@@ -1,0 +1,41 @@
+---
+title: "Downloading Backup Metadata Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41001.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Downloading Backup Metadata Finished
+
+
+Sent when downloading metadata for the unstructured data backup is finished. For more information, see [Restoring Backup Files from Archive Repository](https://helpcenter.veeam.com/docs/backup/vsphere/restore_files_from_archive.html).
+
+General Information
+
+Event ID: 41001
+
+Event message details: NAS backup metadata download for backup <JobName> has been finished. Result: <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Session ID. | SessionID="6b06890f-0164-48aa-acf5-e6cc9360160a" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="NAS backup metadata download for backup File Backup Job 1 has been finished. Result: Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:50:02.522600+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41001 SessionID="6b06890f-0164-48aa-acf5-e6cc9360160a" UserName="TECH\user1" Result="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="NAS backup metadata download for backup File Backup Job 1 has been finished. Result: Success."] |
+
+

--- a/docs/events/event_41200.md
+++ b/docs/events/event_41200.md
@@ -1,0 +1,39 @@
+---
+title: "Detaching Backups Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Detaching Backups Started
+
+
+Sent when a user detaches a backup file from a backup job. For more information, see [Detaching Backups from Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/detach_backup.html).
+
+General Information
+
+Event ID: 41200
+
+Event message details: Detach backup from job <JobName> has been initiated by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Detach backup from job VM Templates Backup has been initiated by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:54:05.381391+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41200 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Detach backup from job VM Templates Backup has been initiated by TECH\user1."] |
+
+

--- a/docs/events/event_41201.md
+++ b/docs/events/event_41201.md
@@ -1,0 +1,39 @@
+---
+title: "Copying Backups Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41201.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Copying Backups Started
+
+
+Sent when a user copies backups to another location. For more information, see [Copying Backups](https://helpcenter.veeam.com/docs/backup/vsphere/copy_backup.html).
+
+General Information
+
+Event ID: 41201
+
+Event message details: Copy backups from <SourceName> to <TargetName> has been initiated by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Copy backups from VMware Servers to Scale-Out Repository 01 has been initiated by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:54:19.521849+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41201 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Copy backups from VMware Servers to Scale-Out Repository 01 has been initiated by TECH\user1."] |
+
+

--- a/docs/events/event_41202.md
+++ b/docs/events/event_41202.md
@@ -1,0 +1,39 @@
+---
+title: "Moving Backups Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41202.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Moving Backups Started
+
+
+Sent when a user moves backups to another location. For more information, see [Moving Backups](https://helpcenter.veeam.com/docs/backup/vsphere/move_backup.html).
+
+General Information
+
+Event ID: 41202
+
+Event message details: Move backups from <SourceName> to <TargetName> has been initiated by <User>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Move backups from Single Storage backup (Days) to Scale-Out Repository 01 has been initiated by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T10:54:30.919991+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41202 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Move backups from Single Storage backup (Days) to Scale-Out Repository 01 has been initiated by TECH\user1."] |
+
+

--- a/docs/events/event_41300.md
+++ b/docs/events/event_41300.md
@@ -1,0 +1,39 @@
+---
+title: "License Report Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Report Created
+
+
+Sent when a user creates a license report.
+
+General Information
+
+Event ID: 41300
+
+Event message details: Product license consumption report was created by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Product license consumption report was created by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-19T06:44:45.770789-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41300 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Product license consumption report was created by TECH\user1."] |
+
+

--- a/docs/events/event_41301.md
+++ b/docs/events/event_41301.md
@@ -1,0 +1,39 @@
+---
+title: "Automatic License Update Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41301.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Automatic License Update Disabled
+
+
+Sent when a user disables automatic license update. For more information, see [Updating License Automatically](https://helpcenter.veeam.com/docs/backup/vsphere/license_autoupdate.html).
+
+General Information
+
+Event ID: 41301
+
+Event message details: Update license automatically was disabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Update license automatically was disabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T10:22:07.602968-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41301 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Update license automatically was disabled by TECH\user1."] |
+
+

--- a/docs/events/event_41302.md
+++ b/docs/events/event_41302.md
@@ -1,0 +1,39 @@
+---
+title: "License Consumption for Veeam Agents Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41302.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# License Consumption for Veeam Agents Disabled
+
+
+Sent when a user disables instance license consumption by Veeam Agents. For more information, see [Managing Instance Consumption by Veeam Agents](https://helpcenter.veeam.com/docs/backup/agents/licensing_requirements.html#managing-instance-consumption-by-veeam-agents).
+
+General Information
+
+Event ID: 41302
+
+Event message details: Allow unlicensed agent to consume instances was disabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Allow unlicensed agent to consume instances was disabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:29:05.225400+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41302 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Allow unlicensed agent to consume instances was disabled by TECH\user1."] |
+
+

--- a/docs/events/event_41303.md
+++ b/docs/events/event_41303.md
@@ -1,0 +1,39 @@
+---
+title: "Object License Revoked"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41303.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object License Revoked
+
+
+Sent when a user revokes a license from Veeam Agent. For more information, see the [Viewing Licensed Veeam Agents and Revoking License](https://helpcenter.veeam.com/docs/agentforwindows/userguide/license_vbr_revoke.html) section in the Veeam Agent for Microsoft Windows User Guide.
+
+General Information
+
+Event ID: 41303
+
+Event message details: License revocation was initiated for objects <Name> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="License revocation was initiated for objects vm1.tech.local by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:28:44.219836+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41303 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="License revocation was initiated for objects vm1.tech.local by TECH\user1."] |
+
+

--- a/docs/events/event_41304.md
+++ b/docs/events/event_41304.md
@@ -1,0 +1,39 @@
+---
+title: "Object License Removed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41304.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object License Removed
+
+
+Sent when a user removes a license from Veeam Agent. For more information, see the [Viewing Licensed Veeam Agents and Revoking License](https://helpcenter.veeam.com/docs/agentforwindows/userguide/license_vbr_revoke.html) section in the Veeam Agent for Microsoft Windows User Guide.
+
+General Information
+
+Event ID: 41304
+
+Event message details: License removal was initiated for objects <Name> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="License removal was initiated for objects vm1.tech.local by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:34:51.349102+01:00 EY-12-1-0-2068 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41304 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="License removal was initiated for objects vm1.tech.local by TECH\user1."] |
+
+

--- a/docs/events/event_41305.md
+++ b/docs/events/event_41305.md
@@ -1,0 +1,39 @@
+---
+title: "Object License Assigned"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41305.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object License Assigned
+
+
+Sent when a user assigns a license to Veeam Agent. For more information, see the [Assigning License to Veeam Agent](https://helpcenter.veeam.com/docs/agentforwindows/userguide/license_vbr_mode.html) section in the Veeam Agent for Microsoft Windows User Guide.
+
+General Information
+
+Event ID: 41305
+
+Event message details: Workstation license was assigned to objects <Name> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Workstation license was assigned to objects vm1.tech.local by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:32:14.687348+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41305 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Workstation license was assigned to objects vm1.tech.local by TECH\user1."] |
+
+

--- a/docs/events/event_41306.md
+++ b/docs/events/event_41306.md
@@ -1,0 +1,39 @@
+---
+title: "Proactive Support Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41306.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Proactive Support Disabled
+
+
+Sent when a user disables proactive technical support services and diagnostic data sharing. For more information, see [Viewing License Information](license_view.md).
+
+General Information
+
+Event ID: 41306
+
+Event message details: Proactive support was disabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Proactive support was disabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T11:15:09.345068-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41306 UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Proactive support was disabled by TECH\user1."] |
+
+

--- a/docs/events/event_41400.md
+++ b/docs/events/event_41400.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Added
+
+
+Sent when a user adds a storage appliance to the backup infrastructure. For more information, see [Deduplicating Storage Appliances](https://helpcenter.veeam.com/docs/backup/vsphere/deduplicating_storage_appliances.html).
+
+General Information
+
+Event ID: 41400
+
+Event message details: Storage <Name> has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:16:13.203210+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41400 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 has been created."] |
+
+

--- a/docs/events/event_41401.md
+++ b/docs/events/event_41401.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41401.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Settings Updated
+
+
+Sent when a user updates storage appliance settings. For more information, see [Deduplicating Storage Appliances](https://helpcenter.veeam.com/docs/backup/vsphere/deduplicating_storage_appliances.html).
+
+General Information
+
+Event ID: 41401
+
+Event message details: Storage <Name> has been modified
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787"><property internal="ConnectionPoint" type="String"><old>pdc01.tech.local</old><new>pdc01</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 has been modified." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:16:55.358667+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41401 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787"><property internal="ConnectionPoint" type="String"><old>pdc01.tech.local</old><new>pdc01</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 has been modified."] |
+
+

--- a/docs/events/event_41402.md
+++ b/docs/events/event_41402.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41402.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Deleted
+
+
+Sent when a user deletes a storage appliance from the backup infrastructure. For more information, see [Deduplicating Storage Appliances](https://helpcenter.veeam.com/docs/backup/vsphere/deduplicating_storage_appliances.html).
+
+General Information
+
+Event ID: 41402
+
+Event message details: Storage <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T12:17:19.624111+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41402 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 has been deleted."] |
+
+

--- a/docs/events/event_41403.md
+++ b/docs/events/event_41403.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Rescan Started Manually"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41403.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Rescan Started Manually
+
+
+Sent when a user starts the storage system rescan manually. For more information, see [Rescan (Storage Discovery) Process](storage_discovery_process.md).
+
+General Information
+
+Event ID: 41403
+
+Event message details: Storage <Name> rescan has been started by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 rescan has been started by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-17T13:09:22.942014+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41403 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 rescan has been started by TECH\user1." |
+
+

--- a/docs/events/event_41404.md
+++ b/docs/events/event_41404.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Rescan Started Automatically"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41404.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Rescan Started Automatically
+
+
+Sent when the storage system rescan starts automatically. For more information, see [Rescan (Storage Discovery) Process](storage_discovery_process.md).
+
+General Information
+
+Event ID: 41404
+
+Event message details: Storage <Name> rescan has been started automatically
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 rescan has been started automatically." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-18T18:13:07.021856+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41404 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 rescan has been started automatically." |
+
+

--- a/docs/events/event_41405.md
+++ b/docs/events/event_41405.md
@@ -1,0 +1,43 @@
+---
+title: "Storage Rescan Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41405.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Storage Rescan Finished
+
+
+Sent when a storage system rescan session is finished. For more information, see [Rescan (Storage Discovery) Process](storage_discovery_process.md).
+
+General Information
+
+Event ID: 41405
+
+Event message details: Storage <Name> rescan has been finished
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| StorageID | Storage appliance ID. | StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" |
+| Type | Storage type. | Type="11" |
+| Name | Storage appliance name. | Name="Nimble Storage 01" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Storage Nimble Storage 01 rescan has been finished." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-18T11:03:25.913720+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41405 StorageID="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" Type="11" Name="Nimble Storage 01" ChangesXML="<changes><object id="47d0dbef-c7d2-4f0e-990d-6e548ca6a787" name="Nimble Storage 01" /></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Storage Nimble Storage 01 rescan has been finished." |
+
+

--- a/docs/events/event_41500.md
+++ b/docs/events/event_41500.md
@@ -1,0 +1,45 @@
+---
+title: "Restore Point Mounted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Mounted
+
+
+Sent when a restore point is mounted to the mount server during a restore session. For more information, see [Data Recovery](https://helpcenter.veeam.com/docs/backup/vsphere/data_recovery.html).
+
+General Information
+
+Event ID: 41500
+
+Event message details: Backup has been mounted. MountID: <MountID>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| MountID | Mount point ID. | MountID="350dd3d8-5aca-4126-9bf1-ce5ff3c89021" |
+| RestorePointID | Restore point ID. | RestorePointID="365c401e-a955-44ff-942c-9796e0974ae7" |
+| Reason | Reason to perform the operation. | Reason="FLR\_VMSRV01" |
+| ObjectName | Object name. | ObjectName="VMware Server 01" |
+| RestorePointTIme | Date and time when a restore point has been created. | RestorePointTIme="03/24/2025 08:59:48" |
+| MountServer | Mount server name. | MountServer="VBRSRV01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup has been mounted. MountID: 350dd3d8-5aca-4126-9bf1-ce5ff3c89021." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:37:28.156718+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41500 UserName="TECH\user1" MountID="350dd3d8-5aca-4126-9bf1-ce5ff3c89021" RestorePointID="365c401e-a955-44ff-942c-9796e0974ae7" Reason="FLR\_VMSRV01" ObjectName="VMware Server 01" RestorePointTIme="03/24/2025 08:59:48" MountServer="VBRSRV01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup has been mounted. MountID: 350dd3d8-5aca-4126-9bf1-ce5ff3c89021."] |
+
+

--- a/docs/events/event_41510.md
+++ b/docs/events/event_41510.md
@@ -1,0 +1,39 @@
+---
+title: "Restore Point Unmounted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41510.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Unmounted
+
+
+Sent when a restore point is unmounted to the mount server during a restore session. For more information, see [Data Recovery](https://helpcenter.veeam.com/docs/backup/vsphere/data_recovery.html).
+
+General Information
+
+Event ID: 41510
+
+Event message details: Backup has been unmounted. MountID: <MountID>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| MountID | Mount point ID. | MountID="350dd3d8-5aca-4126-9bf1-ce5ff3c89021" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup has been unmounted. MountID: 350dd3d8-5aca-4126-9bf1-ce5ff3c89021." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T11:38:13.055666+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41510 MountID="350dd3d85aca41269bf1ce5ff3c89021" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup has been unmounted. MountID: 350dd3d8-5aca-4126-9bf1-ce5ff3c89021."] |
+
+

--- a/docs/events/event_41600.md
+++ b/docs/events/event_41600.md
@@ -1,0 +1,45 @@
+---
+title: "Malware Activity Detected"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Activity Detected
+
+
+Sent when malware activity is detected. For more information, see [Malware Detection](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection.html).
+
+General Information
+
+Event ID: 41600
+
+Event message details: Potential malware activity detected: <Details>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| DetectionTimeUTC | Date and time when malware activity has been detected. | DetectionTimeUTC="03/20/2025 13:05:41" |
+| OibID | Machine ID. | OibID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" |
+| ActivityType | Malware activity type. Possible values:   * DeletedUsefulFiles — Deleted files * SuspiciousFilesInDelta — Indicators of compromise * RansomwareNotes — Ransom notes and onion links * RansomwareExtensions — Known suspicious files and extensions * EncryptedData — Encrypted files * YaraScan — Malware activity specified in the YARA rule * AntivirusScan — Malware activity specified in the antivirus configuration file * RenamedFiles — Renamed files | ActivityType="EncryptedData" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| ObjectName | Object name. | ObjectName="VM01" |
+| CreationTimeUTC | Date and time when a malware detection event has been created. | CreationTimeUTC="03/20/2025 13:10:02" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Potential malware activity detected for OIB: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 (VM01), rule: Encrypted data by user: TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:06:09.662307+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41600 DetectionTimeUTC="03/20/2025 13:05:41" OibID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" ActivityType="EncryptedData" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" ObjectName="VM01" CreationTimeUTC="03/20/2025 13:10:02" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Potential malware activity detected for OIB: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 (VM01), rule: Encrypted data by user: TECH\user1."] |
+
+

--- a/docs/events/event_41610.md
+++ b/docs/events/event_41610.md
@@ -1,0 +1,44 @@
+---
+title: "Object Marked as Clean"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41610.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Marked as Clean
+
+
+Sent when a user marks a machine as clean. For more information, see [Managing Malware Status](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_managing_status.html).
+
+General Information
+
+Event ID: 41610
+
+Event message details: Malware detection event has been resolved: <Details>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| DetectionTimeUTC | Date and time when malware activity has been detected. | DetectionTimeUTC="03/20/2025 15:00:07" |
+| ObjectID | Machine ID. | ObjectID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" |
+| FalsePositive | Defines whether a malware detection event is false positive. | FalsePositive="True" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| ObjectName | Object name. | ObjectName="VM01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Malware detection event has been resolved: Mark as clean: False positive for object: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 by user: TECH\user1. False positive: True." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:00:07.183022+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41610 DetectionTimeUTC="03/20/2025 15:00:07" ObjectID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" FalsePositive="True" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" ObjectName="VM01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Malware detection event has been resolved: Mark as clean: False positive for object: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 by user: TECH\user1. False positive: True."] |
+
+

--- a/docs/events/event_41615.md
+++ b/docs/events/event_41615.md
@@ -1,0 +1,43 @@
+---
+title: "Object Automatically Marked as Clean"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41615.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Object Automatically Marked as Clean
+
+
+Sent when a machine is automatically marked as clean if no malware activities were found during the proactive signature-based scan session. For more information, see [Signature Detection](malware_detection_signature_detection.md).
+
+General Information
+
+Event ID: 41615
+
+Event message details: Proactive malware scan has found no threats for object: <ObjectID> <ObjectName> by user: <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ScanTimeUTC | Date and time when the scan session has started. | ScanTimeUTC="11/20/2025 14:00:06" |
+| ObjectID | Machine ID. | ObjectID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| ObjectName | Object name. | ObjectName="VM01" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Proactive malware scan has found no threats for object: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 (VM01) by user: TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T15:00:06.381205+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41615 ScanTimeUTC="11/20/2025 14:00:06" ObjectID="0e54d3bf-add8-48eb-9122-fad3ac1e8fb3" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" ObjectName="VM01" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Proactive malware scan has found no threats for object: 0e54d3bf-add8-48eb-9122-fad3ac1e8fb3 (VM01) by user: TECH\user1."] |
+
+

--- a/docs/events/event_41700.md
+++ b/docs/events/event_41700.md
@@ -1,0 +1,44 @@
+---
+title: "Health Check Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41700.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Health Check Job Started
+
+
+Sent when a new health check job session starts. For more information, see [Maintenance Settings](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job_advanced_maintenance_vm.html).
+
+General Information
+
+Event ID: 41700
+
+Event message details: Health check session <JobName> has been started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e73fc5d1-47bf-46e5-ac7a-ea7050b831a7" |
+| JobID | Job ID. | JobID="cb16e947-5198-2d40-9571-5d7c186cd411" |
+| JobType | Job type. | JobType="76" |
+| Platform | Platform type. | Platform="4" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Health check session backup\_weekly has been started." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:36:07.299849+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41700 JobSessionID="e73fc5d1-47bf-46e5-ac7a-ea7050b831a7" JobID="cb16e947-5198-2d40-9571-5d7c186cd411" JobType="76" Platform="4" Flags="0" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Health check session backup\_weekly has been started."] |
+
+

--- a/docs/events/event_41710.md
+++ b/docs/events/event_41710.md
@@ -1,0 +1,46 @@
+---
+title: "Health Check Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41710.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Health Check Job Finished
+
+
+Sent when a health check job session is finished. For more information, see [Maintenance Settings](https://helpcenter.veeam.com/docs/backup/vsphere/backup_job_advanced_maintenance_vm.html).
+
+General Information
+
+Event ID: 41710
+
+Event message details: Health check session <JobName> has been finished with <State> state. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="e73fc5d1-47bf-46e5-ac7a-ea7050b831a7" |
+| JobID | Job ID. | JobID="cb16e947-5198-2d40-9571-5d7c186cd411" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="2" |
+| JobType | Job type. | JobType="76" |
+| Platform | Platform type. | Platform="4" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="backup\_weekly" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Health check session backup\_weekly has been finished with 'Failed' state Job details: Failed to perform backup verification" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-30T12:36:20.613369+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41710 JobSessionID="e73fc5d1-47bf-46e5-ac7a-ea7050b831a7" JobID="cb16e947-5198-2d40-9571-5d7c186cd411" JobResult="2" JobType="76" Platform="4" WillBeRetried="False" JobName="backup\_weekly" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Health check session backup\_weekly has been finished with 'Failed' state Job details: Failed to perform backup verification"] |
+
+

--- a/docs/events/event_41800.md
+++ b/docs/events/event_41800.md
@@ -1,0 +1,41 @@
+---
+title: "Attempt to Delete Backup Failed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41800.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Attempt to Delete Backup Failed
+
+
+Sent when a user with insufficient privileges tries to delete a backup file.
+
+General Information
+
+Event ID: 41800
+
+Event message details: Failed attempt to delete backup from <Endpoint>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| EventType | Event type. | EventType="UnsuccessfulAttemptToDeleteBackup" |
+| Endpoint | Machine where the attempt was detected. | Endpoint="172.25.160.65:56164" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failed attempt to delete backup from "172.25.160.65:56164"." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T19:46:03.647831+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41800 EventType="UnsuccessfulAttemptToDeleteBackup" Endpoint="172.25.160.65:56164" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failed attempt to delete backup from "172.25.160.65:56164"."] |
+
+

--- a/docs/events/event_41810.md
+++ b/docs/events/event_41810.md
@@ -1,0 +1,41 @@
+---
+title: "Attempt To Update Security Object Failed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_41810.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Attempt To Update Security Object Failed
+
+
+Sent when a user with insufficient privileges tries to update a security object including users and roles, credential records, certificates, or passwords.
+
+General Information
+
+Event ID: 41810
+
+Event message details: Failed attempt to change security object from <Endpoint>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| EventType | Event type. | EventType="UnsuccessfulAttemptToModifySecurityObject" |
+| Endpoint | Machine where the attempt was detected. | Endpoint="172.25.160.65:56174" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Failed attempt to change security object from "172.25.160.65:56174"." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-31T19:46:32.672010+01:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=41810 EventType="UnsuccessfulAttemptToModifySecurityObject" Endpoint="172.25.160.65:56174" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Failed attempt to change security object from "172.25.160.65:56174"."] |
+
+

--- a/docs/events/event_42000.md
+++ b/docs/events/event_42000.md
@@ -1,0 +1,40 @@
+---
+title: "Downloading Object Storage Backup Metadata Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Downloading Object Storage Backup Metadata Started
+
+
+Sent when a user starts downloading metadata for the object storage backup. For more information, see [Restoring Objects from Archive Repository](https://helpcenter.veeam.com/docs/backup/vsphere/os_data_recovery_restore_files_from_archive.html).
+
+General Information
+
+Event ID: 42000
+
+Event message details: Object storage backup metadata download has been started for backup <JobName> by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Job session ID. | SessionID="ea27aeaf-4be3-4e82-a19d-46b72f6c9da4" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage backup metadata download has been started for backup Object Storage Backup Job 1 by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:42:54.113128+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42000 SessionID="ea27aeaf-4be3-4e82-a19d-46b72f6c9da4" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage backup metadata download has been started for backup Object Storage Backup Job 1 by TECH\user1."] |
+
+

--- a/docs/events/event_42001.md
+++ b/docs/events/event_42001.md
@@ -1,0 +1,41 @@
+---
+title: "Downloading Object Storage Backup Metadata Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42001.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Downloading Object Storage Backup Metadata Finished
+
+
+Sent when downloading metadata for the object storage backup is finished. For more information, see [Restoring Objects from Archive Repository](https://helpcenter.veeam.com/docs/backup/vsphere/os_data_recovery_restore_files_from_archive.html).
+
+General Information
+
+Event ID: 42001
+
+Event message details: Object storage backup metadata download for backup <JobName> has been finished. Result: <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Job session ID. | SessionID="ea27aeaf-4be3-4e82-a19d-46b72f6c9da4" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Object storage backup metadata download for backup Object Storage Backup Job 1 has been finished. Result: Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T15:43:22.930959+04:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42001 SessionID="ea27aeaf-4be3-4e82-a19d-46b72f6c9da4" UserName="TECH\user1" Result="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Object storage backup metadata download for backup Object Storage Backup Job 1 has been finished. Result: Success."] |
+
+

--- a/docs/events/event_42200.md
+++ b/docs/events/event_42200.md
@@ -1,0 +1,39 @@
+---
+title: "Malware Detection Session Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42200.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Detection Session Started
+
+
+Sent when a new malware detection session starts. For more information, see [How Malware Detection Works](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_how_it_works.html).
+
+General Information
+
+Event ID: 42200
+
+Event message details: Malware detection session has been started
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Session ID. | SessionID="0ea5f2b5-a9d4-4431-aa8a-3c7717cfdf5a" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Malware detection session has been started." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-03T00:00:00.692687+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42200 SessionID="0ea5f2b5-a9d4-4431-aa8a-3c7717cfdf5a" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Malware detection session has been started."] |
+
+

--- a/docs/events/event_42210.md
+++ b/docs/events/event_42210.md
@@ -1,0 +1,40 @@
+---
+title: "Malware Detection Session Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42210.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Detection Session Finished
+
+
+Sent when a malware detection session is finished. For more information, see [How Malware Detection Works](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_how_it_works.html).
+
+General Information
+
+Event ID: 42210
+
+Event message details: Malware detection session has finished with <State> | Malware detection session has failed: <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Session ID. | SessionID="0ea5f2b5-a9d4-4431-aa8a-3c7717cfdf5a" |
+| Result | Session result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. Includes the following result states: Success, Warning, Failed. | Description="Malware detection session has finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-03T00:00:00.755647+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42210 SessionID="0ea5f2b5-a9d4-4431-aa8a-3c7717cfdf5a" Result="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Malware detection session has finished with Success."] |
+
+

--- a/docs/events/event_42220.md
+++ b/docs/events/event_42220.md
@@ -1,0 +1,42 @@
+---
+title: "Restore Point Marked as Infected"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42220.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Marked as Infected
+
+
+Sent when a user marks a restore point as infected. For more information, see [Managing Malware Status](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_managing_status.html).
+
+General Information
+
+Event ID: 42220
+
+Event message details: Restore point has been marked as infected by <UserName>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| PointID | Restore point ID. | PointID="2eec1a91-7202-49a9-b60b-1436793c2502" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| ObjectName | Object name. | ObjectName="VM01" |
+| RestorePointTimeStamp | Date and time when a restore point has been created. | RestorePointTimeStamp="03/24/2025 07:00:53" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore point has been marked as infected by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:15:57.141518-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42220 PointID="2eec1a91-7202-49a9-b60b-1436793c2502" UserName="TECH\user1" ObjectName="VM01" RestorePointTimeStamp="03/24/2025 07:00:53" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore point has been marked as infected by TECH\user1."] |
+
+

--- a/docs/events/event_42230.md
+++ b/docs/events/event_42230.md
@@ -1,0 +1,42 @@
+---
+title: "Restore Point Marked as Clean"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42230.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Restore Point Marked as Clean
+
+
+Sent when a user marks a restore point as clean. For more information, see [Managing Malware Status](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_managing_status.html).
+
+General Information
+
+Event ID: 42230
+
+Event message details: Restore point has been marked as clean by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| PointID | Restore point ID. | PointID="2eec1a91-7202-49a9-b60b-1436793c2502" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| ObjectName | Object name. | ObjectName="VM01" |
+| RestorePointTimeStamp | Date and time when a restore point has been created. | RestorePointTimeStamp="01/08/2025 11:00:57" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Restore point has been marked as clean by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-10T06:19:48.314199-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42230 PointID="2eec1a91-7202-49a9-b60b-1436793c2502" UserName="TECH\user1" ObjectName="VM01" RestorePointTimeStamp="01/08/2025 11:00:57" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Restore point has been marked as clean by TECH\user1."] |
+
+

--- a/docs/events/event_42260.md
+++ b/docs/events/event_42260.md
@@ -1,0 +1,41 @@
+---
+title: "Objects Added to Malware Detection Exclusions"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42260.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects Added to Malware Detection Exclusions
+
+
+Sent when a user adds a machine to malware exclusions. For more information, see [Malware Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_exclusions.html).
+
+General Information
+
+Event ID: 42260
+
+Event message details: <N> objects have been added into the malware detection exclusions list. <AddedObjectNames>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| AddedObjectIDs | Machine IDs. | AddedObjectIDs="89f22910-8584-4a33-bce9-606bd271a225,e92f7699-8dbb-4ae8-b06a-44446a8c379b" |
+| AddedObjectNames | Machine names. | AddedObjectNames="Virtual Machine 01,Virtual Machine 02" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="2 objects have been added into the malware detection exclusions list. Virtual Machine 01 Virtual Machine 02" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T07:31:15.259982-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42260 AddedObjectIDs="89f22910-8584-4a33-bce9-606bd271a225,e92f7699-8dbb-4ae8-b06a-44446a8c379b" AddedObjectNames="Virtual Machine 01,Virtual Machine 02" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="2 objects have been added into the malware detection exclusions list. Virtual Machine 01 Virtual Machine 02"] |
+
+

--- a/docs/events/event_42270.md
+++ b/docs/events/event_42270.md
@@ -1,0 +1,41 @@
+---
+title: "Objects Deleted from Malware Detection Exclusions"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42270.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Objects Deleted from Malware Detection Exclusions
+
+
+Sent when a user deletes a machine from malware exclusions. For more information, see [Malware Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_exclusions.html).
+
+General Information
+
+Event ID: 42270
+
+Event message details: <N> objects have been removed from the malware detection exclusions list. <RemovedObjectNames>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| RemovedObjectIDs | Machine IDs. | RemovedObjectIDs="e92f7699-8dbb-4ae8-b06a-44446a8c379b" |
+| RemovedObjectNames | Machine names. | RemovedObjectNames="Virtual Machine 02" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="1 objects have been removed from the malware detection exclusions list. Virtual Machine 02" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-10T06:09:56.762682-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42270 RemovedObjectIDs="e92f7699-8dbb-4ae8-b06a-44446a8c379b" RemovedObjectNames="Virtual Machine 02" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="1 objects have been removed from the malware detection exclusions list. Virtual Machine 02"] |
+
+

--- a/docs/events/event_42280.md
+++ b/docs/events/event_42280.md
@@ -1,0 +1,41 @@
+---
+title: "Malware Detection Exclusions List Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42280.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Detection Exclusions List Updated
+
+
+Sent when a user updates malware exclusions. For more information, see [Malware Exclusions](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_exclusions.html).
+
+General Information
+
+Event ID: 42280
+
+Event message details: Malware exclusions list has been modified with <N> objects. <ModifiedObjectNames>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ModifiedObjectIDs | Machine IDs. | ModifiedObjectIDs="e92f7699-8dbb-4ae8-b06a-44446a8c379b" |
+| ModifiedObjectNames | Machine names. | ModifiedObjectNames="Virtual Machine 02" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Malware exclusions list has been modified with 1 objects. Virtual Machine 02" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:05:38.153114+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42280 ModifiedObjectIDs="e92f7699-8dbb-4ae8-b06a-44446a8c379b" ModifiedObjectNames="Virtual Machine 02" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Malware exclusions list has been modified with 1 objects. Virtual Machine 02"] |
+
+

--- a/docs/events/event_42290.md
+++ b/docs/events/event_42290.md
@@ -1,0 +1,40 @@
+---
+title: "Malware Detection Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42290.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Detection Settings Updated
+
+
+Sent when a user updates malware detection settings. For more information, see [Configuring Malware Detection](https://helpcenter.veeam.com/docs/backup/vsphere/malware_detection_configuring.html).
+
+General Information
+
+Event ID: 42290
+
+Event message details: Malware detection settings have been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><property internal="IsEnabledInlineScanning" type="Boolean"><old>False</old><new>True</new></property><property internal="InlineScanningSensitivity" type="ERansomwareScanningSensitivity"><old /><new>Normal</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Malware detection settings have been changed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:04:20.502011-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42290 ChangesXML="<changes><object><property internal="IsEnabledInlineScanning" type="Boolean"><old>False</old><new>True</new></property><property internal="InlineScanningSensitivity" type="ERansomwareScanningSensitivity"><old /><new>Normal</new></property></object></changes>" UserName="TECH\user1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Malware detection settings have been changed."] |
+
+

--- a/docs/events/event_42300.md
+++ b/docs/events/event_42300.md
@@ -1,0 +1,43 @@
+---
+title: "KMS Server Added"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42300.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# KMS Server Added
+
+
+Sent when a user adds a KMS server. For more information, see [Adding KMS Server](https://helpcenter.veeam.com/docs/backup/vsphere/kms_add_server.html).
+
+General Information
+
+Event ID: 42300
+
+Event message details: KMS server <Name> has been added
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| KMSServerID | Server ID. | KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" |
+| Name | Server name. | Name="kmssrv01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" name="kmssrv01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="KMS server kmssrv01.tech.local has been added." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:41:14.610145+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42300 KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" Name="kmssrv01.tech.local" ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" name="kmssrv01.tech.local" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="KMS server kmssrv01.tech.local has been added."] |
+
+

--- a/docs/events/event_42301.md
+++ b/docs/events/event_42301.md
@@ -1,0 +1,43 @@
+---
+title: "KMS Server Deleted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42301.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# KMS Server Deleted
+
+
+Sent when a user deletes a KMS server. For more information, see [Adding KMS Server](https://helpcenter.veeam.com/docs/backup/vsphere/kms_add_server.html).
+
+General Information
+
+Event ID: 42301
+
+Event message details: KMS server <Name> has been deleted
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| KMSServerID | Server ID. | KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" |
+| Name | Server name. | Name="kmssrv01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" name="kmssrv01.tech.local" /></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="KMS server kmssrv01.tech.local has been deleted." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:15:53.872633+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42301 KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" Name="kmssrv01.tech.local" ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" name="kmssrv01.tech.local" /></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="KMS server kmssrv01.tech.local has been deleted."] |
+
+

--- a/docs/events/event_42302.md
+++ b/docs/events/event_42302.md
@@ -1,0 +1,43 @@
+---
+title: "KMS Server Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42302.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# KMS Server Settings Updated
+
+
+Sent when a user updates KMS server settings. For more information, see [Adding KMS Server](https://helpcenter.veeam.com/docs/backup/vsphere/kms_add_server.html).
+
+General Information
+
+Event ID: 42302
+
+Event message details: KMS server <Name> settings has been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| KMSServerID | Server ID. | KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" |
+| Name | Server name. | Name="kmssrv01.tech.local" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8"><property name="Description" internal="Description" type="String"><old>KMS Server 01</old><new>KMS Server DE 01</new></property></object></changes>" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| UserFullInfo | Detailed information about the user who performed an operation. Includes the following data:   * fullName — the user name * loginType | UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="KMS server kmssrv01.tech.local settings has been changed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T14:13:24.002519+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42302 KMSServerID="7fd84b58-e7fb-41d0-90fb-44439d65e5d8" Name="kmssrv01.tech.local" ChangesXML="<changes><object id="7fd84b58-e7fb-41d0-90fb-44439d65e5d8"><property name="Description" internal="Description" type="String"><old>KMS Server 01</old><new>KMS Server DE 01</new></property></object></changes>" UserName="TECH\user1" UserFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="KMS server kmssrv01.tech.local settings has been changed."] |
+
+

--- a/docs/events/event_42400.md
+++ b/docs/events/event_42400.md
@@ -1,0 +1,41 @@
+---
+title: "Four-Eyes Authorization Enabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42400.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Enabled
+
+
+Sent when a user enables four-eyes authorization. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42400
+
+Event message details: Four-eyes authorization has been enabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Four-eyes authorization has been enabled" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="0" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Four-eyes authorization has been enabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:21:33.216714-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42400 Operation="Four-eyes authorization has been enabled" OperationId="0" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Four-eyes authorization has been enabled by TECH\user1."] |
+
+

--- a/docs/events/event_42401.md
+++ b/docs/events/event_42401.md
@@ -1,0 +1,41 @@
+---
+title: "Four-Eyes Authorization Disabled"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42401.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Disabled
+
+
+Sent when a user disables four-eyes authorization. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42401
+
+Event message details: Four-eyes authorization has been disabled by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Four-eyes authorization has been disabled" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="1" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Four-eyes authorization has been disabled by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:26:58.938788-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42401 Operation="Four-eyes authorization has been disabled" OperationId="1" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Four-eyes authorization has been disabled by TECH\user1."] |
+
+

--- a/docs/events/event_42402.md
+++ b/docs/events/event_42402.md
@@ -1,0 +1,41 @@
+---
+title: "Four-Eyes Authorization Request Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42402.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Request Created
+
+
+Sent when a user creates a four-eyes authorization request. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42402
+
+Event message details: <Operation> event has been initiated by <UserName> and requires an additional approval
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Disable four-eyes authorization" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="103" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Disable four-eyes authorization event has been initiated by TECH\user1 and requires an additional approval." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:26:37.421424-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42402 Operation="Disable four-eyes authorization" OperationId="103" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Disable four-eyes authorization event has been initiated by TECH\user1 and requires an additional approval."] |
+
+

--- a/docs/events/event_42403.md
+++ b/docs/events/event_42403.md
@@ -1,0 +1,42 @@
+---
+title: "Four-Eyes Authorization Request Approved"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42403.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Request Approved
+
+
+Sent when a user approves a four-eyes authorization request. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42403
+
+Event message details: <Operation> event initiated by <UserName> has been approved by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Disable four-eyes authorization" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="103" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| SupervisorFullInfo | Detailed information about the user who verified an operation. Includes the following data:   * fullName — the user name * loginType | SupervisorFullInfo="<ModifiedUserInfo fullName="TECH\user2" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Disable four-eyes authorization event initiated by TECH\user1 has been approved by TECH\user2." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:26:58.953786-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42403 Operation="Disable four-eyes authorization" OperationId="103" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" SupervisorFullInfo="<ModifiedUserInfo fullName="TECH\user2" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Disable four-eyes authorization event initiated by TECH\user1 has been approved by TECH\user2."] |
+
+

--- a/docs/events/event_42404.md
+++ b/docs/events/event_42404.md
@@ -1,0 +1,42 @@
+---
+title: "Four-Eyes Authorization Request Rejected"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42404.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Request Rejected
+
+
+Sent when a user rejects a four-eyes authorization request. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42404
+
+Event message details: <Operation> event initiated by <UserName> has been rejected by <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Delete backup VM01" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="100" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| SupervisorFullInfo | Detailed information about the user who verified an operation. Includes the following data:   * fullName — the user name * loginType | SupervisorFullInfo="<ModifiedUserInfo fullName="TECH\user2" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Delete backup VM01 event initiated by TECH\user1 has been rejected by TECH\user2." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T05:24:42.434059-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42404 Operation="Delete backup VM01" OperationId="100" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" SupervisorFullInfo="<ModifiedUserInfo fullName="TECH\user2" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Delete backup VM01 event initiated by TECH\user1 has been rejected by TECH\user2."] |
+
+

--- a/docs/events/event_42405.md
+++ b/docs/events/event_42405.md
@@ -1,0 +1,41 @@
+---
+title: "Four-Eyes Authorization Request Expired"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42405.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Four-Eyes Authorization Request Expired
+
+
+Sent when a four-eyes authorization request is expired. For more information, see [Four-Eyes Authorization](https://helpcenter.veeam.com/docs/backup/vsphere/four_eyes_authorization.html).
+
+General Information
+
+Event ID: 42405
+
+Event message details: <Operation> event initiated by <UserName> has expired while waiting for additional approval and was auto-rejected
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| Operation | Name of the operation. | Operation="Delete backup VM01" |
+| OperationId | Operation ID. Possible values:   * 0 — Four-eyes authorization has been enabled * 1 — Four-eyes authorization has been disabled * 100 — Delete backup <Name> * 101 — Delete log backup <Name>  * 102 — Delete configuration backup <Name> * 103 — Disable four-eyes authorization * 104 — Delete snapshot <Name> * 105 — Delete object <Name> * 106 — Delete service provider <Name> * 107 — Delete storage <Name> * 108 — Update Veeam Backup & Replication security settings * 10000 — Other operations | OperationId="100" |
+| InitiatorFullInfo | Detailed information about the user who initiated an operation. Includes the following data:   * fullName — the user name * loginType | InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Delete backup VM01 event initiated by TECH\user1 has expired while waiting for additional approval and was auto-rejected." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-12T02:18:33.762068-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42405 Operation="Delete backup VM01" OperationId="100" InitiatorFullInfo="<ModifiedUserInfo fullName="TECH\user1" loginType="0" />" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Delete backup VM01 event initiated by TECH\user1 has expired while waiting for additional approval and was auto-rejected."] |
+
+

--- a/docs/events/event_42500.md
+++ b/docs/events/event_42500.md
@@ -1,0 +1,40 @@
+---
+title: "KMS Key Rotation Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42500.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# KMS Key Rotation Job Finished
+
+
+Sent when a job session for the KMS key rotation is finished. For more information, see [How KMS Works](https://helpcenter.veeam.com/docs/backup/vsphere/kms_how_it_works.html).
+
+General Information
+
+Event ID: 42500
+
+Event message details: KMS key rotation has been completed with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SessionID | Job session ID. | SessionID="913406fe-2ce4-46b7-86c8-26ce1629c822" |
+| Result | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. Includes the following result states: Success, Warning, Failed. | Description="KMS key rotation has been completed with Success" |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T20:00:33.247041+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42500 SessionID="913406fe-2ce4-46b7-86c8-26ce1629c822" Result="0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="KMS key rotation has been completed with Success"] |
+
+

--- a/docs/events/event_42800.md
+++ b/docs/events/event_42800.md
@@ -1,0 +1,42 @@
+---
+title: "SAML Settings Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_42800.html"
+last_updated: "12/12/2025"
+product_version: "13.0.1.1071"
+---
+
+# SAML Settings Updated
+
+
+Sent when a user updates SAML authentication settings. For more information, see [SAML Authentication](identity_provider.md).
+
+General Information
+
+Event ID: 42800
+
+Event message details: SAML Identity Provider options has been changed
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ClientId | Client application ID. | ClientId="veeam-backup-shell" |
+| UserName | Name of the user who performed an operation. | UserName="TECH\user1" |
+| IdpEntityId | Identity provider entity ID. | IdpEntityId="http://adfs.adfs.local/adfs/services/trust" |
+| XmlChange | Updated data in the XML format. | XmlChange="<Changes><Object><property internal="SingleLogoutServiceUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property><property internal="SingleSignOnServiceUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property><property internal="SingleLogoutServiceResponseUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property></Object></Changes>" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="SAML Identity Provider options has been changed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T09:04:20.502011-07:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=42800 ClientId="veeam-backup-shell" UserName="TECH\user1" IdpEntityId="http://adfs.adfs.local/adfs/services/trust" XmlChange="<Changes><Object><property internal="SingleLogoutServiceUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property><property internal="SingleSignOnServiceUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property><property internal="SingleLogoutServiceResponseUrl" type="String"><old>https://adfs.adfs.local/adfs/ls/</old><new>https://adfs.adfs.local/adfs/ls1/</new></property></Object></Changes>" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="SAML Identity Provider options has been changed."] |
+
+

--- a/docs/events/event_43000.md
+++ b/docs/events/event_43000.md
@@ -1,0 +1,43 @@
+---
+title: "High Availability Cluster Created"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43000.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster Created
+
+
+Sent when a user assembles a High Availability cluster. For more information, see [Assembling High Availability Cluster](high_availability_configuration.md).
+
+General Information
+
+Event ID: 43000
+
+Event message details: High Availability cluster has been created
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InitiatorUserName | Name of the user who performed an operation. | InitiatorUserName="TECH\user1" |
+| SecondaryNodeName | Secondary node name. Can be a DNS name or an IP address. | SecondaryNodeName="node02" |
+| ClusterEndpoint | Cluster name. Can be a DNS name or an IP address. | ClusterEndpoint="198.51.100.15" |
+| ClusterDescription | Cluster description. | ClusterDescription="ha-cluster" |
+| CertificateThumbprint | Cluster certificate thumbprint. | CertificateThumbprint="D951CF407C6A9D61AC8754835E4FF96177F0D0A0" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster has been created." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T22:37:19.096979+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43000 InitiatorUserName="TECH\user1" SecondaryNodeName="node02" ClusterEndpoint="198.51.100.15" ClusterDescription="ha-cluster" CertificateThumbprint="D951CF407C6A9D61AC8754835E4FF96177F0D0A0" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster has been created."] |
+
+

--- a/docs/events/event_43001.md
+++ b/docs/events/event_43001.md
@@ -1,0 +1,40 @@
+---
+title: "High Availability Cluster Updated"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43001.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster Updated
+
+
+Sent when a user updates High Availability cluster settings. For more information, see [Editing High Availability Cluster Settings](high_availbility_cluster_editing.md).
+
+General Information
+
+Event ID: 43001
+
+Event message details: High Availability cluster has been re-configured
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InitiatorUserName | Name of the user who performed an operation. | InitiatorUserName="TECH\user1" |
+| ChangesXML | Updated data in the XML format. | ChangesXML="<changes><object><property internal="ClusterEndpoint" type="String"><old>198.51.100.15</old><new>198.51.100.22</new></property></object></changes>" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster has been re-configured." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T10:24:03.094567+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43001 InitiatorUserName="TECH\user1" ChangesXML="<changes><object><property internal="ClusterEndpoint" type="String"><old>198.51.100.15</old><new>198.51.100.22</new></property></object></changes>" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster has been re-configured."] |
+
+

--- a/docs/events/event_43002.md
+++ b/docs/events/event_43002.md
@@ -1,0 +1,41 @@
+---
+title: "High Availability Cluster Removed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43002.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster Removed
+
+
+Sent when a user disassembles a High Availability cluster. For more information, see [Disassembling High Availability Cluster](high_availability_remove.md).
+
+General Information
+
+Event ID: 43002
+
+Event message details: High Availability cluster has been disassembled
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InitiatorUserName | Name of the user who performed an operation. | InitiatorUserName="TECH\user1" |
+| ClusterEndpoint | Cluster name. Can be a DNS name or an IP address. | ClusterEndpoint="198.51.100.15" |
+| ClusterDescription | Cluster description. | ClusterDescription="ha-cluster" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster has been disassembled." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-25T12:05:39.049237+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43002 InitiatorUserName="TECH\user1" ClusterEndpoint="198.51.100.15" ClusterDescription="ha-cluster" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster has been created."] |
+
+

--- a/docs/events/event_43003.md
+++ b/docs/events/event_43003.md
@@ -1,0 +1,41 @@
+---
+title: "High Availability Cluster State Changed"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43003.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster State Changed
+
+
+Sent when the health status of the high Availability cluster is changed. For more information, see [How High Availability Cluster Works](high_availability_hiw.md).
+
+General Information
+
+Event ID: 43003
+
+Event message details: High Availability cluster state has been changed to <State>
+
+Severity: Info, Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| ClusterEndpoint | Cluster name. Can be a DNS name or an IP address. | ClusterEndpoint="198.51.100.15" |
+| ClusterDescription | Cluster description. | ClusterDescription="ha-cluster" |
+| State | Cluster state. Possible values: Online, Offline. | State="Online" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster state has been changed to [Online]." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-28T13:11:06.078102+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43003 ClusterEndpoint="198.51.100.15" ClusterDescription="ha-cluster" State="Online" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster state has been changed to [Online]."] |
+
+

--- a/docs/events/event_43004.md
+++ b/docs/events/event_43004.md
@@ -1,0 +1,42 @@
+---
+title: "High Availability Cluster Failover Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43004.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster Failover Started
+
+
+Sent when a user performs failover for the High Availability cluster. For more information, see [Failover](high_availability_failover.md).
+
+General Information
+
+Event ID: 43004
+
+Event message details: High Availability cluster failover has been initiated by <InitiatorUserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InitiatorUserName | Name of the user who performed an operation. | InitiatorUserName="TECH\user1" |
+| SecondaryNodeName | Secondary node name. Can be a DNS name or an IP address. | SecondaryNodeName="node02" |
+| ClusterEndpoint | Cluster name. Can be a DNS name or an IP address. | ClusterEndpoint="198.51.100.15" |
+| ClusterDescription | Cluster description. | ClusterDescription="ha-cluster" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster failover has been initiated by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-26T08:25:11.015403+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43004 InitiatorUserName="TECH\user1" SecondaryNodeName="node02" ClusterEndpoint="198.51.100.15" ClusterDescription="ha-cluster" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster failover has been initiated by TECH\user1."] |
+
+

--- a/docs/events/event_43006.md
+++ b/docs/events/event_43006.md
@@ -1,0 +1,43 @@
+---
+title: "High Availability Cluster Switchover Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_43006.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Cluster Switchover Started
+
+
+Sent when a user performs switchover for the High Availability cluster. For more information, see [Switchover](high_availability_switchover.md).
+
+General Information
+
+Event ID: 43006
+
+Event message details: High Availability cluster switchover has been initiated by <InitiatorUserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| InitiatorUserName | Name of the user who performed an operation. | InitiatorUserName="TECH\user1" |
+| NewPrimaryNodeName | A new primary node name. Can be a DNS name or an IP address. | NewPrimaryNodeName="newnode01" |
+| NewSecondaryNodeName | A new secondary node name. Can be a DNS name or an IP address. | NewSecondaryNodeName="newnode02" |
+| ClusterEndpoint | Cluster name. Can be a DNS name or an IP address. | ClusterEndpoint="198.51.100.15" |
+| ClusterDescription | Cluster description. | ClusterDescription="ha-cluster" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="High Availability cluster switchover has been initiated by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-27T15:05:14.090345+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=43004 InitiatorUserName="TECH\user1" NewPrimaryNodeName="newnode01" NewSecondaryNodeName="newnode02" ClusterEndpoint="198.51.100.15" ClusterDescription="ha-cluster" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="High Availability cluster switchover has been initiated by TECH\user1."] |
+
+

--- a/docs/events/event_44000.md
+++ b/docs/events/event_44000.md
@@ -1,0 +1,46 @@
+---
+title: "Token Request Approved"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44000.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# Token Request Approved
+
+
+Sent when a new authorization token or token pair has been issued.
+
+General Information
+
+Event ID: 44000
+
+Event message details: Token request was successful
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ClientId | Client application ID. | ClientId="veeam-backup-shell" |
+| GrantType | Authorization grant type. | GrantType="authorization\_code" |
+| FriendlyName | User name. | FriendlyName="veeamadmin" |
+| Subject | User security identifier. | Subject="UID-veeamadmin" |
+| ResourceId | Resource ID. | ResourceId="veeam-backup-services" |
+| ExpirationTimeUtc | Access token expiration time. | ExpirationTimeUtc="11/20/2025 10:29:37" |
+| RefreshTokenChainId | Refresh token ID. | RefreshTokenChainId="cc6231e6-e3f7-43b7-8e0f-6cf7a65d8a3b" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Token request was successful." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T10:14:38.193205-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44000 SourceIpAddress="198.51.100.15" ClientId="veeam-backup-shell" GrantType="authorization\_code" FriendlyName="veeamadmin" Subject="UID-veeamadmin" ResourceId="veeam-backup-services" ExpirationTimeUtc="11/20/2025 10:29:37" RefreshTokenChainId="cc6231e6-e3f7-43b7-8e0f-6cf7a65d8a3b" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Token request was successful."] |
+
+

--- a/docs/events/event_44001.md
+++ b/docs/events/event_44001.md
@@ -1,0 +1,45 @@
+---
+title: "Token Request Rejected"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44001.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# Token Request Rejected
+
+
+Sent when a new authorization token or token pair has not been issued.
+
+General Information
+
+Event ID: 44001
+
+Event message details: Token request was denied: <Reason>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="::1" |
+| ClientId | Client application ID. | ClientId="veeam-backup-web-ui" |
+| GrantType | Authorization grant type. | GrantType="refresh\_token" |
+| FriendlyName | User name. | FriendlyName="veeamadmin" |
+| Subject | User security identifier. | Subject="UID-veeamadmin" |
+| ResourceId | Resource ID. | ResourceId="veeam-backup-services" |
+| Reason | Reason to decline the operation. Possible values:   * -1 — Unknown reason * 0 — Request is malformed * 1 — Unauthenticated * 2 — Account revalidation failed * 3 — Password revalidation failed * 4 — Client is unauthorized * 5 — Resource owner is unauthorized * 6 — Too many invalid requests * 7 — MFA is required * 8 — Unexpected server error occurred * 9 — Selected cookie is missing * 10 — SAML2 is disabled * 11 — GSS is disabled | Reason="1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Token request was denied: an authentication has failed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:56:23.294617-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44001 SourceIpAddress="::1" ClientId="veeam-backup-web-ui" GrantType="refresh\_token" Reason="1" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Token request was denied: an authentication has failed."] |
+
+

--- a/docs/events/event_44002.md
+++ b/docs/events/event_44002.md
@@ -1,0 +1,45 @@
+---
+title: "User Authorization Denied"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44002.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# User Authorization Denied
+
+
+Sent when a user was not authorized during interactive logon.
+
+General Information
+
+Event ID: 44002
+
+Event message details: Authorization request was denied: <Reason>
+
+Severity: Warning
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ClientId | Client application ID. | ClientId="veeam-backup-web-ui" |
+| FriendlyName | User name. | FriendlyName="veeamadmin" |
+| Subject | User security identifier. | Subject="UID-veeamadmin" |
+| ResourceId | Resource ID. | ResourceId="veeam-gateway-api-service" |
+| RedirectUri | Redirect URI. | RedirectUri="/" |
+| Reason | Reason to decline the operation. Possible values:   * -1 — Unknown reason * 0 — Request is malformed * 1 — Unauthenticated * 2 — Account revalidation failed * 3 — Password revalidation failed * 4 — Client is unauthorized * 5 — Resource owner is unauthorized * 6 — Too many invalid requests * 7 — MFA is required * 8 — Unexpected server error occurred * 9 — Selected cookie is missing * 10 — SAML2 is disabled * 11 — GSS is disabled | Reason="1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Authorization request was denied: an authentication has failed." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:57:34.193602-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44002 SourceIpAddress="198.51.100.15" ClientId="veeam-backup-web-ui" FriendlyName="veeamadmin" Subject="UID-veeamadmin" ResourceId="veeam-gateway-api-service" RedirectUri="/" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Authorization request was denied: an authentication has failed."] |
+
+

--- a/docs/events/event_44003.md
+++ b/docs/events/event_44003.md
@@ -1,0 +1,44 @@
+---
+title: "User Authorization Granted"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44003.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# User Authorization Granted
+
+
+Sent when a user was authorized during interactive logon.
+
+General Information
+
+Event ID: 44003
+
+Event message details: Authorization was successful
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ClientId | Client application ID. | ClientId="veeam-backup-web-ui" |
+| FriendlyName | User name. | FriendlyName="veeamadmin" |
+| Subject | User security identifier. | Subject="UID-veeamadmin" |
+| ResourceId | Resource ID. | ResourceId="veeam-gateway-api-service" |
+| RedirectUri | Redirect URI. | RedirectUri="/" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Authorization was successful." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T19:04:38.219437-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44003 SourceIpAddress="198.51.100.15" ClientId="veeam-backup-web-ui" FriendlyName="veeamadmin" Subject="UID-veeamadmin" ResourceId="veeam-gateway-api-service" RedirectUri="/" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Authorization was successful."] |
+
+

--- a/docs/events/event_44004.md
+++ b/docs/events/event_44004.md
@@ -1,0 +1,44 @@
+---
+title: "Password Change Required"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44004.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# Password Change Required
+
+
+Sent when a user is required to change a password during logon.
+
+General Information
+
+Event ID: 44004
+
+Event message details: Password change is required for <FriendlyName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ClientId | Client application ID. | ClientId="veeam-backup-web-ui" |
+| FriendlyName | User name. | FriendlyName="user1" |
+| Subject | User security identifier. | Subject="UID-user1" |
+| ResourceId | Resource ID. | ResourceId="veeam-gateway-api-service" |
+| RedirectUri | Redirect URI. | RedirectUri="/" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Password change is required for user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T17:55:20.194105-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44004 SourceIpAddress="198.51.100.15" ClientId="veeam-backup-web-ui" FriendlyName="user1" Subject="UID-user1" ResourceId="veeam-gateway-api-service" RedirectUri="/" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Password change is required for user1."] |
+
+

--- a/docs/events/event_44005.md
+++ b/docs/events/event_44005.md
@@ -1,0 +1,40 @@
+---
+title: "Token Chain Revoked"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44005.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# Token Chain Revoked
+
+
+Sent when a token chain has been revoked.
+
+General Information
+
+Event ID: 44005
+
+Event message details: Token chain was revoked
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ChainId | Token chain ID. | ChainId="a1b68181-77e1-4b06-866e-10f092f81e23" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Token chain was revoked." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T18:57:33.338104-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44005 SourceIpAddress="198.51.100.15" ChainId="a1b68181-77e1-4b06-866e-10f092f81e23" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Token chain was revoked."] |
+
+

--- a/docs/events/event_44006.md
+++ b/docs/events/event_44006.md
@@ -1,0 +1,44 @@
+---
+title: "Resource Access Denied"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_44006.html"
+last_updated: "1/19/2026"
+product_version: "13.0.1.1071"
+---
+
+# Resource Access Denied
+
+
+Sent when access to the resource has been denied.
+
+General Information
+
+Event ID: 44006
+
+Event message details: Access to the resource was denied
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| SourceIpAddress | IP address of the client application. | SourceIpAddress="198.51.100.15" |
+| ClientId | Client application ID. | ClientId="veeam-backup-web-ui" |
+| FriendlyName | User name. | FriendlyName="veeamadmin" |
+| Subject | User security identifier. | Subject="UID-veeamadmin" |
+| ResourceId | Resource ID. | ResourceId="veeam-gateway-api-service" |
+| ExpectedResourceIds | Resource IDs provided by the Veeam service. | ExpectedResourceIds="veeam-rest, veeam-gateway-api-service" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Access to the resource was denied." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-12-05T06:25:24.921548-07:00 VBRSRV01 Veeam\_Security - - [origin enterpriseId="31023"] [categoryId=0 instanceId=44006 SourceIpAddress="198.51.100.15" ClientId="veeam-backup-web-ui" FriendlyName="veeamadmin" Subject="UID-veeamadmin" ResourceId="veeam-gateway-api-service" ExpectedResourceIds="veeam-rest, veeam-gateway-api-service" VbrHostName="vbrsrv01" VbrVersion="13.0.1.180" Version="1" Description="Access to the resource was denied."] |
+
+

--- a/docs/events/event_450.md
+++ b/docs/events/event_450.md
@@ -1,0 +1,54 @@
+---
+title: "Backup Copy Task Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_450.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Copy Task Finished
+
+
+Sent when a backup copy task is finished. For more information, see [Backup Copy](https://helpcenter.veeam.com/docs/backup/vsphere/backup_copy.html).
+
+General Information
+
+Event ID: 450
+
+Event message details: <VmName> task has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="2053dad3-63d6-4990-88bd-66fa4e2ef28d" |
+| JobID | Job ID. | JobID="f03100a2-4d32-4ddc-a0d0-85759083e2de" |
+| JobType | Job type. | JobType="63" |
+| TaskSessionID | Task session ID. | TaskSessionID="48f7ab45-c494-4147-8af3-bcb7fef16a0c" |
+| OibID | Machine ID. | OibID="3d3ddf15-7a18-491d-a2b7-087c99ab6395" |
+| OriginalOibID | Original machine ID. | OriginalOibID="14db33a5-cec2-44e6-b3a2-f355ca2f542f" |
+| CreationTime | Date and time when a restore point has been created. | CreationTime="03/24/2025 06:54:02" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="5" |
+| JobDescription | Job description. | JobDescription="VM01 backup copy task" |
+| SourceHostName | Source host name. | SourceHostName="pdc01.tech.local" |
+| VmRef | Machine reference ID. | VmRef="vm-01" |
+| VmName | Machine name. | VmName="VM01" |
+| TransferredGb | Transferred data in GB. | TransferredGb="0.011" |
+| Platform | Platform type. | Platform="0" |
+| IsRetry | Defines whether the job will be retried. | IsRetry="False" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="VM01 task has finished with 'InProgress' state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-24T13:06:25.751766+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=450 JobSessionID="2053dad3-63d6-4990-88bd-66fa4e2ef28d" JobID="f03100a2-4d32-4ddc-a0d0-85759083e2de" JobType="63" TaskSessionID="48f7ab45-c494-4147-8af3-bcb7fef16a0c" OibID="3d3ddf15-7a18-491d-a2b7-087c99ab6395" OriginalOibID="14db33a5-cec2-44e6-b3a2-f355ca2f542f" CreationTime="03/24/2025 06:54:02" Status="5" JobDescription="VM01 backup copy task" SourceHostName="pdc01.tech.local" VmRef="vm-01" VmName="VM01" TransferredGb="0.011" Platform="0" IsRetry="False" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="VM01 task has finished with 'InProgress' state."] |
+
+

--- a/docs/events/event_451.md
+++ b/docs/events/event_451.md
@@ -1,0 +1,50 @@
+---
+title: "File Backup Copy Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_451.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Backup Copy Job Finished
+
+
+Sent when a file backup copy job session is finished. For more information, see [Creating File Backup Jobs](https://helpcenter.veeam.com/docs/backup/vsphere/file_share_backup_job.html).
+
+General Information
+
+Event ID: 451
+
+Event message details: Source <SourceName> task has finished with <State> state. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="befc9479-9fcf-4e6f-99c3-15f7c2eb51f1" |
+| JobID | Job ID. | JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" |
+| JobType | Job type. | JobType="13003" |
+| TaskSessionID | Task session ID. | TaskSessionID="fad74fa0-d018-4569-a735-34f3ab5041d6" |
+| Status | Session status ID. Possible values:   * 0 — Success * 2 — Failed * 3 — Warning * 5 — In progress * 6 — Pending | Status="2" |
+| JobDescription | Job description. | JobDescription="Created by TECH\user1 at 03/20/2025 12:35:07 PM." |
+| SourceHostName | Source host name. | SourceHostName="\\fs1\Folder" |
+| SourceName | Source name. | SourceName="\\fs1\Folder" |
+| TransferredGb | Transferred data in GB. | TransferredGb="0.000" |
+| Platform | Platform type. | Platform="11" |
+| IsRetry | Defines whether the job will be retried. | IsRetry="False" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Source '\\fs1\Folder' task has finished with 'Failed' state. Task details: Copying restore point 03/20/2025 4:11:31 PM (20 GB): 1 files (0 B) transferred at 0 KB/s. Connection was lost, task will be cancelled." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:16:51.069076+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=451 JobSessionID="befc9479-9fcf-4e6f-99c3-15f7c2eb51f1" JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" JobType="13003" TaskSessionID="fad74fa0-d018-4569-a735-34f3ab5041d6" Status="2" JobDescription="Created by TECH\user1 at 03/20/2025 12:35:07 PM." SourceHostName="\\fs1\Folder" SourceName="\\fs1\Folder" TransferredGb="0.000" Platform="11" IsRetry="False" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Source '\\fs1\Folder' task has finished with 'Failed' state. Task details: Copying restore point 03/20/2025 4:11:31 PM (20 GB): 1 files (0 B) transferred at 0 KB/s. Connection was lost, task will be cancelled."] |
+
+

--- a/docs/events/event_490.md
+++ b/docs/events/event_490.md
@@ -1,0 +1,46 @@
+---
+title: "Backup Copy Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_490.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Backup Copy Job Finished
+
+
+Sent when a backup copy job session is finished. For more information, see [Backup Copy](https://helpcenter.veeam.com/docs/backup/vsphere/backup_copy.html).
+
+General Information
+
+Event ID: 490
+
+Event message details: Backup Copy job <JobName> finished with <State>. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="11ce771c-54f1-444a-ae1a-ee76c96eabe9" |
+| JobID | Job ID. | JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="13003" |
+| Platform | Platform type. | Platform="11" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Fileshare SMB backup (Copy) 1" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Backup Copy job 'Fileshare SMB backup (Copy) 1' finished with Success. All objects have been backed up successfully." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T16:11:38.164505+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=490 JobSessionID="11ce771c-54f1-444a-ae1a-ee76c96eabe9" JobID="c4adcbc0-ef2f-4a12-8cc4-0f07fb3df2fa" JobResult="0" JobType="13003" Platform="11" WillBeRetried="False" JobName="Fileshare SMB backup (Copy) 1" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Backup Copy job 'Fileshare SMB backup (Copy) 1' finished with Success. All objects have been backed up successfully."] |
+
+

--- a/docs/events/event_510.md
+++ b/docs/events/event_510.md
@@ -1,0 +1,44 @@
+---
+title: "File Copy Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_510.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Copy Job Started
+
+
+Sent when a user starts a file copy job session. For more information, see [File Copy](https://helpcenter.veeam.com/docs/backup/vsphere/file_copy.html).
+
+General Information
+
+Event ID: 510
+
+Event message details: Copy job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="5e1e878a-cfe2-4bb0-bca4-cee33c468162" |
+| JobID | Job ID. | JobID="226e0318-0bb9-4d22-bf1a-f4c0fa51eb1d" |
+| JobType | Job type. | JobType="2" |
+| Platform | Platform type. | Platform="0" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Copy job 'File Copy Job 02' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:10:13.252692+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=510 JobSessionID="5e1e878a-cfe2-4bb0-bca4-cee33c468162" JobID="226e0318-0bb9-4d22-bf1a-f4c0fa51eb1d" JobType="2" Platform="0" Flags="0" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Copy job 'File Copy Job 02' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_512.md
+++ b/docs/events/event_512.md
@@ -1,0 +1,44 @@
+---
+title: "VM Copy Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_512.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# VM Copy Job Started
+
+
+Sent when a user starts a VM copy job session. For more information, see [VM Copy](https://helpcenter.veeam.com/docs/backup/vsphere/vm_copy.html).
+
+General Information
+
+Event ID: 512
+
+Event message details: Copy job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="a827df34-d63b-4536-b2f7-f0cf451109cb" |
+| JobID | Job ID. | JobID="42686b4c-1e75-4d24-b64b-47923e2de189" |
+| JobType | Job type. | JobType="2" |
+| Platform | Platform type. | Platform="0" |
+| Flags | Defines whether the job was started by a user. | Flags="0" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Copy job 'VM Copy Job 02' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:11:26.068734+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=512 JobSessionID="a827df34-d63b-4536-b2f7-f0cf451109cb" JobID="42686b4c-1e75-4d24-b64b-47923e2de189" JobType="2" Platform="0" Flags="0" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Copy job 'VM Copy Job 02' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_590.md
+++ b/docs/events/event_590.md
@@ -1,0 +1,46 @@
+---
+title: "File Copy Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_590.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# File Copy Job Finished
+
+
+Sent when a file copy job session is finished. For more information, see [File Copy](https://helpcenter.veeam.com/docs/backup/vsphere/file_copy.html).
+
+General Information
+
+Event ID: 590
+
+Event message details: Copy job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="5e1e878a-cfe2-4bb0-bca4-cee33c468162" |
+| JobID | Job ID. | JobID="226e0318-0bb9-4d22-bf1a-f4c0fa51eb1d" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="2" |
+| Platform | Platform type. | Platform="0" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="File Copy Job 02" |
+| SourceType | Job source type. | SourceType="3" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Copy job 'File Copy Job 02' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:10:23.353785+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=590 JobSessionID="5e1e878a-cfe2-4bb0-bca4-cee33c468162" JobID="226e0318-0bb9-4d22-bf1a-f4c0fa51eb1d" JobResult="0" JobType="2" Platform="0" WillBeRetried="False" JobName="File Copy Job 02" SourceType="3" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Copy job 'File Copy Job 02' finished with Success."] |
+
+

--- a/docs/events/event_592.md
+++ b/docs/events/event_592.md
@@ -1,0 +1,46 @@
+---
+title: "VM Copy Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_592.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# VM Copy Job Finished
+
+
+Sent when a VM copy job session is finished. For more information, see [VM Copy](https://helpcenter.veeam.com/docs/backup/vsphere/vm_copy.html).
+
+General Information
+
+Event ID: 592
+
+Event message details: Copy job <JobName> finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="a827df34-d63b-4536-b2f7-f0cf451109cb" |
+| JobID | Job ID. | JobID="42686b4c-1e75-4d24-b64b-47923e2de189" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="2" |
+| Platform | Platform type. | Platform="0" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="VM Copy Job 02" |
+| SourceType | Job source type. | SourceType="2" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Copy job 'VM Copy Job 02' finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:12:07.328602+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=592 JobSessionID="a827df34-d63b-4536-b2f7-f0cf451109cb" JobID="42686b4c-1e75-4d24-b64b-47923e2de189" JobResult="0" JobType="2" Platform="0" WillBeRetried="False" JobName="VM Copy Job 02" SourceType="2" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Copy job 'VM Copy Job 02' finished with Success."] |
+
+

--- a/docs/events/event_600.md
+++ b/docs/events/event_600.md
@@ -1,0 +1,43 @@
+---
+title: "Quick Migration Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_600.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Quick Migration Started
+
+
+Sent when a user starts a quick migration job session for an infrastructure component. For more information, see [Quick Migration](https://helpcenter.veeam.com/docs/backup/vsphere/quick_migration.html).
+
+General Information
+
+Event ID: 600
+
+Event message details: <Name> job has been started by user <User>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="63aa6ffff2564e2ca1b6da488eb1527a" |
+| JobID | Job ID. | JobID="565ad243-8502-421e-91e5-012f2a87d770" |
+| Platform | Platform ID. | Platform="8" |
+| JobType | Job type. | JobType="122" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="FileShareMigration job has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:15:39.820755+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=600 JobSessionID="63aa6ffff2564e2ca1b6da488eb1527a" JobID="565ad243-8502-421e-91e5-012f2a87d770" InitiatorName="TECH\user1" JobType="122" Platform="8" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="FileShareMigration job has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_601.md
+++ b/docs/events/event_601.md
@@ -1,0 +1,43 @@
+---
+title: "Migrating File Share to Production Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_601.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Migrating File Share to Production Job Started
+
+
+Sent when a user starts file share migration to production. For more information, see [Migrating File Share to Production](https://helpcenter.veeam.com/docs/backup/vsphere/migrate_share_to_production.html).
+
+General Information
+
+Event ID: 601
+
+Event message details: FileShareMigration switchover job has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="6268d6b3d7ea4189b9137bea897890aa" |
+| JobID | Job ID. | JobID="4c3ae585-b9a5-43fc-82a9-4de25339e764" |
+| InitiatorName | Name of the user who performed an operation. | InitiatorName="TECH\user1" |
+| JobType | Job type. | JobType="122" |
+| Platform | Platform type. | Platform="8" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="FileShareMigration switchover job has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T19:52:35.089758+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=601 JobSessionID="6268d6b3d7ea4189b9137bea897890aa" JobID="4c3ae585-b9a5-43fc-82a9-4de25339e764" InitiatorName="TECH\user1" JobType="122" Platform="8" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="FileShareMigration switchover job has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_610.md
+++ b/docs/events/event_610.md
@@ -1,0 +1,43 @@
+---
+title: "Quick Migration Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_610.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Quick Migration Finished
+
+
+Sent when a quick migration job session is finished. For more information, see [Quick Migration](https://helpcenter.veeam.com/docs/backup/vsphere/quick_migration.html).
+
+General Information
+
+Event ID: 610
+
+Event message details: <JobName> job finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="63aa6ffff2564e2ca1b6da488eb1527a" |
+| JobID | Job ID. | JobID="565ad243-8502-421e-91e5-012f2a87d770" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="122" |
+| Platform | Platform ID. | Platform="8" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="FileShareMigration job finished with 'Success' state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-20T19:16:24.643227+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=610 JobSessionID="63aa6ffff2564e2ca1b6da488eb1527a" JobID="565ad243-8502-421e-91e5-012f2a87d770" JobResult="0" JobType="122" Platform="8" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="FileShareMigration job finished with 'Success' state."] |
+
+

--- a/docs/events/event_650.md
+++ b/docs/events/event_650.md
@@ -1,0 +1,44 @@
+---
+title: "Active Full Backup for Backup Policy Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_650.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Active Full Backup for Backup Policy Started
+
+
+Sent when a user starts an active full backup for the backup policy. For more information, see [Performing Active Full Backup](https://helpcenter.veeam.com/docs/backup/agents/agent_policy_active_full.html).
+
+General Information
+
+Event ID: 650
+
+Event message details: Agent Active Full for <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="9cbb9163-6791-4d7d-a6a9-744210d7e6a6" |
+| JobID | Job ID. | JobID="7eb18610-9aca-4cb5-9b37-8d7051887911" |
+| JobType | Job type. | JobType="12008" |
+| Platform | Platform type. | Platform="6" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Agent Active Full for 'Agent Backup Policy 1' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T16:18:29.774023+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=650 JobSessionID="9cbb9163-6791-4d7d-a6a9-744210d7e6a6" JobID="7eb18610-9aca-4cb5-9b37-8d7051887911" JobType="12008" Platform="6" Flags="1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Agent Active Full for 'Agent Backup Policy 1' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_652.md
+++ b/docs/events/event_652.md
@@ -1,0 +1,46 @@
+---
+title: "Active Full Backup for Backup Policy Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_652.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Active Full Backup for Backup Policy Finished
+
+
+Sent when an active full backup for the backup policy is finished. r more information, see [Performing Active Full Backup](https://helpcenter.veeam.com/docs/backup/agents/agent_policy_active_full.html).
+
+General Information
+
+Event ID: 652
+
+Event message details: Agent Active Full for <JobName> has finished with <State>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="9cbb9163-6791-4d7d-a6a9-744210d7e6a6" |
+| JobID | Job ID. | JobID="7eb18610-9aca-4cb5-9b37-8d7051887911" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="12008" |
+| Platform | Platform type. | Platform="6" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Agent Backup Policy 1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Agent Active Full for 'Agent Backup Policy 1' has finished with Success." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T16:20:45.269895+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=652 JobSessionID="9cbb9163-6791-4d7d-a6a9-744210d7e6a6" JobID="7eb18610-9aca-4cb5-9b37-8d7051887911" JobResult="0" JobType="12008" Platform="6" WillBeRetried="False" JobName="Agent Backup Policy 1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Agent Active Full for 'Agent Backup Policy 1' has finished with Success."] |
+
+

--- a/docs/events/event_710.md
+++ b/docs/events/event_710.md
@@ -1,0 +1,44 @@
+---
+title: "Agent Backup Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_710.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Agent Backup Job Started
+
+
+Sent when a user starts an agent backup job session. For more information, see [Starting and Stopping Veeam Agent Backup Job](https://helpcenter.veeam.com/docs/backup/agents/agent_job_start_stop.html).
+
+General Information
+
+Event ID: 710
+
+Event message details: Agent Backup job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="3334a4f4-54b6-4d0c-8045-cdc329817693" |
+| JobID | Job ID. | JobID="3f427354-5bc1-492a-ae5b-f307bf1a9ab3" |
+| JobType | Job type. | JobType="12003" |
+| Platform | Platform type. | Platform="6" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Agent Backup job 'Agent Backup Job 1' has been started by TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:59:47.415672+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=710 JobSessionID="3334a4f4-54b6-4d0c-8045-cdc329817693" JobID="3f427354-5bc1-492a-ae5b-f307bf1a9ab3" JobType="12003" Platform="6" Flags="1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Agent Backup job 'Agent Backup Job 1' has been started by TECH\user1."] |
+
+

--- a/docs/events/event_790.md
+++ b/docs/events/event_790.md
@@ -1,0 +1,46 @@
+---
+title: "Agent Backup Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_790.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Agent Backup Job Finished
+
+
+Sent when an agent backup job session is finished. For more information, see [Starting and Stopping Veeam Agent Backup Job](https://helpcenter.veeam.com/docs/backup/agents/agent_job_start_stop.html).
+
+General Information
+
+Event ID: 790
+
+Event message details: Agent Backup job <JobName> finished with <State>. <Details>
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="3334a4f4-54b6-4d0c-8045-cdc329817693" |
+| JobID | Job ID. | JobID="3f427354-5bc1-492a-ae5b-f307bf1a9ab3" |
+| JobResult | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | JobResult="0" |
+| JobType | Job type. | JobType="12003" |
+| Platform | Platform type. | Platform="6" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| JobName | Job name. | JobName="Agent Backup Job 1" |
+| SourceType | Job source type. | SourceType="5" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Agent Backup job 'Agent Backup Job 1' finished with Success. All objects have been backed up successfully." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T16:08:19.229942+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=790 JobSessionID="3334a4f4-54b6-4d0c-8045-cdc329817693" JobID="3f427354-5bc1-492a-ae5b-f307bf1a9ab3" JobResult="0" JobType="12003" Platform="6" WillBeRetried="False" JobName="Agent Backup Job 1" SourceType="5" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Agent Backup job 'Agent Backup Job 1' finished with Success. All objects have been backed up successfully."] |
+
+

--- a/docs/events/event_810.md
+++ b/docs/events/event_810.md
@@ -1,0 +1,42 @@
+---
+title: "Rescan Job Started"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_810.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Rescan Job Started
+
+
+Sent when a user starts a rescan job session for an infrastructure component.
+
+General Information
+
+Event ID: 810
+
+Event message details: Rescan job <JobName> has been started by user <UserName>
+
+Severity: Info
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="cf7a9d78-5aee-4913-bd45-4bf5163d7d9d" |
+| JobID | Job ID. | JobID="2e824b3d-194e-4ebb-84bc-83f3bd586e9a" |
+| JobType | Job type. | JobType="12005" |
+| Flags | Defines whether the job was started by a user. | Flags="1" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="Rescan job 'Rescan of vm1.tech.local' has been started by user TECH\user1." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:48:55.040274+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=810 JobSessionID="cf7a9d78-5aee-4913-bd45-4bf5163d7d9d" JobID="2e824b3d-194e-4ebb-84bc-83f3bd586e9a" JobType="12005" Flags="1" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="Rescan job 'Rescan of vm1.tech.local' has been started by user TECH\user1."] |
+
+

--- a/docs/events/event_890.md
+++ b/docs/events/event_890.md
@@ -1,0 +1,43 @@
+---
+title: "Rescan Job Finished"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_890.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Rescan Job Finished
+
+
+Sent when a rescan job session is finished.
+
+General Information
+
+Event ID: 890
+
+Event message details: The Rescan job <JobName> has finished with <State> state
+
+Severity: Info, Warning, Error
+
+Parameters
+
+| Parameter Name | Description | Example |
+| --- | --- | --- |
+| JobSessionID | Job session ID. | JobSessionID="cf7a9d78-5aee-4913-bd45-4bf5163d7d9d" |
+| JobID | Job ID. | JobID="2e824b3d-194e-4ebb-84bc-83f3bd586e9a" |
+| Result | Job result ID. Possible values:   * 0 — Success * 1 — Warning * 2 — Failed | Result="0" |
+| JobType | Job type. | JobType="12005" |
+| WillBeRetried | Defines whether the job will be retried. | WillBeRetried="False" |
+| VbrHostName | Backup server name. Can be a DNS name, an FQDN or an IP address. | VbrHostName="vbrsrv01.tech.local" |
+| VbrVersion | Veeam Backup & Replication version. | VbrVersion="13.0.1.180" |
+| Version | Event version (service parameter). | Version="1" |
+| Description | Event message details. | Description="The Rescan job 'Rescan of vm1.tech.local' has finished with Success state." |
+
+Syslog Message Example
+
+|  |
+| --- |
+| 1 2025-11-23T15:51:25.174125+02:00 VBRSRV01 Veeam\_MP - - [origin enterpriseId="31023"] [categoryId=0 instanceId=890 JobSessionID="cf7a9d78-5aee-4913-bd45-4bf5163d7d9d" JobID="2e824b3d-194e-4ebb-84bc-83f3bd586e9a" Result="0" JobType="12005" WillBeRetried="False" VbrHostName="vbrsrv01.tech.local" VbrVersion="13.0.1.180" Version="1" Description="The Rescan job 'Rescan of vm1.tech.local' has finished with Success state."] |
+
+

--- a/docs/events/event_agent_management.md
+++ b/docs/events/event_agent_management.md
@@ -1,0 +1,15 @@
+---
+title: "Agent Management"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_agent_management.html"
+last_updated: "5/21/2024"
+product_version: "13.0.1.1071"
+---
+
+# Agent Management
+
+
+This section contains Veeam Backup & Replication events related to agent management.
+
+

--- a/docs/events/event_app_plugins.md
+++ b/docs/events/event_app_plugins.md
@@ -1,0 +1,15 @@
+---
+title: "Plug-Ins for Enterprise Applications"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_app_plugins.html"
+last_updated: "5/21/2024"
+product_version: "13.0.1.1071"
+---
+
+# Plug-Ins for Enterprise Applications
+
+
+This section contains Veeam Backup & Replication events related to plug-ins for enterprise applications.
+
+

--- a/docs/events/event_backup.md
+++ b/docs/events/event_backup.md
@@ -1,0 +1,15 @@
+---
+title: "Backup"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_backup.html"
+last_updated: "5/15/2024"
+product_version: "13.0.1.1071"
+---
+
+# Backup
+
+
+This section contains Veeam Backup & Replication events related to backup operations.
+
+

--- a/docs/events/event_backup_general.md
+++ b/docs/events/event_backup_general.md
@@ -1,0 +1,15 @@
+---
+title: "General Operations"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_backup_general.html"
+last_updated: "5/7/2024"
+product_version: "13.0.1.1071"
+---
+
+# General Operations
+
+
+This section contains Veeam Backup & Replication events related to general backup operations.
+
+

--- a/docs/events/event_backup_infrastructure.md
+++ b/docs/events/event_backup_infrastructure.md
@@ -1,0 +1,15 @@
+---
+title: "Infrastructure Components"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_backup_infrastructure.html"
+last_updated: "5/3/2024"
+product_version: "13.0.1.1071"
+---
+
+# Infrastructure Components
+
+
+This section contains Veeam Backup & Replication events related to backup infrastructure components.
+
+

--- a/docs/events/event_backup_infrastructure_general.md
+++ b/docs/events/event_backup_infrastructure_general.md
@@ -1,0 +1,15 @@
+---
+title: "General Operations"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_backup_infrastructure_general.html"
+last_updated: "4/24/2024"
+product_version: "13.0.1.1071"
+---
+
+# General Operations
+
+
+This section contains Veeam Backup & Replication events related to general operations with backup infrastructure components.
+
+

--- a/docs/events/event_backup_jobs.md
+++ b/docs/events/event_backup_jobs.md
@@ -1,0 +1,15 @@
+---
+title: "Jobs"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_backup_jobs.html"
+last_updated: "5/14/2024"
+product_version: "13.0.1.1071"
+---
+
+# Jobs
+
+
+This section contains Veeam Backup & Replication events related to jobs.
+
+

--- a/docs/events/event_changelog.md
+++ b/docs/events/event_changelog.md
@@ -1,0 +1,22 @@
+---
+title: "Event Changelog"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_changelog.html"
+last_updated: "12/2/2025"
+product_version: "13.0.1.1071"
+---
+
+# Event Changelog
+
+
+This page lists Veeam Backup & Replication events for all product versions starting from version 12.1.1. All files are stored in the JSON format.
+
+* [Event list for Veeam Backup & Replication 13.0.1 (build 13.0.1.180)](https://helpcenter.veeam.com/downloads/backup/13.0.1/events/vbr-events-v13.0.1.json)
+* [Event list for Veeam Backup & Replication 13.0.0 (build 13.0.0.4967)](https://helpcenter.veeam.com/downloads/backup/13.0/events/vbr-events-v13.0.0.json)
+* [Event list for Veeam Backup & Replication 12.3.0 (build 12.3.0.310) to 12.3.2 (build 12.3.2.3617)](https://helpcenter.veeam.com/downloads/backup/12.3/events/vbr-events-v12.3.0.json)
+* [Event list for Veeam Backup & Replication 12.2.0 (build 12.2.0.334)](https://helpcenter.veeam.com/downloads/backup/12.2/events/vbr-events-v12.2.0.json)
+* [Event list for Veeam Backup & Replication 12.1.2 (build 12.1.2.172)](https://helpcenter.veeam.com/downloads/backup/12.1.2/events/vbr-events-v12.1.2.json)
+* [Event list for Veeam Backup & Replication 12.1.1 (build 12.1.1.56)](https://helpcenter.veeam.com/downloads/backup/12.1.1/events/vbr-events-v12.1.1.json)
+
+

--- a/docs/events/event_cloud_connect.md
+++ b/docs/events/event_cloud_connect.md
@@ -1,0 +1,15 @@
+---
+title: "Cloud Connect"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_cloud_connect.html"
+last_updated: "5/22/2024"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Connect
+
+
+This section contains Veeam Backup & Replication events related to Cloud Connect.
+
+

--- a/docs/events/event_cloud_connect_infrastructure.md
+++ b/docs/events/event_cloud_connect_infrastructure.md
@@ -1,0 +1,15 @@
+---
+title: "Cloud Connect Infrastructure"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_cloud_connect_infrastructure.html"
+last_updated: "5/21/2024"
+product_version: "13.0.1.1071"
+---
+
+# Cloud Connect Infrastructure
+
+
+This section contains Veeam Backup & Replication events related to Cloud Connect infrastructure.
+
+

--- a/docs/events/event_configuration.md
+++ b/docs/events/event_configuration.md
@@ -1,0 +1,15 @@
+---
+title: "Configuration"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_configuration.html"
+last_updated: "4/3/2025"
+product_version: "13.0.1.1071"
+---
+
+# Configuration
+
+
+This section contains Veeam Backup & Replication events related to the general settings.
+
+

--- a/docs/events/event_credentials.md
+++ b/docs/events/event_credentials.md
@@ -1,0 +1,15 @@
+---
+title: "Credential Records"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_credentials.html"
+last_updated: "4/3/2025"
+product_version: "13.0.1.1071"
+---
+
+# Credential Records
+
+
+This section contains Veeam Backup & Replication events related to credential records.
+
+

--- a/docs/events/event_high_availability.md
+++ b/docs/events/event_high_availability.md
@@ -1,0 +1,15 @@
+---
+title: "High Availability Clusters"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_high_availability.html"
+last_updated: "12/4/2025"
+product_version: "13.0.1.1071"
+---
+
+# High Availability Clusters
+
+
+This section contains Veeam Backup & Replication events related to High Availability clusters.
+
+

--- a/docs/events/event_id_list.md
+++ b/docs/events/event_id_list.md
@@ -1,0 +1,338 @@
+---
+title: "Event IDs List"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_id_list.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Event IDs List
+
+
+This page contains a list of all Veeam Backup & Replication events based on their IDs.
+
+| Event ID | Event Name | MITRE ATT&CK Tactic | MITRE ATT&CK Technique | NIST 800-53r5 | Veeam Products and Components |
+| --- | --- | --- | --- | --- | --- |
+| 110 | [Backup Job Started](event_110.md) | N/A | N/A | N/A | N/A |
+| 114 | [File to Tape Job Started](event_114.md) | N/A | N/A | N/A | N/A |
+| 115 | [Tape Erase Job Started](event_115.md) | TA0040 | T1485, T1490 | AC-2, AC-3, AC-6, CM-6, CM-7, CP-2, CP-7, CP-9, CP-10, SI-3, SI-4, SI-7 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 116 | [Tape Inventorying Job Started](event_116.md) | N/A | N/A | N/A | N/A |
+| 117 | [Tape Cataloging Job Started](event_117.md) | N/A | N/A | N/A | N/A |
+| 118 | [Tape Verification Job Started](event_118.md) | N/A | N/A | N/A | N/A |
+| 119 | [Tape Export Job Started](event_119.md) | TA0010 | T1052 | AC-20, CA-7, MP-7, SC-28 | Tape Encryption |
+| 120 | [Tape Copy Job Started](event_120.md) | N/A | N/A | N/A | N/A |
+| 121 | [Tape Eject Job Started](event_121.md) | N/A | N/A | N/A | N/A |
+| 122 | [Mark Tape As Free Job Started](event_122.md) | TA0040 | T1485, T1490 | AC-2, AC-3, AC-6, CM-6, CM-7, CP-2, CP-7, CP-9, CP-10, SI-3, SI-4, SI-7 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 123 | [Move To Media Pool Job Started](event_123.md) | N/A | N/A | N/A | N/A |
+| 124 | [Delete From Library Job Started](event_124.md) | TA0040 | T1485, T1490 | AC-2, AC-3, AC-6, CM-6, CM-7, CP-2, CP-7, CP-9, CP-10, SI-3, SI-4, SI-7 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 125 | [Library Discovery Job Started](event_125.md) | N/A | N/A | N/A | N/A |
+| 126 | [Tape Import Job Started](event_126.md) | N/A | N/A | N/A | N/A |
+| 150 | [Backup Task Finished](event_150.md) | N/A | N/A | N/A | N/A |
+| 151 | [File Backup Job Finished](event_151.md) | N/A | N/A | N/A | N/A |
+| 190 | [Backup Job Finished](event_190.md) | N/A | N/A | N/A | N/A |
+| 194 | [File to Tape Job Finished](event_194.md) | N/A | N/A | N/A | N/A |
+| 195 | [Tape Erase Job Finished](event_195.md) | N/A | N/A | N/A | N/A |
+| 196 | [Tape Inventorying Job Finished](event_196.md) | N/A | N/A | N/A | N/A |
+| 197 | [Tape Cataloging Job Finished](event_197.md) | N/A | N/A | N/A | N/A |
+| 198 | [Tape Verification Job Finished](event_198.md) | N/A | N/A | N/A | N/A |
+| 199 | [Tape Export Job Finished](event_199.md) | N/A | N/A | N/A | N/A |
+| 200 | [Tape Copy Job Finished](event_200.md) | N/A | N/A | N/A | N/A |
+| 203 | [Tape Eject Job Finished](event_203.md) | N/A | N/A | N/A | N/A |
+| 204 | [Mark Tape As Free Job Finished](event_204.md) | N/A | N/A | N/A | N/A |
+| 205 | [Move To Media Pool Job Finished](event_205.md) | N/A | N/A | N/A | N/A |
+| 206 | [Delete From Library Job Finished](event_206.md) | N/A | N/A | N/A | N/A |
+| 207 | [Library Discovery Job Finished](event_207.md) | N/A | N/A | N/A | N/A |
+| 208 | [Tape Import Job Finished](event_208.md) | N/A | N/A | N/A | N/A |
+| 210 | [Restore Session Started](event_210_40210.md) | N/A | N/A | N/A | N/A |
+| 250 | [Restore Task for VMware VM Finished](event_250.md) | N/A | N/A | N/A | N/A |
+| 251 | [Restore Task for Hyper-V VM FInished](event_251.md) | N/A | N/A | N/A | N/A |
+| 290 | [Restore Session Finished](event_290_40290.md) | N/A | N/A | N/A | N/A |
+| 310 | [SureBackup Job Started](event_310.md) | N/A | N/A | N/A | N/A |
+| 350 | [Verification Task for VMware VM Finished](event_350.md) | N/A | N/A | N/A | N/A |
+| 351 | [Validation Task for VMware VM Finished](event_351.md) | N/A | N/A | N/A | N/A |
+| 360 | [Verification Task for Hyper-V VM Finished](event_360.md) | N/A | N/A | N/A | N/A |
+| 361 | [Validation Task for Hyper-V VM Finished](event_361.md) | N/A | N/A | N/A | N/A |
+| 390 | [SureBackup Job Finished](event_390.md) | N/A | N/A | N/A | N/A |
+| 410 | [Backup Copy Job Started](event_410.md) | N/A | N/A | N/A | N/A |
+| 450 | [Backup Copy Task Finished](event_450.md) | N/A | N/A | N/A | N/A |
+| 451 | [File Backup Copy Job Finished](event_451.md) | N/A | N/A | N/A | N/A |
+| 490 | [Backup Copy Job Finished](event_490.md) | N/A | N/A | N/A | N/A |
+| 510 | [File Copy Job Started](event_510.md) | N/A | N/A | N/A | N/A |
+| 512 | [VM Copy Job Started](event_512.md) | N/A | N/A | N/A | N/A |
+| 590 | [File Copy Job Finished](event_590.md) | N/A | N/A | N/A | N/A |
+| 592 | [VM Copy Job Finished](event_592.md) | N/A | N/A | N/A | N/A |
+| 600 | [Quick Migration Started](event_600.md) | N/A | N/A | N/A | N/A |
+| 601 | [Migrating File Share to Production Job Started](event_601.md) | N/A | N/A | N/A | N/A |
+| 610 | [Quick Migration Finished](event_610.md) | N/A | N/A | N/A | N/A |
+| 650 | [Active Full Backup for Backup Policy Started](event_650.md) | N/A | N/A | N/A | N/A |
+| 652 | [Active Full Backup for Backup Policy Finished](event_652.md) | N/A | N/A | N/A | N/A |
+| 710 | [Agent Backup Job Started](event_710.md) | N/A | N/A | N/A | N/A |
+| 790 | [Agent Backup Job Finished](event_790.md) | N/A | N/A | N/A | N/A |
+| 810 | [Rescan Job Started](event_810.md) | N/A | N/A | N/A | N/A |
+| 890 | [Rescan Job Finished](event_890.md) | N/A | N/A | N/A | N/A |
+| 10010 | [Restore Point Created](event_10010.md) | N/A | N/A | N/A | N/A |
+| 10014 | [Restore Point Offloaded to Tape](event_10014.md) | N/A | N/A | N/A | N/A |
+| 10050 | [Restore Point Deleted](event_10050.md) | TA0040 | T1485, T1490 | AC-2, AC-3, AC-6, CM-6, CM-7, CP-2, CP-7, CP-9, CP-10, SI-3, SI-4, SI-7 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Hardened Repository, Immutability, Veeam ONE |
+| 10090 | [Restore Point Updated](event_10090.md) | N/A | N/A | N/A | N/A |
+| 20114 | [Tape Renamed](event_20114.md) | N/A | N/A | N/A | N/A |
+| 21210 | [Connection to Backup Proxy Restored](event_21210.md) | N/A | N/A | N/A | N/A |
+| 21214 | [Connection to Backup Proxy Lost](event_21214.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Traffic Rules, Multiple Proxies, Veeam ONE |
+| 21220 | [Connection to Backup Repository Restored](event_21220.md) | N/A | N/A | N/A | N/A |
+| 21224 | [Connection to Backup Repository Lost](event_21224.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Scale-Out Backup Repository, Backup Copy, Hardened Repository, Immutability, Veeam ONE |
+| 21230 | [Connection to WAN Accelerator Restored](event_21230.md) | N/A | N/A | N/A | N/A |
+| 21234 | [Connection to WAN Accelerator Lost](event_21234.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Traffic Rules, Multiple WAN Accelerators, Veeam ONE |
+| 23010 | [Job Created](event_23010.md) | N/A | N/A | N/A | N/A |
+| 23050 | [Job Settings Updated](event_23050.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23090 | [Job Deleted](event_23090.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23110 | [Objects for Job Added](event_23110.md) | N/A | N/A | N/A | N/A |
+| 23130 | [Objects for Job Changed](event_23130.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23210 | [SureBackup Job Created](event_23210.md) | N/A | N/A | N/A | N/A |
+| 23220 | [SureBackup Job Settings Updated](event_23220.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23230 | [SureBackup Job Deleted](event_23230.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23310 | [Objects for SureBackup Job Added](event_23310.md) | N/A | N/A | N/A | N/A |
+| 23320 | [Objects for SureBackup Job Deleted](event_23320.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23410 | [Job Assigned as Secondary Destination](event_23410.md) | N/A | N/A | N/A | N/A |
+| 23420 | [Job No Longer Used as Secondary Destination](event_23420.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23440 | [Tape Job Created](event_23440.md) | N/A | N/A | N/A | N/A |
+| 23450 | [Tape Job Settings Updated](event_23450.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23490 | [Tape Job Deleted](event_23490.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23610 | [Tape Media Pool Created](event_23610.md) | N/A | N/A | N/A | N/A |
+| 23611 | [Tape Media Vault Created](event_23611.md) | N/A | N/A | N/A | N/A |
+| 23620 | [Tape Media Pool Updated](event_23620.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23621 | [Tape Media Vault Updated](event_23621.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23622 | [Tape Medium Updated](event_23622.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23623 | [Tape Library Settings Updated](event_23623.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23630 | [Tape Media Pool Deleted](event_23630.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23631 | [Tape Media Vault Deleted](event_23631.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23632 | [Tape Medium Deleted](event_23632.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 23633 | [Tape Library Deleted](event_23633.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24010 | [License Installed](event_24010.md) | N/A | N/A | N/A | N/A |
+| 24020 | [License Expiring](event_24020.md) | N/A | N/A | N/A | N/A |
+| 24030 | [License Expired](event_24030.md) | N/A | N/A | N/A | N/A |
+| 24040 | [License Support Expiring](event_24040.md) | N/A | N/A | N/A | N/A |
+| 24050 | [License Support Expired](event_24050.md) | N/A | N/A | N/A | N/A |
+| 24060 | [License Grace Period Started](event_24060.md) | N/A | N/A | N/A | N/A |
+| 24070 | [License Limit Exceeded](event_24070.md) | N/A | N/A | N/A | N/A |
+| 24080 | [License Removed](event_24080.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24110 | [Tenant Added](event_24110.md) | N/A | N/A | N/A | N/A |
+| 24114 | [Tenant Password Changed](event_24114.md) | TA0003 | T1098 | AC-2, AC-3, AC-5, AC-6, CM-6, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 24120 | [Tenant Deleted](event_24120.md) | TA0040 | T1531 | N/A | N/A |
+| 24130 | [Cloud Gateway Added](event_24130.md) | N/A | N/A | N/A | N/A |
+| 24131 | [Cloud Gateway Settings Updated](event_24131.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24140 | [Cloud Gateway Deleted](event_24140.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24141 | [Cloud Gateway Pool Added](event_24141.md) | N/A | N/A | N/A | N/A |
+| 24142 | [Cloud Gateway Pool Settings Updated](event_24142.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24143 | [Cloud Gateway Pool Deleted](event_24143.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24150 | [Tenant Quota Added](event_24150.md) | N/A | N/A | N/A | N/A |
+| 24160 | [Tenant Quota Changed](event_24160.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24170 | [Tenant Quota Deleted](event_24170.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 24180 | [Cloud Connect Certificate Updated](event_24180.md) | N/A | N/A | N/A | N/A |
+| 25000 | [Tenant State Changed](event_25000.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 25100 | [Tenant Updated](event_25100.md) | N/A | N/A | N/A | N/A |
+| 25200 | [Subtenant Added](event_25200.md) | N/A | N/A | N/A | N/A |
+| 25210 | [Subtenant Deleted](event_25210.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 25220 | [Subtenant Updated](event_25220.md) | TA0003 | T1098 | AC-2, AC-3, AC-5, AC-6, CM-6, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 25230 | [Subtenant State Changed](event_25230.md) | N/A | N/A | N/A | N/A |
+| 25300 | [Credential Record Added](event_25300.md) | N/A | N/A | N/A | N/A |
+| 25400 | [Credential Record Updated](event_25400.md) | TA0003 | T1098 | AC-2, AC-3, AC-5, AC-6, CM-6, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 25500 | [Credential Record Deleted](event_25500.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 25600 | [Hypervisor Host Added](event_25600.md) | N/A | N/A | N/A | N/A |
+| 25700 | [Hypervisor Host Deleted](event_25700.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 25800 | [Hypervisor Host Settings Updated](event_25800.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 25900 | [Failover Plan Created](event_25900.md) | N/A | N/A | N/A | N/A |
+| 26000 | [Failover Plan Settings Updated](event_26000.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 26010 | [Target Location Does Not Match Source Location](event_26010.md) | N/A | N/A | N/A | N/A |
+| 26100 | [Failover Plan Deleted](event_26100.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 26110 | [Failover Plan Failed](event_26110.md) | N/A | N/A | N/A | N/A |
+| 26200 | [Hardware Plan Created](event_26200.md) | N/A | N/A | N/A | N/A |
+| 26300 | [Hardware Plan Settings Updated](event_26300.md) | N/A | N/A | N/A | N/A |
+| 26400 | [Hardware Plan Deleted](event_26400.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 26500 | [Extent State for Scale-Out Backup Repository Changed](event_26500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 26510 | [Cloud Connect State Changed](event_26510.md) | N/A | N/A | N/A | N/A |
+| 26600 | [Failover Plan Started](event_26600.md) | N/A | N/A | N/A | N/A |
+| 26700 | [Failover Plan Stopped](event_26700.md) | N/A | N/A | N/A | N/A |
+| 26800 | [Tenant Replica Started](event_26800.md) | N/A | N/A | N/A | N/A |
+| 26900 | [Tenant Replica Stopped](event_26900.md) | N/A | N/A | N/A | N/A |
+| 27000 | [Tenant Replica Permanent Failover Started](event_27000.md) | N/A | N/A | N/A | N/A |
+| 27100 | [Wan Accelerator Added](event_27100.md) | N/A | N/A | N/A | N/A |
+| 27200 | [Wan Accelerator Settings Updated](event_27200.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 27300 | [Wan Accelerator Deleted](event_27300.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 27400 | [Service Provider Added](event_27400.md) | N/A | N/A | N/A | N/A |
+| 27500 | [Service Provider Updated](event_27500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 27600 | [Service Provider Deleted](event_27600.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 27700 | [Backup Proxy Added](event_27700.md) | N/A | N/A | N/A | N/A |
+| 27800 | [Backup Proxy Settings Updated](event_27800.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 27900 | [Backup Proxy Deleted](event_27900.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28000 | [Backup Repository Added](event_28000.md) | N/A | N/A | N/A | N/A |
+| 28100 | [Backup Repository Settings Updated](event_28100.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28200 | [Backup Repository Deleted](event_28200.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Hardened Repository, Immutability, Veeam ONE |
+| 28300 | [Host Added](event_28300.md) | N/A | N/A | N/A | N/A |
+| 28400 | [Host Settings Updated](event_28400.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28500 | [Host Deleted](event_28500.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 28600 | [Tape Server Added](event_28600.md) | N/A | N/A | N/A | N/A |
+| 28650 | [NDMP Server Added](event_28650.md) | N/A | N/A | N/A | N/A |
+| 28700 | [Tape Server Settings Updated](event_28700.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28750 | [NDMP Server Settings Updated](event_28750.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28800 | [Tape Server Deleted](event_28800.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 28850 | [NDMP Server Deleted](event_28850.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28900 | [File Share Added](event_28900.md) | N/A | N/A | N/A | N/A |
+| 28910 | [File Share Settings Updated](event_28910.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28920 | [File Share Deleted](event_28920.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28930 | [File Server Added](event_28930.md) | N/A | N/A | N/A | N/A |
+| 28940 | [File Server Settings Updated](event_28940.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28950 | [File Server Deleted](event_28950.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28960 | [Object Storage Added](event_28960.md) | N/A | N/A | N/A | N/A |
+| 28970 | [Object Storage Settings Updated](event_28970.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 28980 | [Object Storage Deleted](event_28980.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 29100 | [Protection Group Added](event_29100.md) | N/A | N/A | N/A | N/A |
+| 29110 | [Protection Group Settings Updated](event_29110.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 29120 | [Protection Group Deleted](event_29120.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 29130 | [Objects for Protection Group Added](event_29130.md) | N/A | N/A | N/A | N/A |
+| 29140 | [Objects for Protection Group Changed](event_29140.md) | N/A | N/A | N/A | N/A |
+| 29150 | [Objects for Protection Group Deleted](event_29150.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 29700 | [Archive Object Storage Added](event_29700.md) | N/A | N/A | N/A | N/A |
+| 29800 | [Archive Object Storage Settings Updated](event_29800.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 29900 | [Archive Object Storage Deleted](event_29900.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 30000 | [Scale-Out Backup Repository Added](event_30000.md) | N/A | N/A | N/A | N/A |
+| 30100 | [Scale-Out Backup Repository Settings Updated](event_30100.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 30200 | [Scale-Out Backup Repository Deleted](event_30200.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 30300 | [Application Group Added](event_30300.md) | N/A | N/A | N/A | N/A |
+| 30400 | [Application Group Settings Updated](event_30400.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 30500 | [Application Group Deleted](event_30500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 30600 | [Virtual Lab Added](event_30600.md) | N/A | N/A | N/A | N/A |
+| 30700 | [Virtual Lab Settings Updated](event_30700.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 30800 | [Virtual Lab Deleted](event_30800.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 31000 | [General Settings Updated](event_31000.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 31100 | [Global Settings for Network Traffic Rules Updated](event_31100.md) | N/A | N/A | N/A | N/A |
+| 31200 | [User or Group Added](event_31200.md) | TA0040, TA0003 | T1098, T1565 | AC-2, AC-3, AC-5, AC-6, AC-17, CA-7, CM-6, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31210 | [Adding User or Group Failed](event_31210.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31300 | [Custom Role Added](event_31300.md) | TA0040, TA0003 | T1098, T1565 | AC-2, AC-3, AC-5, AC-6, AC-17, CA-7, CM-6, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31310 | [Custom Role Updated](event_31310.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31320 | [Custom Role Deleted](event_31320.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31400 | [User or Group Deleted](event_31400.md) | TA0040 | T1531 | AC-2, AC-3 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 31500 | [Configuration Backup Job Settings Updated](event_31500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 31600 | [Encryption Password Added](event_31600.md) | TA0040 | T1486, T1490 | AC-2, AC-3, AC-6, CM-6, CP-2, CP-6, CP-7, CP-9, CP-10, SI-4, SI-7 | Multi-Factor Authentication, User Roles, Encryption Keys, Veeam Backup Enterprise Manager, Password Loss Protection, Key Management System Keys, Veeam ONE |
+| 31700 | [Encryption Password Updated](event_31700.md) | TA0040 | T1565, T1486 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Password Loss Protection, Veeam ONE |
+| 31800 | [Encryption Password Deleted](event_31800.md) | TA0040 | T1486 | AC-2, AC-3, AC-6, CM-6, CP-2, CP-6, CP-7, CP-9, CP-10, SI-4, SI-7 | Multi-Factor Authentication, User Roles, Encryption Keys, Veeam Backup Enterprise Manager, Password Loss Protection, Key Management System Keys, Veeam ONE |
+| 31850 | [Encryption Password Verified](event_31850.md) | TA0040 | T1486 | AC-2, AC-3, AC-6, CM-6, CP-2, CP-6, CP-7, CP-9, CP-10, SI-4, SI-7 | Multi-Factor Authentication, User Roles, Encryption Keys, Veeam Backup Enterprise Manager, Password Loss Protection, Key Management System Keys, Veeam ONE |
+| 31900 | [SSH Credentials Changed](event_31900.md) | TA0003 | T1098 | AC-2, AC-3, AC-5, AC-6, CM-6, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Veeam ONE |
+| 32000 | [External Repository Added](event_32000.md) | N/A | N/A | N/A | N/A |
+| 32100 | [External Repository Settings Updated](event_32100.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32120 | [Objects for Job Deleted](event_32120.md) | TA0040 | T1565, T1485 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32200 | [External Repository Deleted](event_32200.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 32300 | [Global Network Traffic Rules Added](event_32300.md) | N/A | N/A | N/A | N/A |
+| 32400 | [Global Network Traffic Rules Deleted](event_32400.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32500 | [Global Network Traffic Rules Updated](event_32500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32600 | [Preferred Networks Updated](event_32600.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32700 | [Preferred Networks Added](event_32700.md) | N/A | N/A | N/A | N/A |
+| 32800 | [Preferred Networks Deleted](event_32800.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 32900 | [Component Updated](event_32900.md) | N/A | N/A | N/A | N/A |
+| 33000 | [Wan Accelerator Cache Populated](event_33000.md) | N/A | N/A | N/A | N/A |
+| 33001 | [Wan Accelerator Cache Cleared](event_33001.md) | N/A | N/A | N/A | N/A |
+| 36011 | [Recovery Token Created](event_36011.md) | N/A | N/A | N/A | N/A |
+| 36012 | [Recovery Token Updated](event_36012.md) | N/A | N/A | N/A | N/A |
+| 36013 | [Recovery Token Deleted](event_36013.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 36014 | [Authentication with Recovery Token Succeeded](event_36014.md) | TA0042 | T1586 | AC-2, IA-2 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 36021 | [Backup Job for Application Backup Policy Started](event_36021.md) | N/A | N/A | N/A | N/A |
+| 36022 | [Backup Job for Application Backup Policy Finished](event_36022.md) | N/A | N/A | N/A | N/A |
+| 36023 | [Backup Task for Application Backup Policy Started](event_36023.md) | N/A | N/A | N/A | N/A |
+| 36024 | [Backup Task for Application Backup Policy Finished](event_36024.md) | N/A | N/A | N/A | N/A |
+| 36025 | [Log Backup Job for Application Backup Policy Started](event_36025.md) | N/A | N/A | N/A | N/A |
+| 36026 | [Log Backup Job for Application Backup Policy Finished](event_36026.md) | N/A | N/A | N/A | N/A |
+| 36100 | [Generic Event for External Infrastructure Created](event_36100.md) | N/A | N/A | N/A | N/A |
+| 36200 | [Connection with Managed Proxy Established](event_36200.md) | N/A | N/A | N/A | N/A |
+| 36300 | [Connection with Managed Proxy Lost](event_36300.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Traffic Rules, Multiple Proxies, Veeam ONE |
+| 36400 | [Connection with Platform Service Established](event_36400.md) | N/A | N/A | N/A | N/A |
+| 36500 | [Connection with Platform Service Lost](event_36500.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Veeam Broker Service, Veeam ONE |
+| 36600 | [Connection from Platform Service to Managed Proxy Established](event_36600.md) | N/A | N/A | N/A | N/A |
+| 36700 | [Connection from Platform Service to Managed Proxy Lost](event_36700.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Traffic Rules, Multiple Proxies, Veeam ONE |
+| 36800 | [Data Synchronization Interrupted](event_36800.md) | TA0040 | T1498, T1489 | AC-2, AC-3, AC-4, AC-5, AC-6, CA-7, CM-5, CM-6, CM-7, SC-7, SI-4 | Traffic Rules, Multiple Proxies, Veeam ONE |
+| 36900 | [Data Synchronization Resumed](event_36900.md) | N/A | N/A | N/A | N/A |
+| 40001 | [Configuration Database Connected](event_40001.md) | N/A | N/A | N/A | N/A |
+| 40002 | [Storage Management Session Finished](event_40002.md) | N/A | N/A | N/A | N/A |
+| 40100 | [Veeam Backup & Replication Console Launched](event_40100.md) | N/A | N/A | N/A | N/A |
+| 40101 | [Veeam Backup & Replication Console Closed](event_40101.md) | N/A | N/A | N/A | N/A |
+| 40200 | [Multi-Factor Authentication Enabled](event_40200.md) | N/A | N/A | N/A | N/A |
+| 40201 | [Multi-Factor Authentication Disabled](event_40201.md) | TA0003, TA0005 | T1556 | AC-2, AC-3, AC-5, AC-6, AC-7, CA-7, CM-5, CM-7, IA-2, IA-5, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 40202 | [Multi-Factor Authentication Token Revoked](event_40202.md) | TA0042, TA0006 | T1586, T1111 | AC-2, AC-20, CA-7, CM-6 , IA-2, IA-5, SI-3, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40203 | [Multi-Factor Authentication for User Enabled](event_40203.md) | N/A | N/A | N/A | N/A |
+| 40204 | [Multi-Factor Authentication for User Disabled](event_40204.md) | TA0003, TA0005 | T1556 | AC-2, AC-3, AC-5, AC-6, AC-7, CA-7, CM-5, CM-7, IA-2, IA-5, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 40205 | [Invalid Code for Multi-Factor Authentication Entered](event_40205.md) | TA0042, TA0006 | T1586, T1111 | AC-2, AC-20, CA-7, CM-6 , IA-2, IA-5, SI-3, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40206 | [Allowed Attempts for Multi-Factor Authentication Exceeded](event_40206.md) | TA0042 | T1586 | AC-2, IA-2 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40207 | [Code for Multi-Factor Authentication Already Used](event_40207.md) | TA0042 | T1586 | AC-2, IA-2 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40210 | [Restore Session Started](event_210_40210.md) | N/A | N/A | N/A | N/A |
+| 40290 | [Restore Session Finished](event_290_40290.md) | N/A | N/A | N/A | N/A |
+| 40300 | [Logs Export Session Finished](event_40300.md) | N/A | N/A | N/A | N/A |
+| 40400 | [Global VM Exclusions Added](event_40400.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40500 | [Global VM Exclusions Deleted](event_40500.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40600 | [Global VM Exclusions Changed](event_40600.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 40700 | [Configuration Backup Job Finished](event_40700.md) | N/A | N/A | N/A | N/A |
+| 40800 | [Configuration Restore Session Finished](event_40800.md) | N/A | N/A | N/A | N/A |
+| 40900 | [Location Added](event_40900.md) | N/A | N/A | N/A | N/A |
+| 40901 | [Location Settings Updated](event_40901.md) | N/A | N/A | N/A | N/A |
+| 40902 | [Location Deleted](event_40902.md) | N/A | N/A | N/A | N/A |
+| 40903 | [Object Location Changed](event_40903.md) | N/A | N/A | N/A | N/A |
+| 41000 | [Downloading Backup Metadata Started](event_41000.md) | N/A | N/A | N/A | N/A |
+| 41001 | [Downloading Backup Metadata Finished](event_41001.md) | N/A | N/A | N/A | N/A |
+| 41200 | [Detaching Backups Started](event_41200.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 41201 | [Copying Backups Started](event_41201.md) | N/A | N/A | N/A | N/A |
+| 41202 | [Moving Backups Started](event_41202.md) | N/A | N/A | N/A | N/A |
+| 41300 | [License Report Created](event_41300.md) | N/A | N/A | N/A | N/A |
+| 41301 | [Automatic License Update Disabled](event_41301.md) | N/A | N/A | N/A | N/A |
+| 41302 | [License Consumption for Veeam Agents Disabled](event_41302.md) | N/A | N/A | N/A | N/A |
+| 41303 | [Object License Revoked](event_41303.md) | N/A | N/A | N/A | N/A |
+| 41304 | [Object License Removed](event_41304.md) | N/A | N/A | N/A | N/A |
+| 41305 | [Object License Assigned](event_41305.md) | N/A | N/A | N/A | N/A |
+| 41306 | [Proactive Support Disabled](event_41306.md) | N/A | N/A | N/A | N/A |
+| 41400 | [Storage Added](event_41400.md) | N/A | N/A | N/A | N/A |
+| 41401 | [Storage Settings Updated](event_41401.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 41402 | [Storage Deleted](event_41402.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Configuration Backup, Veeam ONE |
+| 41403 | [Storage Rescan Started Manually](event_41403.md) | N/A | N/A | N/A | N/A |
+| 41404 | [Storage Rescan Started Automatically](event_41404.md) | N/A | N/A | N/A | N/A |
+| 41405 | [Storage Rescan Finished](event_41405.md) | N/A | N/A | N/A | N/A |
+| 41500 | [Restore Point Mounted](event_41500.md) | N/A | N/A | N/A | N/A |
+| 41510 | [Restore Point Unmounted](event_41510.md) | N/A | N/A | N/A | N/A |
+| 41600 | [Malware Activity Detected](event_41600.md) | TA0002, TA0040 | T1204, T1486 | AC-3, AC-4, AC-6, CA-7, SC-44, SC-7, SI-2, SI-3, SI-4, CP-2, CP-6, CP-7, CP-9, CP-10 | Entropy Analysis, Yara Scan, Hardened Repository, DISA STIG, Antivirus Integration, SureBackup, Veeam Incident API, Security Compliance, Backup Copy, Object Storage, Veeam ONE |
+| 41610 | [Object Marked as Clean](event_41610.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 41615 | [Object Automatically Marked as Clean](event_41615.md) | N/A | N/A | N/A | N/A |
+| 41700 | [Health Check Job Started](event_41700.md) | N/A | N/A | N/A | N/A |
+| 41710 | [Health Check Job Finished](event_41710.md) | N/A | N/A | N/A | N/A |
+| 41800 | [Attempt to Delete Backup Failed](event_41800.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 41810 | [Attempt To Update Security Object Failed](event_41810.md) | TA0005 | T1562 | AC-2, AC-3, AC-5, AC-6, CA-7, CM-5, CM-6, CM7, IA-4 | Multi-Factor Authentication, User Roles, Managed Mode, Veeam Service Provider Console |
+| 42000 | [Downloading Object Storage Backup Metadata Started](event_42000.md) | N/A | N/A | N/A | N/A |
+| 42001 | [Downloading Object Storage Backup Metadata Finished](event_42001.md) | N/A | N/A | N/A | N/A |
+| 42200 | [Malware Detection Session Started](event_42200.md) | N/A | N/A | N/A | N/A |
+| 42210 | [Malware Detection Session Finished](event_42210.md) | N/A | N/A | N/A | N/A |
+| 42220 | [Restore Point Marked as Infected](event_42220.md) | TA0002, TA0040 | T1204, T1486 | AC-3, AC-4, AC-6, CA-7, SC-44, SC-7, SI-2, SI-3, SI-4, CP-2, CP-6, CP-7, CP-9, CP-10 | Entropy Analysis, Yara Scan, Hardened Repository, DISA STIG, Antivirus Integration, SureBackup, Veeam Incident API, Security Compliance, Backup Copy, Object Storage, Veeam ONE |
+| 42230 | [Restore Point Marked as Clean](event_42230.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42260 | [Objects Added to Malware Detection Exclusions](event_42260.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42270 | [Objects Deleted from Malware Detection Exclusions](event_42270.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42280 | [Malware Detection Exclusions List Updated](event_42280.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42290 | [Malware Detection Settings Updated](event_42290.md) | TA0040, TA0005 | T1565, T1562 | AC-2, AC-3, AC-4, AC-5, AC-6, AC-16, AC-17, AC-20, CA-7, CM-5, CM-6, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42300 | [KMS Server Added](event_42300.md) | N/A | N/A | N/A | N/A |
+| 42301 | [KMS Server Deleted](event_42301.md) | TA0040 | T1565, T1485, T1490 | AC-2, AC-3, AC-4, AC-6, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-2, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42302 | [KMS Server Settings Updated](event_42302.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42400 | [Four-Eyes Authorization Enabled](event_42400.md) | N/A | N/A | N/A | N/A |
+| 42401 | [Four-Eyes Authorization Disabled](event_42401.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42402 | [Four-Eyes Authorization Request Created](event_42402.md) | TA0040 | T1485 | AC-2, AC-3, AC-6, CM-6, CM-7, CP-2, CP-7, CP-9, CP-10, SI-3, SI-4, SI-7 | Multi-Factor Authentication, Four-Eyes Authorization, User Roles, Veeam ONE |
+| 42403 | [Four-Eyes Authorization Request Approved](event_42403.md) | N/A | N/A | N/A | N/A |
+| 42404 | [Four-Eyes Authorization Request Rejected](event_42404.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42405 | [Four-Eyes Authorization Request Expired](event_42405.md) | TA0040 | T1565 | AC-2, AC-3, AC-4, AC-16, AC-17, AC-20, CA-7, CM-7, CM-8, CP-6, CP-7, CP-9, CP-10, SC-4, SC-7, SI-4 | Multi-Factor Authentication, User Roles, Configuration Backup, Veeam ONE |
+| 42500 | [KMS Key Rotation Job Finished](event_42500.md) | N/A | N/A | N/A | N/A |
+| 42800 | [SAML Settings Updated](event_42800.md) | N/A | N/A | N/A | N/A |
+| 43000 | [High Availability Cluster Created](event_43000.md) | N/A | N/A | N/A | N/A |
+| 43001 | [High Availability Cluster Updated](event_43001.md) | N/A | N/A | N/A | N/A |
+| 43002 | [High Availability Cluster Removed](event_43002.md) | N/A | N/A | N/A | N/A |
+| 43003 | [High Availability Cluster State Changed](event_43003.md) | N/A | N/A | N/A | N/A |
+| 43004 | [High Availability Cluster Failover Started](event_43004.md) | N/A | N/A | N/A | N/A |
+| 43006 | [High Availability Cluster Switchover Started](event_43006.md) | N/A | N/A | N/A | N/A |
+| 44000 | [Token Request Approved](event_44000.md) | N/A | N/A | N/A | N/A |
+| 44001 | [Token Request Rejected](event_44001.md) | N/A | N/A | N/A | N/A |
+| 44002 | [User Authorization Denied](event_44002.md) | N/A | N/A | N/A | N/A |
+| 44003 | [User Authorization Granted](event_44003.md) | N/A | N/A | N/A | N/A |
+| 44004 | [Password Change Required](event_44004.md) | N/A | N/A | N/A | N/A |
+| 44005 | [Token Chain Revoked](event_44005.md) | N/A | N/A | N/A | N/A |
+| 44006 | [Resource Access Denied](event_44006.md) | N/A | N/A | N/A | N/A |
+
+

--- a/docs/events/event_licenses.md
+++ b/docs/events/event_licenses.md
@@ -1,0 +1,15 @@
+---
+title: "Licenses"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_licenses.html"
+last_updated: "4/3/2025"
+product_version: "13.0.1.1071"
+---
+
+# Licenses
+
+
+This section contains Veeam Backup & Replication events related to product license usage. For events related to Veeam Agent license usage, see [Agent Management](event_agent_management.md).
+
+

--- a/docs/events/event_malware_detection.md
+++ b/docs/events/event_malware_detection.md
@@ -1,0 +1,15 @@
+---
+title: "Malware Detection"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_malware_detection.html"
+last_updated: "4/3/2025"
+product_version: "13.0.1.1071"
+---
+
+# Malware Detection
+
+
+This section contains Veeam Backup & Replication events related to malware detection.
+
+

--- a/docs/events/event_proxy.md
+++ b/docs/events/event_proxy.md
@@ -1,0 +1,15 @@
+---
+title: "Proxy Servers"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_proxy.html"
+last_updated: "4/26/2024"
+product_version: "13.0.1.1071"
+---
+
+# Proxy Servers
+
+
+This section contains Veeam Backup & Replication events related to backup proxy servers.
+
+

--- a/docs/events/event_repositories.md
+++ b/docs/events/event_repositories.md
@@ -1,0 +1,15 @@
+---
+title: "Repositories"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_repositories.html"
+last_updated: "5/3/2024"
+product_version: "13.0.1.1071"
+---
+
+# Repositories
+
+
+This section contains Veeam Backup & Replication events related to backup repositories.
+
+

--- a/docs/events/event_repositories_backup.md
+++ b/docs/events/event_repositories_backup.md
@@ -1,0 +1,15 @@
+---
+title: "Backup Repositories"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_repositories_backup.html"
+last_updated: "5/2/2024"
+product_version: "13.0.1.1071"
+---
+
+# Backup Repositories
+
+
+This section contains Veeam Backup & Replication events related to backup repositories.
+
+

--- a/docs/events/event_repositories_external.md
+++ b/docs/events/event_repositories_external.md
@@ -1,0 +1,15 @@
+---
+title: "External Backup Repositories"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_repositories_external.html"
+last_updated: "3/4/2025"
+product_version: "13.0.1.1071"
+---
+
+# External Backup Repositories
+
+
+This section contains Veeam Backup & Replication events related to external backup repositories.
+
+

--- a/docs/events/event_restore.md
+++ b/docs/events/event_restore.md
@@ -1,0 +1,15 @@
+---
+title: "Restore"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_restore.html"
+last_updated: "5/21/2024"
+product_version: "13.0.1.1071"
+---
+
+# Restore
+
+
+This section contains Veeam Backup & Replication events related to data recovery.
+
+

--- a/docs/events/event_servers.md
+++ b/docs/events/event_servers.md
@@ -1,0 +1,15 @@
+---
+title: "Servers and Hosts"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_servers.html"
+last_updated: "4/25/2024"
+product_version: "13.0.1.1071"
+---
+
+# Servers and Hosts
+
+
+This section contains Veeam Backup & Replication events related to virtualization servers and hosts.
+
+

--- a/docs/events/event_subtenants.md
+++ b/docs/events/event_subtenants.md
@@ -1,0 +1,15 @@
+---
+title: "Subtenants"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_subtenants.html"
+last_updated: "5/22/2024"
+product_version: "13.0.1.1071"
+---
+
+# Subtenants
+
+
+This section contains Veeam Backup & Replication events related to subtenants.
+
+

--- a/docs/events/event_surebackup.md
+++ b/docs/events/event_surebackup.md
@@ -1,0 +1,15 @@
+---
+title: "SureBackup"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_surebackup.html"
+last_updated: "5/15/2024"
+product_version: "13.0.1.1071"
+---
+
+# SureBackup
+
+
+This section contains Veeam Backup & Replication events related to SureBackup.
+
+

--- a/docs/events/event_tapes.md
+++ b/docs/events/event_tapes.md
@@ -1,0 +1,15 @@
+---
+title: "Tapes"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_tapes.html"
+last_updated: "5/15/2024"
+product_version: "13.0.1.1071"
+---
+
+# Tapes
+
+
+This section contains Veeam Backup & Replication events related to tape devices.
+
+

--- a/docs/events/event_tenants.md
+++ b/docs/events/event_tenants.md
@@ -1,0 +1,15 @@
+---
+title: "Tenants"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_tenants.html"
+last_updated: "5/22/2024"
+product_version: "13.0.1.1071"
+---
+
+# Tenants
+
+
+This section contains Veeam Backup & Replication events related to tenants.
+
+

--- a/docs/events/event_unstructured_data_backup.md
+++ b/docs/events/event_unstructured_data_backup.md
@@ -1,0 +1,15 @@
+---
+title: "Unstructured Data Backup"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_unstructured_data_backup.html"
+last_updated: "5/14/2024"
+product_version: "13.0.1.1071"
+---
+
+# Unstructured Data Backup
+
+
+This section contains Veeam Backup & Replication events related to unstructured data backup.
+
+

--- a/docs/events/event_users.md
+++ b/docs/events/event_users.md
@@ -1,0 +1,15 @@
+---
+title: "Users"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_users.html"
+last_updated: "12/5/2025"
+product_version: "13.0.1.1071"
+---
+
+# Users
+
+
+This section contains Veeam Backup & Replication events related to users and user authentication.
+
+

--- a/docs/events/event_vbr_console.md
+++ b/docs/events/event_vbr_console.md
@@ -1,0 +1,15 @@
+---
+title: "Veeam Backup & Replication Console"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_vbr_console.html"
+last_updated: "4/24/2024"
+product_version: "13.0.1.1071"
+---
+
+# Veeam Backup & Replication Console
+
+
+This section contains Veeam Backup & Replication events related to the Veeam Backup & Replication console.
+
+

--- a/docs/events/event_wan.md
+++ b/docs/events/event_wan.md
@@ -1,0 +1,15 @@
+---
+title: "WAN Accelerators"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/event_wan.html"
+last_updated: "4/26/2024"
+product_version: "13.0.1.1071"
+---
+
+# WAN Accelerators
+
+
+This section contains Veeam Backup & Replication events related to WAN accelerators.
+
+

--- a/docs/events/overview.md
+++ b/docs/events/overview.md
@@ -1,0 +1,15 @@
+---
+title: "About Veeam Backup & Replication Event Reference"
+product: "vbr"
+doc_type: "events"
+source_url: "https://helpcenter.veeam.com/docs/vbr/events/overview.html"
+last_updated: "9/3/2025"
+product_version: "13.0.1.1071"
+---
+
+# About Veeam Backup & Replication Event Reference
+
+
+This reference provides information about events written by Veeam Backup & Replication.
+
+

--- a/docs/powershell/get-vbrbackuprepository.md
+++ b/docs/powershell/get-vbrbackuprepository.md
@@ -1,13 +1,14 @@
 ---
 title: "Get-VBRBackupRepository"
+product: "vbr"
+doc_type: "powershell"
 source_url: "https://helpcenter.veeam.com/docs/vbr/powershell/get-vbrbackuprepository.html"
-last_updated: "4/3/2024"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Get-VBRBackupRepository
 
-In this article
 
 Short Description
 
@@ -49,7 +50,10 @@ This cmdlet supports Microsoft PowerShell common parameters. For more informatio
 
 Output Object
 
-The cmdlet returns the CBackupRepository object that contains settings of backup repositories added to the backup infrastructure.
+The cmdlet returns one of the following objects:
+
+* VBRScaleOutBackupRepository — if you specify the ScaleOut parameter.
+* CBackupRepository — if you do not specify the ScaleOut parameter.
 
 Examples
 
@@ -77,6 +81,4 @@ Examples
 | --- | --- |
 | This command gets scale-out backup repository named  Veeam Performance Scale-Out Repository.  |  | | --- | | Get-VBRBackupRepository -ScaleOut -Name "Veeam Performance Scale-Out Repository" | |
 
-Page updated 4/3/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/used_ports.md
+++ b/docs/used_ports.md
@@ -3,7 +3,7 @@ title: "Ports"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html"
-last_updated: "1/19/2026"
+last_updated: "1/20/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -100,9 +100,9 @@ Outgoing Connections
 | NTP server | UDP | 123 | Port used by backup servers deployed from the Veeam Software Appliance ISO for synchronization with NTP time servers. |
 | NTS server | UDP | 123 | Ports used by backup servers deployed from the Veeam Software Appliance ISO for synchronization with NTS time servers. |
 | TCP | 4460 |
-| Active Directory Domain Controller | TCP | 636, 3268, 3269 | Ports used for communications over LDAP and LDAPS protocols. |
+| Active Directory Domain Controllers | TCP | 636, 3268, 3269 | Ports used for communications over LDAP and LDAPS protocols. |
 | UDP, TCP | 389 |
-| UDP, TCP | 445, 139 | Ports used for communications over SMB (Samba) protocol. |
+| UDP, TCP | 445, 139 | Ports used for communications over SMB protocol. |
 | UDP, TCP | 88 | Port used for Kerberos authentication. |
 
 Backup & Replication Console
@@ -245,7 +245,7 @@ The following table describes network ports that must be opened to ensure proper
 | From | To | Protocol | Port | Notes |
 | --- | --- | --- | --- | --- |
 | Gateway server or backup proxy | SMB (CIFS) backup repository (Microsoft Windows) | TCP | 445 | Port used as a transmission channel from the gateway server to the target SMB (CIFS) backup repository if a gateway server is specified explicitly in SMB (CIFS) backup repository settings. |
-| Active Directory Domain Controller | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
+| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
 | TCP | 88 | Port used for Kerberos authentication. |
 
 Dell Data Domain System
@@ -573,7 +573,7 @@ File Share Connections
 | NAS filer (Dell PowerScale (formerly Isilon) or Nutanix Files storage system) | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
 | TCP | 445 | Standard SMB port. |
 | TCP | 20048 | Port used for the NFS mountd access and service request monitoring. |
-| Active Directory Domain Controller | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
+| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
 | TCP | 88 | Port used for Kerberos authentication. |
 | File server (Windows or Linux), backup proxy or tape server | NFS share | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
 | SMB share | TCP | 445 | Standard SMB port. |
@@ -582,7 +582,7 @@ File Share Connections
 | Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
 | Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access |
 | S3 compatible object storage | TCP | Depends on device configuration | Port used to communicate with S3 compatible object storage. |
-| Active Directory Domain Controller | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
+| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
 | TCP | 88 | Port used for Kerberos authentication. |
 | Mount server | SMB share | TCP | 137-139, 443, 445, 6170 | Ports used during Instant File Share Recovery. |
 

--- a/docs/using_gmsa.md
+++ b/docs/using_gmsa.md
@@ -1,13 +1,14 @@
 ---
 title: "Using Group Managed Service Accounts"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/using_gmsa.html"
-last_updated: "1/9/2026"
+last_updated: "1/19/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Using Group Managed Service Accounts
 
-In this article
 
 A Group Managed Service Account (gMSA) is the type of domain account configured on the server. It does not need the administrator to manage the password as this role is performed by the Microsoft Windows operating system. Randomly generated complex passwords are automatically changed every 30 days which reduce the risk of brute force and dictionary attacks. For more information about gMSAs, see [this Microsoft article](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/service-accounts-group-managed).
 
@@ -16,7 +17,7 @@ You can use gMSAs to only run guest processing tasks.
 |  |
 | --- |
 | Note |
-| For application-aware processing, using a gMSA is supported for backups or replicas of VMs that run Microsoft Active Directory (domain controllers), Microsoft Exchange, Microsoft SQL Server, and Oracle 12c Release 2 and later. You cannot back up or replicate VMs that run Microsoft SharePoint with the gMSA. |
+| Consider the following regarding application-aware processing:   * For image-level backups or replicas, using a gMSA is supported for VMs that run Microsoft Active Directory (domain controllers), Microsoft Exchange, Microsoft SQL Server, and Oracle 12c Release 2 and later. You cannot back up or replicate VMs that run Microsoft SharePoint with the gMSA. * For Veeam Agent backups, using a gMSA is supported only in [backup jobs managed by the backup server](agents_job_mode.md), and only for [Microsoft SQL Server](agent_job_vss_sql.md) and [scripts](agent_job_vss_scripts.md) processing. |
 
 Requirements and Limitations
 
@@ -131,6 +132,4 @@ To run guest processing tasks with the gMSA, do the following:
 1. Add the gMSA account type to the Credentials Manager. For more information, see [Group Managed Service Accounts](credentials_manager_gmsa.md).
 2. Select the gMSA when specifying guest OS credentials for jobs or policies.
 
-Page updated 1/9/2026
 
-Page content applies to build 13.0.1.1071


### PR DESCRIPTION
## Documentation Update - VBR

Scraped from [Veeam Help Center](https://helpcenter.veeam.com) on 2026-01-21.

### Summary

| Type | New | Updated (Content) | Updated (Metadata) | Deleted |
|------|-----|-------------------|-------------------|---------|
| Markdown | 349 | 13 | 3 | 0 |
| Images | 0 | 0 | - | 0 |
### New Pages (349)

#### Events (349)

- `docs/events/event_10010.md` - Restore Point Created
- `docs/events/event_10014.md` - Restore Point Offloaded to Tape
- `docs/events/event_10050.md` - Restore Point Deleted
- `docs/events/event_10090.md` - Restore Point Updated
- `docs/events/event_110.md` - Backup Job Started
- `docs/events/event_114.md` - File to Tape Job Started
- `docs/events/event_115.md` - Tape Erase Job Started
- `docs/events/event_116.md` - Tape Inventorying Job Started
- `docs/events/event_117.md` - Tape Cataloging Job Started
- `docs/events/event_118.md` - Tape Verification Job Started
- `docs/events/event_119.md` - Tape Export Job Started
- `docs/events/event_120.md` - Tape Copy Job Started
- `docs/events/event_121.md` - Tape Eject Job Started
- `docs/events/event_122.md` - Mark Tape As Free Job Started
- `docs/events/event_123.md` - Move To Media Pool Job Started
- `docs/events/event_124.md` - Delete From Library Job Started
- `docs/events/event_125.md` - Library Discovery Job Started
- `docs/events/event_126.md` - Tape Import Job Started
- `docs/events/event_150.md` - Backup Task Finished
- `docs/events/event_151.md` - File Backup Job Finished
- ... and 329 more pages\n

### Content Updates (13)

#### Em (2)

| File | Changes | Summary |
|------|---------|---------|
| `docs/em/em_installation_byb.md` | +2/-2 | The article was updated to reference the Veeam Backup & Replication 13.0.1 Release Notes. |
| `docs/em/em_upgrade_byb.md` | +2/-2 | The article was updated to reference the Veeam Backup & Replication 13.0.1 Release Notes. |

#### Entraid (1)

| File | Changes | Summary |
|------|---------|---------|
| `docs/entraid/entra_id_ports.md` | +3/-3 | The article was updated to clarify that Veeam Backup for Microsoft Entra ID does not support remote backup proxies. |

#### Powershell (1)

| File | Changes | Summary |
|------|---------|---------|
| `docs/powershell/get-vbrbackuprepository.md` | +7/-5 | The article was updated to reflect the correct output object. |

#### Userguide (9)

| File | Changes | Summary |
|------|---------|---------|
| `docs/agent_job_vss_oracle.md` | +6/-5 | The article was updated to clarify that the Oracle account with SYSDBA privileges must be configured as specified in the "Permissions for Guest Processing" section. |
| `docs/agent_job_vss_scripts.md` | +6/-5 | The article was updated to specify that the account used to run pre-freeze and post-thaw scripts must be a Microsoft Windows user account or a Group Managed Service Account (gMSA). |
| `docs/agent_job_vss_sharepoint.md` | +4/-5 | The article was updated to clarify that the SharePoint admin account must be configured as specified in the "Permissions for Guest Processing" section. |
| `docs/agent_job_vss_sql.md` | +6/-5 | The article was updated to specify that the account used to connect to Microsoft SQL Server must be a Microsoft Windows user account or a Group Managed Service Account (gMSA) with roles and permissions as specified in the "Permissions for Guest Processing" section. |
| `docs/agent_policy_win_vss_oracle.md` | +4/-5 | The article was updated to clarify that the Oracle account with SYSDBA privileges must be configured as specified in the "Permissions for Guest Processing" section. |
| `docs/agent_policy_win_vss_sharepoint.md` | +4/-5 | The article was updated to clarify that the SharePoint admin account must be configured as specified in the "Permissions for Guest Processing" section. |
| `docs/backup_repo_edit.md` | +6/-5 | The article was updated to add a note about the unit of measurement for GB and TB. |
| `docs/used_ports.md` | +6/-6 | The article was updated to clarify the usage of ports for communication with Active Directory Domain Controllers. |
| `docs/using_gmsa.md` | +4/-5 | The article was updated to clarify the usage of Group Managed Service Accounts (gMSAs) for application-aware processing and Veeam Agent backups. |


### Metadata-Only Updates (3)

<details><summary>3 files with only frontmatter changes (version, date)</summary>

- `docs/mongo_protected_computers_update.md`
- `docs/tape_decrypt_kms.md`
- `docs/tape_decrypt_password.md`

</details>

---
*Automatically generated by [veeam-docs-scraper](https://github.com/comnam90/veeam-docs-scraper)*
