### PR TITLE
docs(vbr): documentation update 2026-01-27

### DIFF
--- a/docs/about_backup.md
+++ b/docs/about_backup.md
@@ -1,13 +1,14 @@
 ---
 title: "About Backup"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/about_backup.html"
-last_updated: "2/10/2025"
+last_updated: "1/14/2026"
 product_version: "13.0.1.1071"
 ---
 
 # About Backup
 
-In this article
 
 Veeam Backup & Replication is built for virtual environments. It operates at the virtualization layer and uses an image-based approach for VM backup.
 
@@ -40,6 +41,4 @@ In This Section
 * [Resume on Disconnect](replica_resume_disconnect.md)
 * [Snapshot Hunter](snapshot_hunter.md)
 
-Page updated 2/10/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/adding_object_storage.md
+++ b/docs/adding_object_storage.md
@@ -1,15 +1,21 @@
 ---
 title: "Adding Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/adding_object_storage.html"
-last_updated: "7/22/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Adding Object Storage
 
-In this article
 
 You can add various object storage systems as sources of unstructured data available for protection by Veeam Backup & Replication.
+
+|  |
+| --- |
+| Important |
+| Veeam Backup & Replication does not support Google Cloud object storage as a source for unstructured data backups. |
 
 In This Section
 
@@ -18,6 +24,4 @@ In This Section
 * [Adding Microsoft Azure Object Storage](os_azure_add.md)
 * [Adding Microsoft Data Lake](os_data_lake_add.md)
 
-Page updated 7/22/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/appgroup_before_you_begin.md
+++ b/docs/appgroup_before_you_begin.md
@@ -1,17 +1,18 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/appgroup_before_you_begin.html"
-last_updated: "8/7/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create an application group, consider the following:
 
-* A valid license for Enterprise edition of Veeam Backup & Replication must be installed on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * All applications and services on which verified machines are dependent must be virtualized in your environment.
 * If you plan to scan machines data for malware, [check requirements and limitations](av_scan_about.md#av_limitations).
 * If you plan to verify machines with a ping test, the firewall on tested machine must allow ping requests.
@@ -24,6 +25,4 @@ Before you create an application group, consider the following:
 
 * [For storage snapshots] The storage system must be added to the backup infrastructure.
 
-Page updated 8/7/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/appgroup_before_you_begin_hv.md
+++ b/docs/appgroup_before_you_begin_hv.md
@@ -1,17 +1,18 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/appgroup_before_you_begin_hv.html"
-last_updated: "8/7/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create and start a recovery verification job, check the following prerequisites:
 
-* A valid license for Enterprise edition of Veeam Backup & Replication must be installed on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * All applications and services on which verified machines are dependent must be virtualized in your environment.
 * If you plan to scan machines data for malware, [check requirements and limitations](av_scan_about.md#av_limitations).
 * If you plan to verify machines with a ping test, the firewall on tested machines must allow ping requests.
@@ -22,6 +23,4 @@ Before you create and start a recovery verification job, check the following pre
 * To open a console of a verified machine, you must have the RDP client version 7.0 and later installed on the backup server. The RDP client is pre-installed on Microsoft Windows 7 OS and later.
 * You cannot add to application groups VMs from backups created with backup copy jobs and backups stored in Cloud Connect backup repositories.
 
-Page updated 8/7/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/archiver_appliance.md
+++ b/docs/archiver_appliance.md
@@ -1,13 +1,14 @@
 ---
 title: "Archiver Appliances"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/archiver_appliance.html"
-last_updated: "9/19/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Archiver Appliances
 
-In this article
 
 Archiver appliance is a temporary virtual machine that is located in the Public Cloud (AWS or Microsoft Azure). Veeam Backup & Replication uses it for the following operations:
 
@@ -32,7 +33,7 @@ Consider the following:
 
 * The archiver appliance is used in case extents of your scale-out backup repository consists of the same object storage providers. For example, performance or capacity extents consist of [Microsoft Azure Blob storage](osr_adding_blob_storage.md) and the archive extent consist of [Azure Archive Storage](azure_archive_tier_archiver_appliance.md). If your scale-out backup repository has a mixed configuration, for example performance or capacity extents consist of an [Adding S3 Compatible Object Storage](adding_s3c_object_storage.md) and the archive extent consist of Azure Archive Storage, Veeam Backup & Replication will use the other component for the data transfer operation that might result in additional costs.
 
-* The archiever appliance is not used for the direct data transfer from the performance tier to the archive tier if your scale-out backup repository has the following configuration:
+* The archiver appliance is not used for the direct data transfer from the performance tier to the archive tier if your scale-out backup repository has the following configuration:
 
 * The archive tier consists of S3 compatible object storage with data archiving.
 * The performance tier consist of a direct attached storage or network attached storage and the archive tier consist of Amazon S3 object storage or Microsoft Azure Blob storage.
@@ -42,6 +43,4 @@ In these cases, the component that transfers data depends on the connection type
 * If you use the direct connection type, the data mover that runs on performance extents transfers data to the archive tier.
 * If you use the connection through gateway servers, the specified gateway servers transfer data to the archive tier.
 
-Page updated 9/19/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/background_retention_job.md
+++ b/docs/background_retention_job.md
@@ -1,15 +1,18 @@
 ---
 title: "Background Retention"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/background_retention_job.html"
-last_updated: "11/27/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Background Retention
 
-In this article
 
-In addition to applying a retention policy ([short-term retention](retention_policy.md) and [long-term retention](gfs_retention_policy.md)) within a job session, Veeam Backup & Replication performs background retention for backups. The background retention aims mostly at backups that are no longer processed by jobs (orphaned backups shown in the node with the (Orphaned) postfix). However, this retention can also be helpful for standard backups, in case backups are created by jobs without a schedule, the job retention has not been applied yet or failed for some reason, and so on.
+In addition to applying a retention policy ([short-term retention](retention_policy.md) and [long-term retention](gfs_retention_policy.md)) within a job session, Veeam Backup & Replication performs background retention for backups. Background retention mostly targest backups that are no longer processed by jobs (orphaned backups shown in the node with the (Orphaned) postfix). In such cases, background retention uses the last known retention settings and can delete the entire backup. Background retention is the only method for deleting the outdated restore points and backups.
+
+However, background retention can also apply to backups that still have an associated job. In these cases, background retention follows the retention settings of the job and the presence or absence of a schedule does not affect the process. It always leaves 3 restore points, even if all the points are outdated. Background retention is especially useful for jobs without a schedule, where there can be an outdated storage before the next manual run.
 
 The background retention starts automatically every 24 hours at 00:30, runs in the background and consists of the following activities:
 
@@ -19,6 +22,8 @@ The background retention starts automatically every 24 hours at 00:30, runs in t
 * Backup cleanup
 * Deleted Agent retention
 * Storage system snapshot retention
+
+It can also be started manually at any time through the [Apply retention](backup_background_retention_launch.md) option.
 
 Limitations
 
@@ -50,6 +55,7 @@ Consider the following:
 * [For backups created with Veeam Agent for Windows operating in standalone or managed by Veeam Agent mode] For backups linked to jobs basic retention does not apply.
 * Unlike the job retention, the background retention does not merge data from one backup file to another; it just deletes files. In the case of forever forward incremental and forward incremental backup chains, the background retention deletes incremental files only after the last increment in the related part of the backup chain becomes outdated.
 * The background retention does not delete backup files if they are locked by other processes. The retention waits until the backup file is unlocked.
+* Background retention requires free space in the target repository for the generated metadata file (.VBM). If the backup repository does not have enough free disk space, the background retention task (including manual Apply retention option) will fail. Ensure the repository has sufficient free space before you run background retention.
 * You can launch the background retention manually as described in section [Launching Background Retention](backup_background_retention_launch.md).
 
 Background Basic Retention
@@ -96,6 +102,4 @@ Related Links
 * [Launching Background Retention](backup_background_retention_launch.md)
 * [Disabling Background Retention](backup_background_retention_disable.md)
 
-Page updated 11/27/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/background_retention_job_hv.md
+++ b/docs/background_retention_job_hv.md
@@ -1,15 +1,18 @@
 ---
 title: "Background Retention"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/background_retention_job_hv.html"
-last_updated: "11/27/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Background Retention
 
-In this article
 
-In addition to applying a retention policy ([short-term retention](retention_policy_hv.md) and [long-term retention](gfs_retention_policy_hv.md)) within a job session, Veeam Backup & Replication performs background retention for backups. The background retention aims mostly at backups that are no longer processed by jobs (orphaned backups shown in the node with the (Orphaned) postfix). However, this retention can also be helpful for standard backups, in case backups are created by jobs without a schedule, the job retention has not been applied yet or failed for some reason, and so on.
+In addition to applying a retention policy ([short-term retention](retention_policy_hv.md) and [long-term retention](gfs_retention_policy_hv.md)) within a job session, Veeam Backup & Replication performs background retention for backups. Background retention mostly targest backups that are no longer processed by jobs (orphaned backups shown in the node with the (Orphaned) postfix). In such cases, background retention uses the last known retention settings and can delete the entire backup. Background retention is the only method for deleting the outdated restore points and backups.
+
+However, background retention can also apply to backups that still have an associated job. In these cases, background retention follows the retention settings of the job and the presence or absence of a schedule does not affect the process. It always leaves 3 restore points, even if all the points are outdated. Background retention is especially useful for jobs without a schedule, where there can be an outdated storage before the next manual run.
 
 The background retention starts automatically every 24 hours at 00:30, runs in the background and consists of the following activities:
 
@@ -18,6 +21,8 @@ The background retention starts automatically every 24 hours at 00:30, runs in t
 * Background log retention
 * Backup cleanup
 * Deleted Agent retention
+
+It can also be started manually at any time through the [Apply retention](backup_background_retention_launch_hv.md) option.
 
 Limitations
 
@@ -52,6 +57,9 @@ Consider the following:
 * [For backups created with Veeam Agent for Windows operating in standalone or managed by Veeam Agent mode] For backups linked to jobs basic retention does not apply.
 * Unlike the job retention, the background retention does not merge data from one backup file to another; it just deletes files. In the case of forever forward incremental and forward incremental backup chains, the background retention deletes incremental files only after the last increment in the related part of the backup chain becomes outdated.
 * The background retention does not delete backup files if they are locked by other processes. The retention waits until the backup file is unlocked.
+
+* Background retention requires free space in the target repository for the generated metadata file (.VBM). If the backup repository does not have enough free disk space, the background retention task (including manual Apply retention option) will fail. Ensure the repository has sufficient free space before you run background retention.
+
 * You can launch the background retention manually as described in section [Launching Background Retention](backup_background_retention_launch_hv.md).
 
 Background Basic Retention
@@ -94,6 +102,4 @@ Related Links
 * [Launching Background Retention](backup_background_retention_launch_hv.md)
 * [Disabling Background Retention](backup_background_retention_disable_hv.md)
 
-Page updated 11/27/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_copy_before_you_begin.md
+++ b/docs/backup_copy_before_you_begin.md
@@ -1,13 +1,14 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_before_you_begin.html"
-last_updated: "10/21/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create a backup copy job, check the following prerequisites:
 
@@ -27,11 +28,9 @@ To upload scripts to the Linux backup server, in the Veeam Backup & Replication 
 * If you plan to copy backups to an HPE StoreOnce repository, [check limitations and requirements](deduplicating_appliance_storeonce.md) for it.
 * If you plan to copy Veeam Agents backups, see [Veeam Agent Backup](agent_backup_backup_copy.md) for limitations and requirements.
 * If you plan to copy backups to an immutable repository, you must enable the GFS retention policy. For more information, see [Long-Term Retention Policy (GFS)](backup_copy_gfs.md).
-* If you plan to use WAN accelerators, check that you use the Enterprise Plus edition of Veeam Backup & Replication and that target and source WAN accelerators are added to the backup infrastructure. For more information, see [Adding WAN Accelerators](wan_add.md).
+* If you plan to use WAN accelerators, check that you have the required license. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). Also, the target and source WAN accelerators are added to the backup infrastructure. For more information, see [Adding WAN Accelerators](wan_add.md).
 * If you plan to migrate VMs between hosts in the cluster or SCVMM, you will not have to reconfigure jobs in Veeam Backup & Replication. Veeam Backup & Replication will automatically locate migrated VMs and continue processing them as usual. If you migrate VMs between standalone hosts that are not a part of one cluster or SCVMM server registered in Veeam Backup & Replication, you will have to reconfigure jobs to include the migrated VMs. After that, Veeam Backup & Replication will create full backups for these VMs. If you do not reconfigure the jobs, they will fail.
 * If you delete the source backup job after creating the backup copy job, backup files will become orphaned. The orphaned backup files are displayed under the Backups > Disk (Orphaned) node. If the orphaned backup files were also stored in [capacity tier](capacity_tier.md) or [archive tier](archive_tier.md), they will also be displayed under the Backups > Object Storage (Orphaned) or Backups > Archive (Orphaned) nodes. The orphaned backup files can not be processed by any job.
 * Even if Use per-machine backup files option is disabled in a repository that you are planning to use as the target, backup copy job will always create per-machine backup files in the backup repository.
 
-Page updated 10/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_copy_path.md
+++ b/docs/backup_copy_path.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup Copy Architecture"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_path.html"
-last_updated: "9/9/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup Copy Architecture
 
-In this article
 
 To transport data from the source backup repository to the target backup repository, the backup copy job uses one of the following paths:
 
@@ -43,7 +44,7 @@ Veeam Backup & Replication transports data through a pair of WAN accelerators: o
 |  |
 | --- |
 | Important |
-| The WAN acceleration technology is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise Plus edition is required. For more information, see [WAN Acceleration](wan_acceleration.md). |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 When Veeam Backup & Replication transports data using WAN accelerators, it uses Veeam Data Movers on the following backup infrastructure components:
 
@@ -52,6 +53,4 @@ When Veeam Backup & Replication transports data using WAN accelerators, it uses 
 
 ![Backup Copy Architecture](images/backup_copy_wan_path.webp)
 
-Page updated 9/9/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vbr_vss_proxy_choose.md
+++ b/docs/backup_job_vbr_vss_proxy_choose.md
@@ -1,13 +1,14 @@
 ---
 title: "Choose Guest Interaction Proxy"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vbr_vss_proxy_choose.html"
-last_updated: "12/8/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Choose Guest Interaction Proxy
 
-In this article
 
 To produce transactionally consistent backups and to perform file system indexing, Veeam Backup & Replication communicates with the guest OS of each processed VM to deploy non-persistent runtime components that coordinate guest processing activities such as accessing VM applications and creating a catalog of VM files. Since these activities may significantly increase the load on the backup server in case of a large backup scope, Veeam Backup & Replication distributes the load among all Microsoft Windows and Linux servers added to the backup infrastructure (further referred to as guest interaction proxies).
 
@@ -22,7 +23,7 @@ To connect a backup server to the processed VM guest OS, specify the [guest inte
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality is included in the Veeam Universal License. If you use the legacy socket-based license, you will require an Enterprise or higher edition. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 For a server to be displayed in the list of available log shipping servers, it must be added to the backup infrastructure as described in sections [Adding Microsoft Windows Servers](add_windows_server.md) and [Adding Linux Servers](add_linux_server.md).
 
@@ -33,6 +34,4 @@ For a server to be displayed in the list of available log shipping servers, it m
 
 ![Choose Guest Interaction Proxy](images/vm_backup_job_vss_proxy.webp)
 
-Page updated 12/8/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vbr_vss_proxy_choose_hv.md
+++ b/docs/backup_job_vbr_vss_proxy_choose_hv.md
@@ -1,13 +1,14 @@
 ---
 title: "Choose Guest Interaction Proxy"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vbr_vss_proxy_choose_hv.html"
-last_updated: "12/8/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Choose Guest Interaction Proxy
 
-In this article
 
 To produce transactionally consistent backups and to perform file system indexing, Veeam Backup & Replication communicates with the guest OS of each processed VM to deploy non-persistent runtime components that coordinate guest processing activities such as accessing VM applications and creating a catalog of VM files. Since these activities may significantly increase the load on the backup server in case of a large backup scope, Veeam Backup & Replication distributes the load among all Microsoft Windows and Linux servers added to the backup infrastructure (further referred to as guest interaction proxies).
 
@@ -22,7 +23,7 @@ To connect a backup server to the processed VM guest OS, specify the [guest inte
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality is included in the Veeam Universal License. If you use the legacy socket-based license, you will require an Enterprise or higher edition. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 For a server to be displayed in the list of available log shipping servers, it must be added to the backup infrastructure as described in sections [Adding Microsoft Windows Servers](add_windows_server.md) and [Adding Linux Servers](add_linux_server.md).
 
@@ -33,6 +34,4 @@ For a server to be displayed in the list of available log shipping servers, it m
 
 ![Choose Guest Interaction Proxy](images/vm_backup_job_vss_proxy.webp)
 
-Page updated 12/8/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vbr_vss_proxy_choose_hv_web.md
+++ b/docs/backup_job_vbr_vss_proxy_choose_hv_web.md
@@ -1,13 +1,14 @@
 ---
 title: "Choose Guest Interaction Proxy"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vbr_vss_proxy_choose_hv_web.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Choose Guest Interaction Proxy
 
-In this article
 
 To produce transactionally consistent backups and to perform file system indexing, Veeam Backup & Replication communicates with the guest OS of each processed VM to deploy non-persistent runtime components that coordinate guest processing activities such as accessing VM applications and creating a catalog of VM files. Since these activities may significantly increase the load on the backup server in case of a large backup scope, Veeam Backup & Replication distributes the load among all Microsoft Windows and Linux servers added to the backup infrastructure (further referred to as guest interaction proxies).
 
@@ -22,7 +23,7 @@ To connect a backup server to the processed VM guest OS, specify the [guest inte
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality is included in the Veeam Universal License. If you use the legacy socket-based license, you will require an Enterprise or higher edition. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 For a server to be displayed in the list of available log shipping servers, it must be added to the backup infrastructure as described in sections [Adding Microsoft Windows Servers](add_windows_server.md) and [Adding Linux Servers](add_linux_server.md).
 
@@ -33,6 +34,4 @@ For a server to be displayed in the list of available log shipping servers, it m
 
 [![Click to zoom in](images/vm_backup_job_vss_proxy_web.webp)](images/vm_backup_job_vss_proxy_web.webp "Click to zoom in")
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vbr_vss_proxy_choose_web.md
+++ b/docs/backup_job_vbr_vss_proxy_choose_web.md
@@ -1,13 +1,14 @@
 ---
 title: "Choose Guest Interaction Proxy"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vbr_vss_proxy_choose_web.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Choose Guest Interaction Proxy
 
-In this article
 
 To produce transactionally consistent backups and to perform file system indexing, Veeam Backup & Replication communicates with the guest OS of each processed VM to deploy non-persistent runtime components that coordinate guest processing activities such as accessing VM applications and creating a catalog of VM files. Since these activities may significantly increase the load on the backup server in case of a large backup scope, Veeam Backup & Replication distributes the load among all Microsoft Windows and Linux servers added to the backup infrastructure (further referred to as guest interaction proxies).
 
@@ -22,7 +23,7 @@ To connect a backup server to the processed VM guest OS, specify the [guest inte
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality is included in the Veeam Universal License. If you use the legacy socket-based license, you will require an Enterprise or higher edition. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 For a server to be displayed in the list of available log shipping servers, it must be added to the backup infrastructure as described in sections [Adding Microsoft Windows Servers](add_windows_server.md) and [Adding Linux Servers](add_linux_server.md).
 
@@ -33,6 +34,4 @@ For a server to be displayed in the list of available log shipping servers, it m
 
 [![Click to zoom in](images/vm_backup_job_vss_proxy_web.webp)](images/vm_backup_job_vss_proxy_web.webp "Click to zoom in")
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vss_exclude.md
+++ b/docs/backup_job_vss_exclude.md
@@ -1,20 +1,21 @@
 ---
 title: "VM Guest OS File Exclusion"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_exclude.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS File Exclusion
 
-In this article
 
 If you do not want to back up specific files and folders on the VM guest OS, you can exclude them from the backup.
 
 |  |
 | --- |
 | Note |
-| VM guest OS file exclusion functionality is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 To specify excluded files and folders, do the following:
 
@@ -35,6 +36,4 @@ To specify excluded files and folders, do the following:
 
 ![VM Guest OS File Exclusion](images/file_exclude.webp)
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vss_exclude_hv.md
+++ b/docs/backup_job_vss_exclude_hv.md
@@ -1,20 +1,21 @@
 ---
 title: "VM Guest OS File Exclusion"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_exclude_hv.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS File Exclusion
 
-In this article
 
 If you do not want to back up specific files and folders on the VM guest OS, you can exclude them from the backup.
 
 |  |
 | --- |
 | Note |
-| VM guest OS file exclusion functionality is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. |
+| The availability of the file exclusion feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 To specify excluded files and folders, do the following:
 
@@ -40,6 +41,4 @@ To specify excluded files and folders, do the following:
 
 ![VM Guest OS File Exclusion](images/file_exclude_hv.webp)
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vss_exclude_hv_web.md
+++ b/docs/backup_job_vss_exclude_hv_web.md
@@ -1,20 +1,21 @@
 ---
 title: "VM Guest OS File Exclusion"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_exclude_hv_web.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS File Exclusion
 
-In this article
 
 If you do not want to back up specific files and folders on the VM guest OS, you can exclude them from the backup.
 
 |  |
 | --- |
 | Note |
-| VM guest OS file exclusion functionality is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 To specify excluded files and folders, do the following:
 
@@ -40,6 +41,4 @@ To specify excluded files and folders, do the following:
 
 [![Click to zoom in](images/file_exclude_hv_web.webp)](images/file_exclude_hv_web.webp "Click to zoom in")
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_job_vss_exclude_web.md
+++ b/docs/backup_job_vss_exclude_web.md
@@ -1,20 +1,21 @@
 ---
 title: "VM Guest OS File Exclusion"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_exclude_web.html"
-last_updated: "12/9/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS File Exclusion
 
-In this article
 
 If you do not want to back up specific files and folders on the VM guest OS, you can exclude them from the backup.
 
 |  |
 | --- |
 | Note |
-| VM guest OS file exclusion functionality is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 To specify excluded files and folders, do the following:
 
@@ -35,6 +36,4 @@ To specify excluded files and folders, do the following:
 
 [![Click to zoom in](images/file_exclude_web.webp)](images/file_exclude_web.webp "Click to zoom in")
 
-Page updated 12/9/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_repository_sobr.md
+++ b/docs/backup_repository_sobr.md
@@ -1,20 +1,21 @@
 ---
 title: "Scale-Out Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_repository_sobr.html"
-last_updated: "11/10/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Scale-Out Backup Repositories
 
-In this article
 
 A scale-out backup repository is a repository system with horizontal scaling support for multi-tier storage of data. A scale-out backup repository consists of one or more backup repositories or object storage repositories called performance tier, and can be expanded with object storage repositories for long-term and archive storage: capacity tier and archive tier. All the storage devices and systems inside the scale-out backup repository are joined into a system, with their capacities summarized.
 
 |  |
 | --- |
 | Note |
-| Consider the following:   * Scale-out backup repository is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required. * If you configure a scale-out backup repository and then downgrade to the Standard license, you will not be able to run jobs targeted at the scale-out backup repository. However, you will be able to perform restore from the scale-out backup repository. |
+| Consider the following:   * The availability of the scale-out backup repository depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). * If you configure a scale-out backup repository and then downgrade to the Standard license, you will not be able to run jobs targeted at the scale-out backup repository. However, you will be able to perform restore from the scale-out backup repository. |
 
 This feature provides the following benefits:
 
@@ -61,6 +62,4 @@ In This Section
 * [Adding Scale-Out Backup Repositories](sobr_add.md)
 * [Managing Scale-Out Backup Repositories](managing_sobr_data.md)
 
-Page updated 11/10/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/backup_to_tape_jobs.md
+++ b/docs/backup_to_tape_jobs.md
@@ -1,20 +1,21 @@
 ---
 title: "Backup to Tape"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_jobs.html"
-last_updated: "10/20/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Tape
 
-In this article
 
 To back up data to tape, you need to create and run tape jobs. The backup to tape job is a dedicated job that archives to tape Veeam backups that were produced by Veeam backup jobs. Note that you cannot directly backup virtual machines to tapes.
 
 |  |
 | --- |
 | Note |
-| Support of the backup to tape is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise or Enterprise Plus edition of Veeam Backup & Replication is required. For details, see [Veeam Editions Comparison](https://www.veeam.com/backup-version-standard-enterprise-editions-comparison.html). |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 You can archive the following data to tape:
 
@@ -121,6 +122,4 @@ Related Topics
 * [Creating Backup to Tape Jobs](creating_backup_to_tape_jobs.md)
 * [Linking Backup Jobs to Backup to Tape Jobs](linking_backup_to_backup_to_tape.md)
 
-Page updated 10/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/before_you_begin_data_box.md
+++ b/docs/before_you_begin_data_box.md
@@ -1,13 +1,14 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/before_you_begin_data_box.html"
-last_updated: "8/2/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you add Microsoft Azure Data Box to the backup infrastructure, complete the following steps:
 
@@ -58,12 +59,15 @@ Consider that Veeam Backup & Replication supports Azure Data Box devices that ar
 
 As with any other object storage, REST API performance depends on scale. As Azure Data Box is a single endpoint, the individual throughput of this REST API may be limited. The block size used in Veeam Backup & Replication capacity tier for object storage offload matches that of the source job. The default object size will be a compressed 1 MB block, resulting in objects of around 512 KB in size.
 
-The speed of data offload to Azure Data Box devices may reach about 300 MB/s. To achieve this speed, we recommend using a separate gateway server with 8 CPU cores.
+Data offload speed capabilities depend on the Azure Data Box devices:
+
+* Azure Data Box 80 TiB: Data offload speed can reach up to 300 MB/s.
+* Azure Data Box Next Gen 120 TB: Data offload speed can reach up to 600 MB/s.
+
+For optimal performance, it is recommended to use a dedicated gateway server equipped with at least 8 CPU cores.
 
 Related Topics
 
 [Gateway Servers](gateway_server.md)
 
-Page updated 8/2/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/cdp_requirements.md
+++ b/docs/cdp_requirements.md
@@ -1,19 +1,20 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_requirements.html"
-last_updated: "11/18/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 If you plan to use CDP to protect your workloads, consider the following requirements and limitations.
 
 Licensing
 
-CDP is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise Plus edition is required.
+The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 Platforms and Datastores
 
@@ -67,6 +68,4 @@ Related Topics
 
 [Backup Infrastructure for CDP](cdp_infrastructure.md)
 
-Page updated 11/18/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/copying_files_and_folders.md
+++ b/docs/copying_files_and_folders.md
@@ -1,13 +1,14 @@
 ---
 title: "Copying Files and Folders Manually"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/copying_files_and_folders.html"
-last_updated: "12/2/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Copying Files and Folders Manually
 
-In this article
 
 You can manually copy and move files and folders between servers and hosts added to the backup infrastructure.
 
@@ -15,7 +16,7 @@ Veeam Backup & Replication lets you copy files manually between the following ba
 
 * Virtualization hosts
 * Microsoft Windows servers
-* Linux servers
+* Linux servers that are not used as hardened repositories
 * Deduplicating storage appliances used as backup repositories
 
 |  |
@@ -35,6 +36,4 @@ You can also use a drag and drop operation to copy files and folders between the
 
 [![Click to zoom in](images/file_copy_manual.webp)](images/file_copy_manual.webp "Click to zoom in")
 
-Page updated 12/2/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/deduplicating_appliance_exgrid.md
+++ b/docs/deduplicating_appliance_exgrid.md
@@ -3,7 +3,7 @@ title: "ExaGrid"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deduplicating_appliance_exgrid.html"
-last_updated: "1/15/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -105,7 +105,7 @@ Configure backup job settings in the following way:
 |  |
 | --- |
 | Note |
-| Consider the following:   * Do not create multiple backup repositories directed at the same folder/path on the same device.  * We recommend against enabling encryption for the jobs targeted at the deduplication storage appliance. Encryption has a negative effect on the deduplication ratio. For more information, see [Data Encryption](encryption_job.md).      * Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429). |
+| Consider the following:   * The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).  * Do not create multiple backup repositories directed at the same folder/path on the same device.  * We recommend against enabling encryption for the jobs targeted at the deduplication storage appliance. Encryption has a negative effect on the deduplication ratio. For more information, see [Data Encryption](encryption_job.md). * Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429). |
 
 For more information and recommendations on working with ExaGrid, see [this Veeam KB article](https://www.veeam.com/kb1745).
 

--- a/docs/deduplicating_appliance_quantum.md
+++ b/docs/deduplicating_appliance_quantum.md
@@ -3,7 +3,7 @@ title: "Quantum DXi"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deduplicating_appliance_quantum.html"
-last_updated: "1/15/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -34,7 +34,7 @@ Quantum DXi hosts Veeam Data Mover permanently. Veeam Backup & Replication insta
 |  |
 | --- |
 | Note |
-| Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429). |
+| Consider the following:   * Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429).  * The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 For more information and recommendations on working with Quantum DXi, see [this Veeam KB article](https://www.veeam.com/kb1745).
 

--- a/docs/deduplicating_appliance_storeonce.md
+++ b/docs/deduplicating_appliance_storeonce.md
@@ -1,13 +1,14 @@
 ---
 title: "HPE StoreOnce"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deduplicating_appliance_storeonce.html"
-last_updated: "11/24/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # HPE StoreOnce
 
-In this article
 
 You can use HPE StoreOnce storage systems with StoreOnce Catalyst as backup repositories.
 
@@ -47,6 +48,8 @@ General
 If you plan to use HPE StoreOnce as a backup repository for jobs other than file backup jobs, object storage backup jobs and Veeam Plug-In for Enterprise Application jobs, consider the following recommendations and limitations. These requirements and limitations apply only if you use HPE StoreOnce in the integration mode, not the shared folder mode.
 
 * Check that HPE StoreOnce that you plan to use is supported. For more information, see [Backup Target](system_requirements.md#target).
+
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 * Check [requirements and limitations for the gateway server](gateway_server.md).
 
@@ -141,6 +144,4 @@ Related Topics
 * [Accelerated Restore of Entire VM](storeonce_accelerated_restore.md)
 * [Adding Deduplicating Storage Appliances](dsa_repository_add.md)
 
-Page updated 11/24/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/dell_dd.md
+++ b/docs/dell_dd.md
@@ -3,7 +3,7 @@ title: "Dell Data Domain"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/dell_dd.html"
-last_updated: "1/15/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -46,6 +46,7 @@ General
 If you plan to use Dell Data Domain as a backup repository, consider the following:
 
 * We strongly recommend that you follow recommendations from this list and also recommendations from [this Veeam KB article](https://www.veeam.com/kb1745).
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * Check [requirements and limitations for the gateway server](gateway_server.md).
 * The same Data Domain Boost storage unit cannot be added to multiple backup servers.
 

--- a/docs/four_eyes_authorization.md
+++ b/docs/four_eyes_authorization.md
@@ -1,13 +1,14 @@
 ---
 title: "Four-Eyes Authorization"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/four_eyes_authorization.html"
-last_updated: "11/19/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Four-Eyes Authorization
 
-In this article
 
 You can enable four-eyes authorization to reduce the risk of accidental actions affecting sensitive data. This functionality requires additional approval for certain operations in Veeam Backup & Replication given by another user. To approve the request, the user must have the Veeam Backup Administrator or Veeam Security Administrator role.
 
@@ -53,7 +54,7 @@ Requirements and Limitations
 
 Four-eyes authorization has the following requirements and limitations:
 
-* The functionality is included only in the Veeam Universal License or the Enterprise Plus edition. If the license expires, you will still be able to process already created requests but not to create new ones.
+* The availability of the functionality depends on the license you use. For more information, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). If the license expires, you will still be able to process already created requests but not to create new ones.
 * If four-eyes authorization is enabled, you cannot perform the following operations:
 
 + Delete operations using PowerShell cmdlets, REST API, and Veeam Backup Enterprise Manager.
@@ -94,6 +95,4 @@ To view events related to four-eyes authorization, open the History view and sel
 
 [![Four-Eyes Authorization](images/four_eyes_history.webp)](images/four_eyes_history.webp)
 
-Page updated 11/19/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/fujitsu.md
+++ b/docs/fujitsu.md
@@ -3,7 +3,7 @@ title: "Fujitsu ETERNUS CS800"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/fujitsu.html"
-last_updated: "1/15/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -35,7 +35,7 @@ Fujitsu ETERNUS hosts Veeam Data Mover permanently. Veeam Backup & Replication i
 |  |
 | --- |
 | Note |
-| Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429). |
+| Consider the following:   * Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429).  * The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf) |
 
 Configuration on Fujitsu ETERNUS Side
 

--- a/docs/general_limitations.md
+++ b/docs/general_limitations.md
@@ -1,13 +1,14 @@
 ---
 title: "General Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/general_limitations.html"
-last_updated: "1/2/2026"
+last_updated: "1/26/2026"
 product_version: "13.0.1.1071"
 ---
 
 # General Considerations and Limitations
 
-In this article
 
 This section contains general limitations for object storage repositories:
 
@@ -40,7 +41,7 @@ Ports and Network
 
 Consider the following network limitations:
 
-* Make sure to open required ports to communicate with object storage repositories in advance. Consider that a backup server or a gateway server must have internet access to verify that the certificates installed on object storage repositories are valid. For more details, see [Ports](used_ports.md#osrc).
+* Ensure that you open the required ports to communicate with object storage repositories in advance. Consider that non-internet-facing infrastructure components (for example, a gateway server or a backup proxy) must have internet access to verify that the certificates installed on object storage repositories are valid. For more information, see [Ports](used_ports.md#osrc). If these components do not have access to the Internet to perform certificate revocation checks, disable them by modifying the registry (for Windows-based servers) or the etc/VeeamAgentConfig file (for Linux-based servers). For more information, see [this Veeam KB article](https://www.veeam.com/kb4373), step 6.
 
 * If you use default network security configuration for helper appliances, make sure that they are compliant with your internal security policies.
 
@@ -99,6 +100,4 @@ For more information on limitations for Veeam solutions that utilizes object sto
 * [Veeam Agent for Mac](https://helpcenter.veeam.com/docs/agentformac/userguide/backup_object_ovw.html?ver=13#considerations-and-limitations) — to check limitations for data protection and disaster recovery solution for physical endpoints and virtual machines running macOS.
 * [Veeam Cloud Connect Guide](https://helpcenter.veeam.com/docs/vbr/cloud/cc_object_storage.html?ver=13#considerations-and-limitations) — to check limitations for data protection and disaster recovery solution for cloud service providers.
 
-Page updated 1/2/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/guest_file_exclusion.md
+++ b/docs/guest_file_exclusion.md
@@ -1,13 +1,14 @@
 ---
 title: "VM Guest OS Files"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/guest_file_exclusion.html"
-last_updated: "2/10/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS Files
 
-In this article
 
 If you do not want to back up or replicate some files and folders on the VM guest OS, you can exclude them from the backup or replica. File exclusion reduces the size of the backup or replica but may affect job performance.
 
@@ -62,7 +63,7 @@ Requirements and Limitations for VM Guest OS File Exclusion
 VM guest OS files exclusion has the following limitations:
 
 * File exclusion works only on Microsoft Windows NTFS.
-* File exclusion is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required.
+* The availability of the file exclusion functionality depends on the license you use. For more details about licensing support, see Veeam [Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * To exclude VM guest OS files, Veeam Backup & Replication must be able to deploy the non-persistent runtime components or use (in necessary, deploy) persistent agent components inside the VM. For this reason, the VM must be running and accessible by an IP address or through the Installer Service on VM, and credentials for application-aware processing must be valid.
 * Veeam Backup & Replication supports both basic and dynamic disks. For the dynamic disks, simple type of volumes is supported. Spanned, mirrored and striped volumes are not supported.
 * It is not recommended that you use VM guest files exclusion in Microsoft Windows for volumes with enabled Data Deduplication. If you decide to use VM guest files exclusion for such volumes and set up a list of inclusions, you must add the System Volume Information folder to the list of inclusions.
@@ -113,6 +114,4 @@ During the job session with file exclude, Veeam Backup & Replication makes chang
 * Data blocks that were excluded during the previous job session
 * Data blocks that must be excluded during the current job session
 
-Page updated 2/10/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/guest_file_exclusion_hv.md
+++ b/docs/guest_file_exclusion_hv.md
@@ -1,13 +1,14 @@
 ---
 title: "VM Guest OS Files"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/guest_file_exclusion_hv.html"
-last_updated: "2/11/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # VM Guest OS Files
 
-In this article
 
 If you do not want to back up or replicate some files and folders on the VM guest OS, you can exclude them from the backup or replica. File exclusion reduces the size of the backup or replica but may affect job performance.
 
@@ -62,7 +63,7 @@ Requirements and Limitations for VM Guest OS File Exclusion
 VM guest OS files exclusion has the following limitations:
 
 * File exclusion works only on Microsoft Windows NTFS.
-* File exclusion is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required.
+* The availability of the file exclusion feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * To exclude VM guest OS files, Veeam Backup & Replication must be able to deploy the non-persistent runtime components or use (in necessary, deploy) persistent agent components inside the VM. For this reason, the VM must be running and accessible by an IP address or through the Installer Service on VM, and credentials for application-aware processing must be valid.
 * Veeam Backup & Replication supports both basic and dynamic disks. For the dynamic disks, simple type of volumes is supported. Spanned, mirrored and striped volumes are not supported.
 * It is not recommended that you use VM guest files exclusion in Microsoft Windows for volumes with enabled Data Deduplication. If you decide to use VM guest files exclusion for such volumes and set up a list of inclusions, you must add the System Volume Information folder to the list of inclusions.
@@ -113,6 +114,4 @@ During the job session with file exclude, Veeam Backup & Replication makes chang
 * Data blocks that were excluded during the previous job session
 * Data blocks that must be excluded during the current job session
 
-Page updated 2/11/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/guest_interaction_proxy.md
+++ b/docs/guest_interaction_proxy.md
@@ -1,20 +1,21 @@
 ---
 title: "Guest Interaction Proxies"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/guest_interaction_proxy.html"
-last_updated: "1/7/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Guest Interaction Proxies
 
-In this article
 
 The guest interaction proxy is a backup infrastructure component that sits between the backup server and the processed VM. To interact with the VM guest OS, Veeam Backup & Replication needs either to install non-persistent runtime components or use (if necessary, install) persistent agent components in each VM. The task of deploying these components in a VM is performed by the guest interaction proxy. For more information on the components, see [Non-Persistent Runtime Components and Persistent Agent Components](runtime_process.md).
 
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality requires a license with Enterprise or higher edition. |
+| The availability of the guest interaction proxy functionality depends on the license you use. For more details about licensing support, see Veeam [Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 The guest interaction proxy allows you to communicate with the VM guest OS even if the backup server and processed VM run in different networks.
 
@@ -80,6 +81,4 @@ Related Topics
 * [Creating Replication Jobs](replica_job.md)
 * [Creating VM Copy Jobs](copy_job.md)
 
-Page updated 1/7/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/guest_restore_before_you_begin.md
+++ b/docs/guest_restore_before_you_begin.md
@@ -1,19 +1,20 @@
 ---
 title: "Microsoft Windows File Recovery"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/guest_restore_before_you_begin.html"
-last_updated: "11/19/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Microsoft Windows File Recovery
 
-In this article
 
 This section lists considerations and limitations that apply to recovery from Microsoft Windows workloads.
 
 Licensing
 
-[Restore changes functionality](guest_restore_save.md#changed) is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise or Enterprise Plus editions of Veeam Backup & Replication are required.
+The availability of the recovery features depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 Infrastructure Components
 
@@ -102,6 +103,4 @@ Recovery Finalization
 * If the Veeam Backup & Replication console is launched on the backup server, the Copy to operation does not allow copying files to the backup server. You can only copy files to a network shared folder.
 * [For Hyper-V VMs] You can restore files and folders to components of the Veeam Backup & Replication infrastructure available over the network.
 
-Page updated 11/19/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/hardened_repository_backup_server.md
+++ b/docs/hardened_repository_backup_server.md
@@ -1,18 +1,17 @@
 ---
-title: "Using Backup Server as Hardened Repository"
+title: "Using Backup Server as Immutable Repository"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hardened_repository_backup_server.html"
-last_updated: "8/13/2025"
+last_updated: "1/26/2026"
 product_version: "13.0.1.1071"
 ---
 
-# Using Backup Server as Hardened Repository
+# Using Backup Server as Immutable Repository
 
-In this article
 
-You can use your Veeam Backup & Replication backup server as a hardened repository without additional preparation. This provides the same functionality as a hardened repository on a dedicated server.
+If you use a Veeam Software Appliance as a backup server, it can be used as an immutable repository without additional preparation. This provides similar functionality to a hardened repository on a dedicated server.
 
-Due to the presence of additional services and fewer restrictions, using a backup server as a hardened repository increases the attack surface of your backup infrastructure. For medium-sized and large-scale environments, it is recommended to deploy a hardened repository on a dedicated server.
+However, due to the presence of additional services and fewer restrictions, using a backup server as a immutable repository increases the attack surface of your backup infrastructure. For medium-sized and large-scale environments, it is recommended to deploy a hardened repository on a dedicated server.
 
-Page updated 8/13/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/hardened_repository_immutability.md
+++ b/docs/hardened_repository_immutability.md
@@ -1,13 +1,14 @@
 ---
 title: "How Immutability Works"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hardened_repository_immutability.html"
-last_updated: "10/17/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # How Immutability Works
 
-In this article
 
 Immutability is managed by the following services:
 
@@ -111,7 +112,9 @@ For information on how immutability works for unstructured data backups and ente
 * [Veeam Plug-In for Oracle RMAN](repos_rman.md#hardened)
 * [Veeam Plug-In for SAP HANA](sap_repos.md#hardened)
 * [Veeam Plug-In for SAP on Oracle](sap_orcl_repos.md#hardened)
+* [Veeam Plug-In for SAP MaxDB](plugins_sap_maxdb_overview_data_backup_repos.md#hardened)
 * [Veeam Plug-In for Microsoft SQL Server](repos_mssql.md#hardened)
+* [Veeam Plug-In for IBM Db2](db2_backup_repos.md#hardened)
 
 Retention Scenarios
 
@@ -130,6 +133,4 @@ Consider the following retention scenarios:
 
 * [With disabled retention period] Veeam Backup & Replication ignores the VeeamZIP or Export Backup retention period. The immutability time period for VeeamZIP or Export Backup backup files equals the period specified in the setting of a hardened repository.
 
-Page updated 10/17/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/hardened_repository_limitations.md
+++ b/docs/hardened_repository_limitations.md
@@ -1,13 +1,14 @@
 ---
 title: "Requirements and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hardened_repository_limitations.html"
-last_updated: "1/8/2026"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Requirements and Limitations
 
-In this article
 
 For the hardened repository, consider the following requirements and limitations.
 
@@ -57,6 +58,7 @@ Repository
 * For importing a backup, use VBK backup files. Metadata files of a backup chain (.VBM) cannot be immutable because they are updated on every job pass.
 * Veeam Backup & Replication does not support symlinks in the path to the hardened repository.
 * Only Veeam Data Mover Service/Veeam Transport Service child processes can run under the root account on a hardened repository.
+* Hardened repositories are not visible in the Files view in the Veeam Backup & Replication console.
 
 Immutability Feature
 
@@ -73,6 +75,4 @@ When deploying a Veeam Hardened Repository with Veeam Infrastructure Appliance, 
 * Multi-factor authentication cannot be disabled on hardened repositories that do not have security officer accounts enabled.
 * If security officer accounts are enabled, you must initialize the default security officer account before you add the hardened repository to your Veeam Backup & Replication infrastructure.
 
-Page updated 1/8/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/import_encrypted.md
+++ b/docs/import_encrypted.md
@@ -1,13 +1,14 @@
 ---
 title: "Importing Encrypted Backups"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/import_encrypted.html"
-last_updated: "7/7/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Importing Encrypted Backups
 
-In this article
 
 You can import backups that were encrypted on this backup server or on another backup server.
 
@@ -30,7 +31,7 @@ If you enter the correct passwords, Veeam Backup & Replication will decrypt the 
 |  |
 | --- |
 | Note |
-| You can recover data from encrypted backups even if the password is lost. Restoring data without a password is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. Also, your backup server must be connected to Veeam Backup Enterprise Manager. For more information, see [Decrypting Backups With Enterprise Manager Keys](decrypt_without_pass.md). |
+| You can recover data from encrypted backups even if the password is lost. The availability of restoring data without a password depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). Also, your backup server must be connected to Veeam Backup Enterprise Manager. For more information, see [Decrypting Backups With Enterprise Manager Keys](decrypt_without_pass.md). |
 
 ![Importing Encrypted Backups](images/decrypt_file.webp)
 
@@ -38,6 +39,4 @@ Related Topics
 
 [Creating Encrypted Configuration Backups](config_backup_encrypted.md)
 
-Page updated 7/7/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/import_encrypted_hv.md
+++ b/docs/import_encrypted_hv.md
@@ -1,13 +1,14 @@
 ---
 title: "Importing Encrypted Backups"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/import_encrypted_hv.html"
-last_updated: "7/7/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Importing Encrypted Backups
 
-In this article
 
 You can import backups that were encrypted on this backup server or on another backup server.
 
@@ -30,7 +31,7 @@ If you enter the correct passwords, Veeam Backup & Replication will decrypt the 
 |  |
 | --- |
 | Note |
-| You can recover data from encrypted backups even if the password is lost. Restoring data without a password is included in the Veeam Universal License. When using a legacy socket-based license, an Enterprise or higher edition is required. Also, your backup server must be connected to Veeam Backup Enterprise Manager. For more information, see [Decrypting Backups With Enterprise Manager Keys](decrypt_without_pass.md). |
+| You can recover data from encrypted backups even if the password is lost. The availability of restoring data without a password depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). Also, your backup server must be connected to Veeam Backup Enterprise Manager. For more information, see [Decrypting Backups With Enterprise Manager Keys](decrypt_without_pass.md). |
 
 ![Importing Encrypted Backups](images/decrypt_file.webp)
 
@@ -38,6 +39,4 @@ Related Topics
 
 [Creating Encrypted Configuration Backups](config_backup_encrypted.md)
 
-Page updated 7/7/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/infinidat_infiniguard.md
+++ b/docs/infinidat_infiniguard.md
@@ -3,7 +3,7 @@ title: "Infinidat InfiniGuard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/infinidat_infiniguard.html"
-last_updated: "1/15/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -35,7 +35,7 @@ Infinidat InfiniGuard hosts Veeam Data Mover permanently. Veeam Backup & Replica
 |  |
 | --- |
 | Note |
-| Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429). |
+| Consider the following:   * Since Veeam Backup & Replication version 12, deduplicating storage appliances use the TLS connection. For Microsoft Windows-based backup server, you can disable the TLS connection with a registry value for the deduplicating storage appliances that do not support the TLS connection. For Linux-based backup server, you can disable the TLS connection by editing the configuration file. For more information, see [this Veeam KB article](https://www.veeam.com/kb4429).  * The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf) |
 
 Configuration on Infinidat InfiniGuard Side
 

--- a/docs/io_settings.md
+++ b/docs/io_settings.md
@@ -1,20 +1,21 @@
 ---
 title: "Specifying I/O Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/io_settings.html"
-last_updated: "10/31/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Specifying I/O Settings
 
-In this article
 
 You can specify data processing settings.
 
 Consider the following:
 
-* The Enable storage latency control option is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required.
-* The Set custom thresholds on individual datastores option is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise Plus edition is required.
+* The availability of the Enable storage latency control option depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
+* The availability of the Set custom thresholds on individual datastores option depends on the license you use. For more information about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * For vVols/vSAN storage used in VMware vSphere environments, the Enable storage latency control option is not supported.
 
 To specify data processing settings:
@@ -50,6 +51,4 @@ To set the I/O latency limit for every storage separately:
 
 ![Specifying I/O Settings](images/notify_io_volume.webp)
 
-Page updated 10/31/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/ndmp_servers_backup_to_tape.md
+++ b/docs/ndmp_servers_backup_to_tape.md
@@ -1,20 +1,21 @@
 ---
 title: "NDMP Servers Backup to Tape"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ndmp_servers_backup_to_tape.html"
-last_updated: "8/27/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # NDMP Servers Backup to Tape
 
-In this article
 
 If your NAS device supports the NDMP protocol, you can back up data from it to tape. For this, you need to utilize the file to tape job.
 
 |  |
 | --- |
 | Note |
-| Support of NDMP servers backup to tape is included in the Veeam Universal License and does not consume Veeam licenses. When using a legacy socket-based license, the Enterprise Plus edition of Veeam Backup & Replication is required. For details, see [Veeam Editions Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 To back up data from NAS devices by the NDMP protocol, you need to add the device as an NDMP server. For details, see [Adding NDMP Servers](adding_ndmp_servers.md).
 
@@ -46,6 +47,4 @@ See Also
 
 [File Restore from Tape](file_restore_from_tape.md)
 
-Page updated 8/27/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_db2_object_storage.md
+++ b/docs/plugins_db2_object_storage.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_db2_object_storage.html"
-last_updated: "8/6/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Object Storage
 
-In this article
 
 If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
 
@@ -51,8 +52,6 @@ To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
 |  |
 | --- |
 | Note |
-| Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](db2_backup_repos.md#object). |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](db2_backup_repos.md#object).  * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_sap_maxdb_overview_object_storage_immutable.md). |
 
-Page updated 8/6/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_db2_object_storage_immutable.md
+++ b/docs/plugins_db2_object_storage_immutable.md
@@ -1,0 +1,86 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_db2_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+Example
+
+You create a backup on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first block generation will be July 1st + 7 days (minimum immutability period) + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the first block generation period from July 1st to July 10th will be immutable till July 18th.
+
+The second block generation will start 10 days later on July 11th. The effective immutability period for the second block generation will be July 11th + 7 days (minimum immutability period)  + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the second block generation period from July 11th to July 21st will be immutable till July 28th.
+
+

--- a/docs/plugins_mssql_object_storage.md
+++ b/docs/plugins_mssql_object_storage.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_mssql_object_storage.html"
-last_updated: "11/6/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Object Storage
 
-In this article
 
 If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
 
@@ -51,8 +52,6 @@ To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
 |  |
 | --- |
 | Note |
-| Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](repos_mssql.md#object). |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](repos_mssql.md#object).  * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_mssql_object_storage_immutable.md). |
 
-Page updated 11/6/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_mssql_object_storage_immutable.md
+++ b/docs/plugins_mssql_object_storage_immutable.md
@@ -1,0 +1,90 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_mssql_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+As Veeam Plug-In for Microsoft SQL Server supports backup chains, the logic behind the effective immutability period is different from other Veeam Plug-Ins. For database backups created with Veeam Plug-In for Microsoft SQL Server, if the block generation period is over but the backup chain remains active, an effective immutability period will be extended until a new backup chain is started.
+
+To learn more about backup chains, see [Backup Chain](mssql_backup_chain.md).
+
+Example
+
+You create a backup with Veeam Plug-In for Microsoft SQL Server on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first generation is July 1st + 7 days (minimum immutability period) + 10 days (default block generation period for IBM Cloud Object Storage). If the block generation period ends but the backup chain remains active, Veeam Backup & Replication extends the immutability locks for all objects created during this block generation period. Veeam Backup & Replication continues to extend the immutability locks until the next full backup is created, which starts a new backup chain. As a result, database backups created during the first block generation period should be by default the backups created from July 1st to July 10th, but the July 10th is not the final end date, the block generation period can be extended until a new backup chain is started. Suppose that the next full backup is created 5 days later on July 15th. As a result, July 15th is the end date for the first block generation period, and database backups created from July 1st to July 15th will be immutable until July 22th.
+
+The second block generation starts on July 16th. The effective immutability period for the second block will be July 16th + 7 days (minimum immutability period)  + 10 days (default block generation period for IBM Cloud Object Storage). Note that the second block generation period can be also extended if the block generation period ends but the backup chain remains active.
+
+

--- a/docs/plugins_rman_hana_object_storage.md
+++ b/docs/plugins_rman_hana_object_storage.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_rman_hana_object_storage.html"
-last_updated: "8/6/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Object Storage
 
-In this article
 
 If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
 
@@ -51,8 +52,6 @@ To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
 |  |
 | --- |
 | Note |
-| Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](repos_rman.md#object). |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](repos_rman.md#object). * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_rman_hana_object_storage_immutable.md). |
 
-Page updated 8/6/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_rman_hana_object_storage_immutable.md
+++ b/docs/plugins_rman_hana_object_storage_immutable.md
@@ -1,0 +1,86 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_rman_hana_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+Example
+
+You create a backup on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first block generation will be July 1st + 7 days (minimum immutability period) + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the first block generation period from July 1st to July 10th will be immutable till July 18th.
+
+The second block generation will start 10 days later on July 11th. The effective immutability period for the second block generation will be July 11th + 7 days (minimum immutability period)  + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the second block generation period from July 11th to July 21st will be immutable till July 28th.
+
+

--- a/docs/plugins_sap_hana_object_storage.md
+++ b/docs/plugins_sap_hana_object_storage.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_hana_object_storage.html"
-last_updated: "8/12/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Object Storage
 
-In this article
 
 If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
 
@@ -51,8 +52,6 @@ To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
 |  |
 | --- |
 | Note |
-| Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](sap_repos.md#object). |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](sap_repos.md#object).  * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_sap_hana_object_storage_immutable.md). |
 
-Page updated 8/12/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_sap_hana_object_storage_immutable.md
+++ b/docs/plugins_sap_hana_object_storage_immutable.md
@@ -1,0 +1,86 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_hana_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+Example
+
+You create a backup on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first block generation will be July 1st + 7 days (minimum immutability period) + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the first block generation period from July 1st to July 10th will be immutable till July 18th.
+
+The second block generation will start 10 days later on July 11th. The effective immutability period for the second block generation will be July 11th + 7 days (minimum immutability period)  + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the second block generation period from July 11th to July 21st will be immutable till July 28th.
+
+

--- a/docs/plugins_sap_maxdb_overview_data_backup_repos.md
+++ b/docs/plugins_sap_maxdb_overview_data_backup_repos.md
@@ -1,13 +1,14 @@
 ---
 title: "Veeam Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_maxdb_overview_data_backup_repos.html"
-last_updated: "11/21/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Veeam Backup Repositories
 
-In this article
 
 Veeam Plug-Ins store backup files in repositories added to the Veeam Backup & Replication infrastructure. In this section, you can find the list of supported backup repositories and limitations for Veeam Plug-In backups.
 
@@ -160,7 +161,7 @@ You can configure Veeam Backup & Replication to transfer Veeam Plug-In backup fi
 
 For Veeam Plug-In backups, immutability works according to the following rules:
 
-* Immutability is applied to backup (.VAB) files and backup metadata (.VASM) files. Backup job metadata (.VACM) files are not immutable.
+* Immutability is applied to backup files (.VAB) and backup metadata files (.VASM). Backup job metadata files (.VACM) are not immutable.
 
 * Backup files become immutable for the configured time period (minimum 7 days, maximum 9999 days).
 
@@ -190,10 +191,8 @@ Before you configure your backup infrastructure to back up to the object storage
 * Azure Data Box
 
 * Data in object storage repositories must be managed solely by Veeam Backup & Replication, including retention and data management. Lifecycle rules are not supported, and their enabling may result in backup and restore failures.
-* For backups located in object storage repositories, data recovery options are not available if you access the object storage repository using credentials with the read-only access permissions.
+* If you access the object storage repository using credentials with the read-only access permissions, data recovery options are not available for backups located in object storage repositories.
 
 * For Microsoft Azure Blob storage, Veeam Plug-Ins do not support soft delete for blobs.
 
-Page updated 11/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_sap_maxdb_overview_object_storage.md
+++ b/docs/plugins_sap_maxdb_overview_object_storage.md
@@ -1,0 +1,57 @@
+---
+title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_maxdb_overview_object_storage.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup to Object Storage
+
+
+If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
+
+You can store backups created with Veeam Plug-Ins on the following types of the object storage:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Veeam Plug-In on the machine with the database always accesses object storage through Veeam Backup & Replication. As a result, Veeam Plug-In access to object storage is managed by a proxy component that Veeam Backup & Replication selects according to the connection mode specified in the repository settings:
+
+* Connection through a gateway server. With this connection mode, Veeam Plug-Ins access object storage through a gateway server specified in the repository settings. Backup data is sent from computer with Veeam Plug-In to the gateway server, then it is sent from gateway server to the object storage. For details about gateway server, see [Gateway Servers](gateway_server.md).
+* Direct connection. With this connection mode, Veeam Plug-Ins access object storage through a mount server specified in the repository settings. Backup data is sent from computer with Veeam Plug-In to the mount server, then it is sent from mount server to the object storage. The usage of the mount server allows Veeam Plug-In to avoid high CPU consumption on the machine with the database. For details about mount server, see [Mount Servers](mount_server.md).
+
+|  |
+| --- |
+| IMPORTANT |
+| * After you switch your repository from one connection mode to another, Veeam Plug-In will need to connect to Veeam Backup & Replication to update repository settings. Until this connection is made, all backup operations by Veeam Plug-In will fail.  * If you plan to back up data to the S3 compatible storage, you must perform an extra step: manually set access to the object storage. For details, see [Managing Permissions for S3 Compatible Object Storage](access_permissions.md). |
+
+Getting Started
+
+To back up database to an object storage, you must complete the following steps:
+
+1. Add repository in the Veeam backup console. For details, see [Adding Object Storage Repositories](new_object_storage.md).
+
+You can use an object storage in Veeam Backup & Replication as one of the following repositories:
+
+* Backup repository. For details, see [Backup Repositories](backup_repository.md).
+* Scale-out backup repository added as a Veeam backup repository. For details, see [Scale-Out Backup Repositories](backup_repository_sobr.md).
+
+1. [For S3 compatible object storage] Set access to the added S3 compatible object storage. For details, see [Managing Permissions for S3 Compatible Object Storage](access_permissions.md).
+2. Create an application backup policy and select the object storage from the list of available repositories.
+
+To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
+
+|  |
+| --- |
+| Note |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](plugins_sap_maxdb_overview_data_backup_repos.md#object).  * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_sap_maxdb_overview_object_storage_immutable.md). |
+
+

--- a/docs/plugins_sap_maxdb_overview_object_storage_immutable.md
+++ b/docs/plugins_sap_maxdb_overview_object_storage_immutable.md
@@ -1,0 +1,86 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_maxdb_overview_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+Example
+
+You create a backup on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first block generation will be July 1st + 7 days (minimum immutability period) + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the first block generation period from July 1st to July 10th will be immutable till July 18th.
+
+The second block generation will start 10 days later on July 11th. The effective immutability period for the second block generation will be July 11th + 7 days (minimum immutability period)  + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the second block generation period from July 11th to July 21st will be immutable till July 28th.
+
+

--- a/docs/plugins_sap_orcl_object_storage.md
+++ b/docs/plugins_sap_orcl_object_storage.md
@@ -1,13 +1,14 @@
 ---
 title: "Backup to Object Storage"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_orcl_object_storage.html"
-last_updated: "8/6/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Backup to Object Storage
 
-In this article
 
 If you want to store your data in a cloud-based or on-premises object storage, you can use Veeam Plug-In to create backups in repositories provided by the object storage. Veeam Plug-Ins support the object storage as a primary repository for backup jobs and Veeam Backup & Replication supports the object storage as a primary repository for backup copy jobs.
 
@@ -51,8 +52,6 @@ To learn more, see [Creating Application Backup Policy](mongo_policy_create.md).
 |  |
 | --- |
 | Note |
-| Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](sap_orcl_repos.md#object). |
+| * Before you configure your backup infrastructure to back up to the object storage, consider the limitations listed in [Veeam Backup Repositories](sap_orcl_repos.md#object).  * If you plan to configure immutability for the object storage repository, consider the limitations listed in [Backup Immutability](plugins_sap_orcl_object_storage_immutable.md). |
 
-Page updated 8/6/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/plugins_sap_orcl_object_storage_immutable.md
+++ b/docs/plugins_sap_orcl_object_storage_immutable.md
@@ -1,0 +1,86 @@
+---
+title: "Backup Immutability"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/plugins_sap_orcl_object_storage_immutable.html"
+last_updated: "1/23/2026"
+product_version: "13.0.1.1071"
+---
+
+# Backup Immutability
+
+
+If you store your backup files in an object storage repository, Veeam Backup & Replication allows you to protect backup data from deletion or modification by making that data temporarily immutable. It is done for increased security: immutability protects data in your recent backups from loss as a result of attacks, malware activity or any other injurious actions.
+
+|  |
+| --- |
+| Important |
+| Backup immutability uses native capabilities of object storage. Enabling this feature may result in additional API and storage charges from the storage provider. |
+
+Supported Object Storage Types
+
+Veeam Backup & Replication supports database backup immutability for all supported object storage types:
+
+* Amazon S3
+* S3 compatible
+* Google Cloud Storage
+* Microsoft Azure Blob Storage
+* IBM Cloud Object Storage
+* Wasabi Cloud Storage
+* Veeam Data Cloud Vault
+* 11:11 Cloud Object Storage
+
+Before You Begin
+
+Before you configure immutability for database backups, you must prepare the target storage account. Depending on the selected object storage type, perform the following actions:
+
+* [S3 Compatible and Amazon S3 storage] When you create an S3 bucket, you must enable the S3 Versioning and S3 Object Lock features for the bucket. For more information, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-storage.html).
+
+* [S3 Compatible and Amazon S3 storage] After you create an S3 bucket with Object Lock enabled, make sure that the default retention is disabled to avoid unpredictable system behavior and data loss. To disable the default retention, edit the Object Lock retention settings as described in [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
+
+* [Microsoft Azure Blob storage] You must enable blob versioning and version-level immutability support for the Azure container. For more information, see [Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview).
+* [Google Cloud Storage] When you create a bucket, you must enable the Object Versioning and Object Retention Lock features for the bucket. For more information on Object Versioning, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-versioning). For more information on Object Retention Lock, see [Google Cloud documentation](https://cloud.google.com/storage/docs/object-lock).
+
+Consider the following about backup immutability:
+
+* [S3 Compatible and Amazon S3 storage] Veeam Plug-In will use the compliance retention mode for each uploaded object. For more information on retention modes of S3 Object Lock, see [AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock-overview.html).
+* [Microsoft Azure Blob storage] Do not enable immutability for already existing containers in the Microsoft Azure Portal. Otherwise, Veeam Backup & Replication will not be able to process these containers properly and it may result in data loss.
+* After you specify a minimum immutability period for a backup and run the backup job for the first time, Veeam Backup & Replication will append the block generation period to the specified immutability period. To learn more, see [Block Generation Period](#gen).
+
+* Increasing the minimum immutability duration in the object storage repository settings updates immutability locks for all objects in this repository to match the block generation period of the current generation. As a result, this change may cause additional costs as it results in requests generated for each object in the object storage repository.
+
+Backup Immutability and Retention Policy
+
+Veeam Backup & Replication removes obsolete restore points based on the defined backup retention policy, but only if such restore points are no longer immutable. If data associated with an obsolete restore point is still immutable, such restore point will remain in the backup chain and in the repository until its immutability period is over. After that, such restore point is automatically removed from the backup chain and storage.
+
+Block Generation Period
+
+When you specify an immutability period in the object storage repository settings, Veeam Backup & Replication will automatically calculate an effective immutability period as a sum of the following periods:
+
+* minimum immutability period
+
+You can specify the minimum immutability period in the object storage repository settings. To learn more, see [Adding Object Storage Repositories](new_object_storage.md).
+
+* block generation period
+
+The block generation period serves to reduce the number of requests to the object storage repository, which results in lower traffic and reduced storage costs. During this block generation period, all of the transferred data objects will have the same immutability.
+
+The block generation period is predetermined depending on the object storage that you use:
+
+* 30 days — for repositories in Amazon S3 and Google Cloud Storage IBM Cloud and 11:11 Cloud Object Storage.
+* 10 days — for repositories in S3 compatible storage, Microsoft Azure Blob Storage and Veeam Data Cloud Vault.
+
+|  |
+| --- |
+| Note |
+| * You may configure a backup repository in IBM Cloud and 11:11 Cloud Object Storage using the S3 Compatible wizard. In this case, Veeam Backup & Replication will append the block generation period of 10 days. * You can change the predetermined block generation period with the registry key. For more information, submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
+
+Example
+
+You create a backup on IBM Cloud Object Storage on July 1st with immutability set for 7 days.
+
+The effective immutability period for the first block generation will be July 1st + 7 days (minimum immutability period) + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the first block generation period from July 1st to July 10th will be immutable till July 18th.
+
+The second block generation will start 10 days later on July 11th. The effective immutability period for the second block generation will be July 11th + 7 days (minimum immutability period)  + 10 days (block generation period for IBM Cloud Object Storage). As a result, database backups created during the second block generation period from July 11th to July 21st will be immutable till July 28th.
+
+

--- a/docs/protect_applications.md
+++ b/docs/protect_applications.md
@@ -1,13 +1,14 @@
 ---
 title: "Databases and Enterprise Applications"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/protect_applications.html"
-last_updated: "1/8/2026"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Databases and Enterprise Applications
 
-In this article
 
 Veeam Backup & Replication allows you to protect data from various applications and databases, such as Microsoft Active Directory, Microsoft SQL Server, MongoDB and others. Depending on the application you want to back up and the level on which you want to create a backup, Veeam Backup & Replication suggests the following options:
 
@@ -32,7 +33,7 @@ Veeam Backup & Replication allows you to protect data from various applications 
 
 Image-Level Backup with Application-Aware Processing
 
-Application-aware processing is available for most platforms protected by Veeam. With the application-aware processing enabled, Veeam Backup & Replication creates image-level backups of your workload and also backs up application logs. To configure application-aware processing, you must select the Enable application-aware processing check box in the backup job settings. For more information, see guides or sections dedicated to your platform. Make sure that you configured the infrastructure as required for the platform. For example, see [VMware vSphere](vmware_vsphere.md) for VMware vSphere VMs; [Veeam Agent Backup](protect_comp.md) for physical computers and VMs; [Veeam Backup for AWS](https://helpcenter.veeam.com/docs/vbaws/guide/welcome.html?ver=10) for EC2 instances and so on.
+Application-aware processing is available for most platforms protected by Veeam. With the application-aware processing enabled, Veeam Backup & Replication creates image-level backups of your workload and also backs up application logs. To configure application-aware processing, you must select the Enable application-aware processing check box in the backup job settings. For more information, see guides or sections dedicated to your platform. Make sure that you configured the infrastructure as required for the platform. For example, see [VMware vSphere](vmware_vsphere.md) for VMware vSphere VMs and [Veeam Agent Backup](protect_comp.md) for physical computers and VMs.
 
 For recovery, Veeam Backup & Replication provides recovery of workloads themselves as well as recovery of application items. For recovery, Veeam Backup & Replication uses tools called Veeam Explorers. Veeam Explorers are distributed as part of Veeam Backup & Replication, and you do not need to install them separately. You also do not need to purchase any additional license to use Veeam Explorers. For information on how to launch Veeam Explorers to restore application items, see [Launching Veeam Explorer from Image-Level Backups](restoring_veeam_explorers.md). As an alternative, you can launch Veeam Explorers as a separate tool. For more information, see the [Veeam Explorers User Guide](https://helpcenter.veeam.com/docs/vbr/explorers/explorers_introduction.html?ver=13).
 
@@ -58,6 +59,4 @@ Veeam Backup & Replication allows you to use the following backup solutions for 
 | Important |
 | Veeam Plug-Ins store database and log backups in repositories added to the Veeam Backup & Replication infrastructure. Thus, to use Veeam Plug-Ins, you must have a Veeam Backup & Replication server deployed in your infrastructure. To learn how to deploy Veeam Backup & Replication, see [Deployment](deployment.md). |
 
-Page updated 1/8/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/recovery_verification_overview.md
+++ b/docs/recovery_verification_overview.md
@@ -1,13 +1,14 @@
 ---
 title: "Recovery Verification for VMware vSphere"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/recovery_verification_overview.html"
-last_updated: "8/11/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Recovery Verification for VMware vSphere
 
-In this article
 
 Veeam Backup & Replication offers two technologies to verify recoverability of VM backups and replicas:
 
@@ -17,8 +18,6 @@ Veeam Backup & Replication offers two technologies to verify recoverability of V
 |  |
 | --- |
 | Important |
-| The recovery verification functionality is included in the Veeam Universal License.  When using a legacy socket-based license, Enterprise or higher edition is required. If you use the Standard edition, you can manually verify VM backups with Instant Recovery. For more information, see [Manual Recovery Verification](surebackup_manual.md). |
+| The availability of the recovery verification feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).  If you use the Standard edition, you can manually verify VM backups with Instant Recovery. For more information, see [Manual Recovery Verification](surebackup_manual.md). |
 
-Page updated 8/11/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/recovery_verification_overview_hv.md
+++ b/docs/recovery_verification_overview_hv.md
@@ -1,13 +1,14 @@
 ---
 title: "Recovery Verification for Microsoft Hyper-V"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/recovery_verification_overview_hv.html"
-last_updated: "8/11/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Recovery Verification for Microsoft Hyper-V
 
-In this article
 
 Veeam Backup & Replication offers the [SureBackup technology](surebackup_recovery_verification_hv.md) that lets you verify recoverability of VM backups and scan them for malware.
 
@@ -16,8 +17,6 @@ Veeam Backup & Replication offers the [SureBackup technology](surebackup_recover
 |  |
 | --- |
 | Important |
-| The recovery verification functionality is included in the Veeam Universal License.  When using a legacy socket-based license, Enterprise or higher edition is required. If you use the Standard edition, you can manually verify VM backups with Instant Recovery. For more information, see [Manual Recovery Verification](surebackup_manual.md). |
+| The availability of the recovery verification feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).  If you use the Standard edition, you can manually verify VM backups with Instant Recovery. For more information, see [Manual Recovery Verification](surebackup_manual.md). |
 
-Page updated 8/11/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/repos_mssql.md
+++ b/docs/repos_mssql.md
@@ -3,7 +3,7 @@ title: "Veeam Backup Repositories"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repos_mssql.html"
-last_updated: "1/19/2026"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -148,7 +148,7 @@ You can configure Veeam Backup & Replication to transfer Veeam Plug-In backup fi
 
 For Veeam Plug-In for Microsoft SQL Server backups, immutability works according to the following rules:
 
-* Immutability is applied to backup (.VAB) files and backup metadata (.VASM) files. Backup job metadata (.VACM) files are not immutable.
+* Immutability is applied to backup files (.VAB) and backup metadata files (.VASM). Backup job metadata files (.VACM) are not immutable.
 
 * Backup files become immutable for the configured time period (minimum 7 days, maximum 9999 days).
 
@@ -159,7 +159,7 @@ For Veeam Plug-In for Microsoft SQL Server backups, immutability works according
 | TIP |
 | Contact Veeam Customer Support to change the default 24 hour lifespan of a backup file. To do that, you can submit a support case on the [Veeam Customer Support Portal](https://www.veeam.com/support.html). |
 
-* The immutability period is automatically extended for backup files that contain restore points of the active chain.
+* The immutability period is automatically extended for backup files that contain restore points of the active chain. The logic is the same as for immutability that is configured in the object storage repository. Consider example in [Backup Immutability](plugins_mssql_object_storage_immutable.md#ex).
 
 Data Restore from Hardened Repository
 
@@ -188,7 +188,7 @@ Before you configure your backup infrastructure to back up to the object storage
 * Azure Data Box
 
 * Data in object storage repositories must be managed solely by Veeam Backup & Replication, including retention and data management. Lifecycle rules are not supported, and their enabling may result in backup and restore failures.
-* For backups located in object storage repositories, data recovery options are not available if you access the object storage repository using credentials with the read-only access permissions.
+* If you access the object storage repository using credentials with the read-only access permissions, data recovery options are not available for backups located in object storage repositories.
 
 * For Microsoft Azure Blob storage, Veeam Plug-Ins do not support soft delete for blobs.
 

--- a/docs/repos_rman.md
+++ b/docs/repos_rman.md
@@ -1,13 +1,14 @@
 ---
 title: "Veeam Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repos_rman.html"
-last_updated: "12/5/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Veeam Backup Repositories
 
-In this article
 
 Veeam Plug-Ins store backup files in repositories added to the Veeam Backup & Replication infrastructure. In this section, you can find the list of supported backup repositories and limitations for Veeam Plug-In backups.
 
@@ -160,7 +161,7 @@ You can configure Veeam Backup & Replication to transfer Veeam Plug-In backup fi
 
 For Veeam Plug-In for Oracle RMAN backups, immutability works according to the following rules:
 
-* Immutability is applied to backup (VAB) files and backup metadata (VASM) files. Backup job metadata (VACM) files are not immutable.
+* Immutability is applied to backup files (.VAB) and backup metadata files (.VASM). Backup job metadata files (.VACM) are not immutable.
 
 * Backup files become immutable for the configured time period (minimum 7 days, maximum 9999 days).
 
@@ -190,10 +191,8 @@ Before you configure your backup infrastructure to back up to the object storage
 * Azure Data Box
 
 * Data in object storage repositories must be managed solely by Veeam Backup & Replication, including retention and data management. Lifecycle rules are not supported, and their enabling may result in backup and restore failures.
-* For backups located in object storage repositories, data recovery options are not available if you access the object storage repository using credentials with the read-only access permissions.
+* If you access the object storage repository using credentials with the read-only access permissions, data recovery options are not available for backups located in object storage repositories.
 
 * For Microsoft Azure Blob storage, Veeam Plug-Ins do not support soft delete for blobs.
 
-Page updated 12/5/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/restore_amazon_byb.md
+++ b/docs/restore_amazon_byb.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_amazon_byb.html"
-last_updated: "1/7/2026"
+last_updated: "1/26/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 Check the following considerations and limitations.
 
@@ -27,7 +28,7 @@ Helper Appliance
 
 The helper appliance is an auxiliary Linux-based EC2 instance. It is used to upload backed-up data to Amazon EC2. Veeam Backup & Replication automatically deploys the helper appliance in Amazon EC2 only for the duration of the restore process and removes it immediately after that.
 
-* It is recommended to use the helper appliance when you recover from backups of EC2 instances. In other cases, it is recommended to use restore without the helper appliance.
+* It is recommended to use the helper appliance when you recover from backups of EC2 instances created by [Veeam Backup for AWS](https://helpcenter.veeam.com/docs/vbaws/guide/overview.html?ver=10). In other cases, it is recommended to use restore without the helper appliance.
 
 For information on how to configure the helper appliance, see [Configure Helper Appliance](restore_amazon_proxy.md).
 
@@ -66,6 +67,4 @@ AWS-Specific Considerations
 * Veeam Backup & Replication uses AWS VM Import/Export during restore. It is recommended to check limitations in the [AWS Documentation](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html).
 * If you plan to assign AWS tags to the restored EC2 instance, check limitations for tags in the [AWS Documentation](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/Using_Tags.html).
 
-Page updated 1/7/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/restore_from_immutable_rman.md
+++ b/docs/restore_from_immutable_rman.md
@@ -1,13 +1,14 @@
 ---
 title: "Restore from Hardened Repository"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_from_immutable_rman.html"
-last_updated: "12/4/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Restore from Hardened Repository
 
-In this article
 
 As a result of malware activity or unplanned actions, backup job metadata files (.VACM) may become unavailable in the hardened repository. In such cases, to restore data from the hardened repository, Veeam Backup & Replication can regenerate the .VACM file based on information from the backup job storage metadata file (.VASM). The recovery process depends on whether the backup is still visible in the Veeam Backup & Replication console. Use the following procedure to restore backup availability in the Veeam Backup & Replication console.
 
@@ -23,8 +24,6 @@ To restore metadata with a rescan operation, complete the following steps:
 
 As a result, the backup will appear in the Veeam Backup & Replication console as an imported backup. You can perform all available restore operations for imported backups with the newly imported backup.
 
-[![Repair of Backup](images/repo_rescan.webp)](images/repo_rescan.webp "Repair of Backup")
+[![Repair of Backup](images/plugins_repo_rescan.webp)](images/plugins_repo_rescan.webp "Repair of Backup")
 
-Page updated 12/4/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/restore_from_immutable_sap_orcl.md
+++ b/docs/restore_from_immutable_sap_orcl.md
@@ -1,13 +1,14 @@
 ---
 title: "Restore from Hardened Repository"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_from_immutable_sap_orcl.html"
-last_updated: "11/7/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Restore from Hardened Repository
 
-In this article
 
 As a result of malware activity or unplanned actions, backup job metadata files (.VACM) may become unavailable in the hardened repository. In such cases, to restore data from the hardened repository, Veeam Backup & Replication can regenerate the .VACM file based on information from the backup job storage metadata file (.VASM). The recovery process depends on whether the backup is still visible in the Veeam Backup & Replication console. Use the following procedure to restore backup availability in the Veeam Backup & Replication console.
 
@@ -23,8 +24,6 @@ To restore metadata with a rescan operation, complete the following steps:
 
 As a result, the backup will appear in the Veeam Backup & Replication console as an imported backup. You can perform all available restore operations for imported backups with the newly imported backup.
 
-[![Repair of Backup](images/repo_rescan.webp)](images/repo_rescan.webp "Repair of Backup")
+[![Repair of Backup](images/plugins_repo_rescan.webp)](images/plugins_repo_rescan.webp "Repair of Backup")
 
-Page updated 11/7/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/restore_google_byb.md
+++ b/docs/restore_google_byb.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_google_byb.html"
-last_updated: "12/30/2025"
+last_updated: "1/26/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 Check the following considerations and limitations.
 
@@ -40,7 +41,7 @@ Helper Appliance
 
 The helper appliance is an auxiliary Linux-based VM instance. It is used to upload backed-up data to Google Compute Engine. Veeam Backup & Replication automatically deploys the helper appliance in Google Compute Engine only for the duration of the restore process and removes it immediately after that.
 
-* It is recommended to use the helper appliance when you recover from backups of Google Compute Engine virtual machines. In other cases, it is recommended to use restore without the helper appliance.
+* It is recommended to use the helper appliance when you recover from backups of Google Compute Engine virtual machines created by [Veeam Backup for Google Cloud](https://helpcenter.veeam.com/docs/vbgc/guide/welcome.html?ver=7). In other cases, it is recommended to use restore without the helper appliance.
 
 For information on how to configure the helper appliance, see [Configure Helper Appliance](restore_google_proxy_appliance.md).
 
@@ -50,6 +51,4 @@ For information on how to configure the helper appliance, see [Configure Helper 
 * The VPC route table must contain a route from the IP address of the Veeam Backup & Replication server to an active Google Cloud internet gateway. For more information on internet gateways and how to create route tables, see the [Google Cloud documentation](https://cloud.google.com/vpc/docs/routes).
 * Check that OS Login is disabled for the project where you plan to recover VM instances. For more information on how to configure OS Login, see the [Google Cloud documentation](https://cloud.google.com/compute/docs/oslogin/set-up-oslogin). If you want to have OS Login enabled, use restore without the helper appliance.
 
-Page updated 12/30/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/sap_orcl_repos.md
+++ b/docs/sap_orcl_repos.md
@@ -1,13 +1,14 @@
 ---
 title: "Veeam Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sap_orcl_repos.html"
-last_updated: "11/21/2025"
+last_updated: "1/23/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Veeam Backup Repositories
 
-In this article
 
 Veeam Plug-Ins store backup files in repositories added to the Veeam Backup & Replication infrastructure. In this section, you can find the list of supported backup repositories and limitations for Veeam Plug-In backups.
 
@@ -160,7 +161,7 @@ You can configure Veeam Backup & Replication to transfer Veeam Plug-In backup fi
 
 For Veeam Plug-In for SAP on Oracle backups, immutability works according to the following rules:
 
-* Immutability is applied to backup (VAB) files and backup metadata (VASM) files. Backup job metadata (VACM) files are not immutable.
+* Immutability is applied to backup files (.VAB) and backup metadata files (.VASM). Backup job metadata files (.VACM) are not immutable.
 
 * Backup files become immutable for the configured time period (minimum 7 days, maximum 9999 days).
 
@@ -190,10 +191,8 @@ Before you configure your backup infrastructure to back up to the object storage
 * Azure Data Box
 
 * Data in object storage repositories must be managed solely by Veeam Backup & Replication, including retention and data management. Lifecycle rules are not supported, and their enabling may result in backup and restore failures.
-* For backups located in object storage repositories, data recovery options are not available if you access the object storage repository using credentials with the read-only access permissions.
+* If you access the object storage repository using credentials with the read-only access permissions, data recovery options are not available for backups located in object storage repositories.
 
 * For Microsoft Azure Blob storage, Veeam Plug-Ins do not support soft delete for blobs.
 
-Page updated 11/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/sobr_limitations.md
+++ b/docs/sobr_limitations.md
@@ -1,13 +1,14 @@
 ---
 title: "Limitations for Scale-Out Backup Repositories"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sobr_limitations.html"
-last_updated: "11/20/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Limitations for Scale-Out Backup Repositories
 
-In this article
 
 Limitations for Jobs
 
@@ -92,7 +93,7 @@ Enterprise edition of Veeam Backup & Replication has the following limitations f
 |  |
 | --- |
 | Note |
-| Veeam Universal License and Enterprise Plus of Veeam Backup & Replication editions have no limitations on the number of scale-out backup repositories or performance extents and capacity extents. |
+| Veeam Universal License and Enterprise Plus editions of Veeam Backup & Replication have no limitations on the number of scale-out backup repositories or performance extents and capacity extents. |
 
 Limitations for Veeam Solutions
 
@@ -107,6 +108,4 @@ For more information on limitations for a specific Veeam solution that utilizes 
 
 * [Veeam Agent for Microsoft Windows](https://helpcenter.veeam.com/docs/agentforwindows/userguide/backup_to_object_storage.html?ver=13#considerations-and-limitations) — to check limitations for data protection and disaster recovery solution for physical and virtual machines running Windows-based operating systems.
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/staged_restore_about.md
+++ b/docs/staged_restore_about.md
@@ -1,13 +1,14 @@
 ---
 title: "Staged Restore"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/staged_restore_about.html"
-last_updated: "10/21/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Staged Restore
 
-In this article
 
 Staged restore allows you to run an executable script for VMs before recovering them to the production environment. Staged restore is a part of the entire VM restore operations. To perform staged restore, you must select the Staged Restore mode in the [Full VM Restore](performing_full_recovery.md) wizard and specify [staged restore settings](full_restore_staged_vm.md).
 
@@ -20,7 +21,7 @@ Staged restore can help you ensure that recovered VMs do not contain any persona
 |  |
 | --- |
 | Note |
-| The staged restore functionality is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required. |
+| The availability of the staged restore feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 Requirements and Limitations for Staged Restore
 
@@ -72,6 +73,4 @@ Related Topics
 
 * [Pre-Freeze and Post-Thaw Scripts](pre_post_scripts.md)
 
-Page updated 10/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/staged_restore_about_hv.md
+++ b/docs/staged_restore_about_hv.md
@@ -1,13 +1,14 @@
 ---
 title: "Staged Restore"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/staged_restore_about_hv.html"
-last_updated: "10/21/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Staged Restore
 
-In this article
 
 Staged restore allows you to run an executable script for VMs before recovering them to the production environment. Staged restore is a part of the entire VM restore operations. To perform staged restore, you must select the Staged Restore mode in the [Full VM Restore](performing_full_recovery_hv.md) wizard and specify [staged restore settings](full_restore_staged_hv.md).
 
@@ -20,7 +21,7 @@ Staged restore can help you ensure that recovered VMs do not contain any persona
 |  |
 | --- |
 | Note |
-| The staged restore functionality is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required. |
+| The availability of the staged restore feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 Requirements and Limitations for Staged Restore
 
@@ -65,6 +66,4 @@ Related Topics
 
 * [Pre-Freeze and Post-Thaw Scripts](pre_post_scripts_hv.md)
 
-Page updated 10/21/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/storage_limitations_ciscohx.md
+++ b/docs/storage_limitations_ciscohx.md
@@ -1,17 +1,18 @@
 ---
 title: "Cisco HyperFlex"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/storage_limitations_ciscohx.html"
-last_updated: "2/14/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Cisco HyperFlex
 
-In this article
 
 If you plan to use VMware integration and perform backup and replication from Cisco HyperFlex storage snapshots, consider the following:
 
-* License for Veeam Backup & Replication Enterprise Plus edition must be installed on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 * Cisco HyperFlex system must be added to the backup infrastructure. For more information, see [Adding Cisco HyperFlex Storage System](cisco_add.md).
 
@@ -27,6 +28,4 @@ During backup or replication, Veeam Backup & Replication fails to trigger Cisco 
 * The Limit processed VM count per storage snapshots to N option is not applicable to Cisco HyperFlex since snapshots for VMs hosted on Cisco HyperFlex are created at the VM level, not volume level.
 * For working with REST API, use default route and default port: https://{hostname}:443.
 
-Page updated 2/14/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/storage_limitations_general.md
+++ b/docs/storage_limitations_general.md
@@ -1,13 +1,14 @@
 ---
 title: "General Requirements and Limitations (Storage Systems)"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/storage_limitations_general.html"
-last_updated: "1/6/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # General Requirements and Limitations (Storage Systems)
 
-In this article
 
 The following limitations apply to all storage systems supported by Veeam Backup & Replication.
 
@@ -57,7 +58,7 @@ To use IPv6 addresses and resolve names using IPv6, configure IPv6 communication
 
 Backup from storage snapshots has the following requirements and limitations:
 
-* You must install the Enterprise Plus edition of Veeam Backup & Replication on the backup server.
+* The availability of backup from storage snapshots depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 * You must configure the backup infrastructure in the following way:
 
@@ -106,7 +107,7 @@ Snapshot jobs (snapshot-only jobs and backup jobs with storage snapshot retentio
 + Add to the backup infrastructure vCenter Server or ESXi hosts with VMs whose disks are hosted on the storage system.
 + Add the storage system to the backup infrastructure. If you plan to perform backup from snapshots on secondary storage arrays, also add the secondary storage array to the backup infrastructure.
 
-* You must install a license for Veeam Backup & Replication Enterprise Plus edition on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * [For backup from secondary storage arrays] When you add storage arrays to the backup infrastructure, you must add to the rescan scope volumes and LUNs on which VM disks are located (both for primary and secondary storage arrays). For more information, see the description of the storage system wizard.
 
 [VMware Integration] Data Recovery from Storage Snapshots
@@ -165,6 +166,4 @@ Before you restore VM guest OS files from Linux, Unix or other file systems, che
 
 For more information on configuring connection settings for Linux servers, see the [Specify Credentials and SSH Settings](linux_server_ssh.md) step of the New Linux Server wizard.
 
-Page updated 1/6/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/supported_features.md
+++ b/docs/supported_features.md
@@ -1,13 +1,14 @@
 ---
 title: "Supported Storage Features for Backup and Orchestration"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/supported_features.html"
-last_updated: "1/6/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Supported Storage Features for Backup and Orchestration
 
-In this article
 
 Veeam Backup & Replication supports the following native storage features for backup from storage snapshots and snapshot orchestration:
 
@@ -48,7 +49,7 @@ The following table shows which storage systems and which features supports Veea
 | Pure Storage FlashArray | ✓ | Asynchronous Replication ActiveCluster Replication | ✓ | Asynchronous Replication2 ActiveCluster Replication1 | ✕ | Offload2 |
 | Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile) | ✓ | ✕ | ✓ | ✕ | ✕ | ✕ |
 
-1 Snapshot orchestration requires at least Enterprise license. Backup from storage snapshots with snapshot retention always requires Enterprise Plus license.
+1 Snapshot orchestration and backup from storage snapshots with snapshot retention requires specific licenses. For more information, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 2 Enterprise Plus license is required.
 
@@ -72,6 +73,4 @@ The following table shows storage systems, replication features and terms for th
 | Hitachi VSP/VSP One Block | ✕ | TrueCopy Global-Active Device (GAD) |
 | Pure Storage FlashArray | Asynchronous Replication | ActiveCluster Replication |
 
-Page updated 1/6/2026
 
-Page content applies to build 13.0.1.1071

--- a/docs/surebackup_before_you_begin_hv.md
+++ b/docs/surebackup_before_you_begin_hv.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_before_you_begin_hv.html"
-last_updated: "1/19/2026"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -12,7 +12,7 @@ product_version: "13.0.1.1071"
 
 Before you create and start a recovery verification job, check the following prerequisites:
 
-* A valid Veeam Universal License of Veeam Backup & Replication must be installed on the backup server. When using a legacy socket-based license, Enterprise or higher edition is required.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 * All applications and services on which verified machines are dependent must be virtualized in your environment.
 * You must create or connect a virtual lab. For more information, see sections [Creating Virtual Lab](vlab_hv.md) and [Connecting to Existing Virtual Lab](connect_to_vlab_hv.md).

--- a/docs/uni_cdp_considerations.md
+++ b/docs/uni_cdp_considerations.md
@@ -1,19 +1,20 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/uni_cdp_considerations.html"
-last_updated: "12/12/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 If you plan to use universal CDP to protect your workloads, consider the following requirements and limitations.
 
 Licensing
 
-CDP is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise Plus edition is required.
+The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 
 Infrastructure Components
 
@@ -74,6 +75,4 @@ Replicas
 * On the target host, Veeam Backup & Replication does not allow you to migrate replicas using VMware vSphere Storage vMotion. Note that host vMotion is allowed. However, note that during failover, host vMotion is not allowed.
 * Replicas can be powered on only using the failover operation; powering on replicas manually is not supported.
 
-Page updated 12/12/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/used_ports.md
+++ b/docs/used_ports.md
@@ -3,7 +3,7 @@ title: "Ports"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html"
-last_updated: "1/21/2026"
+last_updated: "1/26/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -113,9 +113,7 @@ The following table describes network ports that must be opened to ensure proper
 | From | To | Protocol | Port | Notes |
 | --- | --- | --- | --- | --- |
 | Veeam Backup & Replication console | Mount server | TCP | 6162, 2500 to 3300 | [Remote console only] Ports used as data transmission channels for guest OS file-level restore. For every TCP connection that a job uses, one port from this range is assigned.  These ports are used if the mount server is not located on the console.  Note: The port range 2500-3300 is optional. You can use it for failover if port 6162 is unavailable. |
-|  | TCP |  |  |
 | Veeam AI Assistant  (rest-ai.veeam.com) | TCP | 443 | Default port for communication with the Veeam AI Assistant service. |
-| Backup server | TCP | 9396 | Port used for gRPC communication with UI Service required for GUI operation (processing database queries and caching data). |
 | Backup server | TCP | 9420 | [For console version 12.3.2 P1 (build 12.3.2.4165)] Port used by the Veeam Backup & Replication console to communicate with the backup server for console automatic update. |
 
 Veeam Infrastructure Appliance
@@ -130,6 +128,11 @@ The following table describes network ports that must be opened to ensure proper
 | NTP server | UDP | 123 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO for synchronization with NTP time servers. |
 | NTS server | UDP | 123 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO for synchronization with NTS time servers. |
 | TCP | 4460 |
+| DNS server | UDP | 53 | Port used for communication with the DNS server. It is required for forward/reverse name resolution of all backup and infrastructure servers including Active Directory domain controllers. |
+| Active Directory Domain Controllers | TCP | 636, 3268, 3269 | Ports used for communications over LDAP and LDAPS protocols. |
+| UDP, TCP | 389 |
+| UDP, TCP | 445, 139 | Ports used for communications over SMB protocol. |
+| UDP, TCP | 88 | Port used for Kerberos authentication. |
 | Backup server | Veeam Infrastructure Appliance | TCP | 443 | Port used by Veeam Backup & Replication to synchronize Veeam Updater settings on backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. |
 | Management client PC (remote access) | TCP | 10443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. Required to connect to the Host Management console. |
 
@@ -1018,7 +1021,7 @@ Veeam Plug-Ins for Cloud Solutions
 
 * [AWS Plug-In for Veeam Backup & Replication](https://helpcenter.veeam.com/docs/vbaws/guide/ports.html?ver=10)
 * [Microsoft Azure Plug-In for Veeam Backup & Replication](https://helpcenter.veeam.com/docs/vbazure/guide/ports.html?ver=8.1)
-* [Google Cloud Plug-In for Veeam Backup & Replication](https://helpcenter.veeam.com/docs/vbgc/guide/ports.html?ver=7)
+* [Veeam Plug-in for Google Cloud](https://helpcenter.veeam.com/docs/vbgc/guide/ports.html?ver=7)
 
 Kasten
 

--- a/docs/vbr_restore_pass.md
+++ b/docs/vbr_restore_pass.md
@@ -1,13 +1,14 @@
 ---
 title: "Step 5. Specify Password"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vbr_restore_pass.html"
-last_updated: "12/4/2023"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Step 5. Specify Password
 
-In this article
 
 The Password step of the wizard is available if you have enabled the encryption option in the configuration backup properties.
 
@@ -21,10 +22,8 @@ If you forgot or lost the password, click the I forgot the password link. For mo
 |  |
 | --- |
 | Note |
-| Restoring configuration data without a password is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required.  Also, your backup server must be connected to Veeam Backup Enterprise Manager. Otherwise, you will not see the I forgot the password link. |
+| The availability of restoring configuration data without a password depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).  Also, your backup server must be connected to Veeam Backup Enterprise Manager. Otherwise, you will not see the I forgot the password link. |
 
 ![Step 5. Specify Password](images/vbr_restore_pass.webp)
 
-Page updated 12/4/2023
 
-Page content applies to build 13.0.1.1071

--- a/docs/vead_considerations.md
+++ b/docs/vead_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_considerations.html"
-last_updated: "11/20/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for Microsoft Active Directory.
 
@@ -22,6 +23,12 @@ General
 
 * Veeam Explorer for Microsoft Active Directory does not support data recovery using a group Managed Service Account (gMSA) to connect to the target server.
 * Veeam Explorer for Microsoft Active Directory must stay open during all data recovery operations. If the user who started the operation logs out or is logged out automatically, the operation will be terminated.
+
+* Veeam Explorer for Microsoft Active Directory does not support Active Directory Lightweight Directory Services (AD LDS).
+* Database files created by the domain controller can be opened for object recovery with Veeam Explorer for Microsoft Active Directory only if Veeam Explorer for Microsoft Active Directory is installed on a Windows machine with the same OS version or later than the version of the domain controller OS.
+* To open database files, Veeam Explorer for Microsoft Active Directory uses a service dynamic link library (Esent.dll) which is installed with Microsoft Active Directory Domain Services and can be found in the %SystemRoot% directory. The Esent.dll file on a machine with Veeam Explorer for Microsoft Active Directory must be of the same version as that of Microsoft Active Directory Domain Services that was used to create database files.
+
+* [For machines with ReFS] The mount server, backup server and the machine where the Veeam Backup & Replication console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
 * [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 
 Restore
@@ -54,6 +61,4 @@ Export
 * Veeam Explorer for Microsoft Active Directory uses Lightweight Data Interchange Format to save Active Directory objects and containers to .ldf files. You can make an .ldf file available to the Active Directory Domain Services server by importing it with the ldifde utility. For more information, see [this Microsoft article](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc816781%28v%3Dws.10%29).
 * Veeam Explorer for Microsoft Active Directory does not support exporting passwords.
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vead_systemreqs.md
+++ b/docs/vead_systemreqs.md
@@ -1,13 +1,14 @@
 ---
 title: "System Requirements"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_systemreqs.html"
-last_updated: "11/7/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # System Requirements
 
-In this article
 
 This section lists system requirements for Veeam Explorer for Microsoft Active Directory.
 
@@ -15,14 +16,4 @@ This section lists system requirements for Veeam Explorer for Microsoft Active D
 | --- | --- |
 | Microsoft Active Directory Domain Services | Veeam Explorer for Microsoft Active Directory supports restore of domain controllers running on the following operating systems:   * Microsoft Windows Server 2025 * Microsoft Windows Server 2022 * Microsoft Windows Server 2019 * Microsoft Windows Server 2016 * Microsoft Windows Server 2012 R2   Minimum supported domain and forest functional level is Windows 2012 R2. |
 
-Consider the following:
 
-* Veeam Explorer for Microsoft Active Directory does not support Active Directory Lightweight Directory Services (AD LDS).
-* Database files created by the domain controller can be opened for object recovery with Veeam Explorer for Microsoft Active Directory only if Veeam Explorer for Microsoft Active Directory is installed on a Windows machine with the same OS version or later than the version of the domain controller OS.
-* To open database files, Veeam Explorer for Microsoft Active Directory uses a service dynamic link library (esent.dll) which is installed with Microsoft Active Directory Domain Services and can be found in the %SystemRoot% directory. The Esent.dll file on a machine with Veeam Explorer for Microsoft Active Directory must be of the same version as that of Microsoft Active Directory Domain Services that was used to create database files.
-
-* [For machines with ReFS] The mount server, backup server and the machine where the Veeam Backup & Replication console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
-
-Page updated 11/7/2025
-
-Page content applies to build 13.0.1.1071

--- a/docs/vehana_considerations.md
+++ b/docs/vehana_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vehana_considerations.html"
-last_updated: "11/3/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for SAP HANA.
 
@@ -66,6 +67,4 @@ For more information about this command, see [Restore to Another Server (System 
 * Before you restore a tenant database using the SSL protocol, make sure that the target SAP HANA system is properly configured to use SSL and that the backup server has SAP Common Crypto Library installed. For more information about how to install SAP Common Crypto Library on Windows machines, see the [SAP Help Portal](https://help.sap.com/docs/SAP_DATA_SERVICES/e54136ab6a4a43e6a370265bf0a2d744/c049e28431ee4e8280cd6f5d1a8937d8.html?locale=en-US).
 * [For Windows-based backup servers] If you are using secure restore, the backup server is running Microsoft Windows Server 2012 or 2016 and you are using SAP Common Crypto Library 8.5.51 or higher, you must export the SSL private key with the Triple DES encryption algorithm. SAP Common Crypto Library 8.5.51 or higher uses the AES 256 encryption algorithm as default for PKCS #12 encryption, while this encryption algorithm is not supported in Microsoft Windows Server 2012 and 2016.
 
-Page updated 11/3/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vemdb_considerations.md
+++ b/docs/vemdb_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vemdb_considerations.html"
-last_updated: "11/20/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for MongoDB.
 
@@ -16,15 +17,10 @@ General
 Consider the following:
 
 * When Veeam Explorer for MongoDB is installed on a server on which both Veeam Backup & Replication and Veeam Backup for Microsoft 365 are installed, the notification settings will be inherited from the Veeam Backup & Replication Global Notification settings.
-
 * Before you recover MongoDB data to another server, make sure MongoDB is installed on the target server. For more information on supported MongoDB versions, see [System Requirements](vemdb_systemreqs.md).
-
 * Before you recover MongoDB data, make sure that the target system has the same major MongoDB version as the one installed on the backed-up system.
-
 * Data recovery to MongoDB sharded clusters is not supported.
-
 * You cannot recover MongoDB data encrypted with native MongoDB encryption.
-
 * Before you use TLS or X.509 authentication with the System Certificate Authority option, make sure that the Certificate Authority file of the target replica set is added to the Trusted Root Certification Authorities certificate store of the mount server associated with the backup repository.
 * Data recovery to machines running MongoDB Community Edition is not supported.
 * [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
@@ -35,7 +31,6 @@ Consider the following when planning to restore MongoDB data:
 
 * Veeam Explorer for MongoDB does not support restore using PowerShell Direct, VIX API or vSphere Automation API.
 * Restoring an entire MongoDB instance does not preserve replica set infrastructure. For more information on how to redeploy the replica set, see the [MongoDB Manual](https://www.mongodb.com/docs/manual/tutorial/convert-standalone-to-replica-set/).
-
 * When restoring collections, you can only restore to the primary node of the target MongoDB replica set.
 * Point-in-time restore is only available when restoring multiple collections from the replica set node or when restoring an entire instance. Point-in-time restore is not available when restoring single databases, or when restoring multiple collections from a database. This is because MongoDB collects the oplog on the level of the entire replica set.
 * You cannot restore MongoDB data from multiple backups in parallel to the same target machine.
@@ -47,6 +42,4 @@ Consider the following when planning to publish MongoDB data:
 * Make sure that the volume with the write cache has enough free disk space to store the changes of the published database. The write cache is stored in the /var/lib/veeam/IRCache folder on the mount server.
 * To be able to restore collections from a published instance, make sure the instance is published to the primary node of the target replica set.
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/veo_systemreqs.md
+++ b/docs/veo_systemreqs.md
@@ -1,13 +1,14 @@
 ---
 title: "System Requirements"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veo_systemreqs.html"
-last_updated: "11/12/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # System Requirements
 
-In this article
 
 The system requirements depend on whether you want to use an image-level backup created with native Veeam Backup & Replication functionality or an application backup created with Veeam Plug-In for Oracle RMAN.
 
@@ -18,7 +19,7 @@ This section lists system requirements that are relevant when recovering data fr
 | Component | Requirement |
 | --- | --- |
 | Oracle Database on Windows OS | Veeam Explorer for Oracle supports restore of Oracle Database running on the following Microsoft Windows operating systems:   * Microsoft Windows Server 2025 * Microsoft Windows Server 2022 * Microsoft Windows Server 2019 * Microsoft Windows Server 2016  Veeam Explorer for Oracle supports restore of the following Oracle Database versions on Microsoft Windows machines:  * Oracle Database 21c * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c Release 2 * Oracle Database 12c Release 1 * Oracle Database 11g Release 2 |
-| Oracle Database on Linux OS | Veeam Explorer for Oracle supports restore of Oracle Database running on the following Linux distributions:   * RHEL 8.4 to 9.4 * SLES 12 SP5, 15 SP3 or later * Oracle Linux 7 (UEK3) to 9 (UEK R7) * Oracle Linux 7 to 9 (RHCK)  Veeam Explorer for Oracle supports restore of the following Oracle Database versions on Linux machines:  * Oracle Database 21c * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c Release 2 * Oracle Database 12c Release 1 * Oracle Database 11g Release 2 |
+| Oracle Database on Linux OS | Veeam Explorer for Oracle supports restore of Oracle Database running on the following Linux distributions:  * RHEL 8.4 to 9.4 * SLES 12 SP5, 15 SP3 or later * Oracle Linux 7 (UEK3) to 9 (UEK R7) * Oracle Linux 7 to 9 (RHCK)  Veeam Explorer for Oracle supports restore of the following Oracle Database versions on Linux machines:  * Oracle Database 21c * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c Release 2 * Oracle Database 12c Release 1 * Oracle Database 11g Release 2 |
 
 Restore from RMAN Plug-in Backups
 
@@ -27,8 +28,6 @@ This section lists system requirements that are relevant when restoring data fro
 | Component | Requirement |
 | --- | --- |
 | Oracle Database on Windows OS | Veeam Explorer for Oracle supports restore from RMAN plug-in backups of Oracle Database running on the following Microsoft Windows operating systems:   * Microsoft Windows Server 2025 * Microsoft Windows Server 2022 * Microsoft Windows Server 2019 * Microsoft Windows Server 2016 * Microsoft Windows Server 2012 R2   Veeam Explorer for Oracle supports restore from RMAN plug-in backups of the following versions of Oracle Database on Windows machines:   * Oracle Database 21c  * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c Release 2 * Oracle Database 12c Release 1 * Oracle Database 11g Release 2   Notes:   * Oracle Express Edition (XE) is not supported. * Oracle databases residing in OS-level containerized environments (for example: Docker, Podman) are not supported. * Support for Oracle database 23ai is limited to virtual machines in cloud deployments (for example: Oracle Cloud Infrastructure, Oracle Exadata Cloud) and Oracle Engineered Systems (for example: Oracle Exadata, Oracle Database Appliance). |
-| Oracle Database on Linux OS | Veeam Explorer for Oracle supports restore from RMAN plug-in backups of Oracle Database running on the following Linux distributions:   * SUSE Linux Enterprise Server 12 SP5, 15 SP3 and SP7 (x86 and x86\_64) * RHEL 8.4 – 9.x, 10.0 including Extended Update Support Add-On * Oracle Linux 7 – 9.x * CentOS 6.4 – 8.x: For non-production environments, as it is not officially supported by Oracle for their databases.   Veeam Explorer for Oracle supports restore from RMAN plug-in backups of the following versions of Oracle Database on Linux machines:   * Oracle Database 23ai * Oracle Database 21c  * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c * Oracle Database 11g Release 2   Notes:   * Oracle Express Edition (XE) is not supported. * Oracle databases residing in OS-level containerized environments (for example: Docker, Podman) are not supported. * Support for Oracle database 23ai is limited to virtual machines in cloud deployments (for example: Oracle Cloud Infrastructure, Oracle Exadata Cloud) and Oracle Engineered Systems (for example: Oracle Exadata, Oracle Database Appliance). |
+| Oracle Database on Linux OS | Veeam Explorer for Oracle supports restore from RMAN plug-in backups of Oracle Database running on the following Linux distributions:   * SUSE Linux Enterprise Server 12 SP5, 15 SP3 and SP7 (x86 and x86\_64) * RHEL 8.4 – 9.x, 10.0 including Extended Update Support Add-On * Oracle Linux 7 – 9.x * CentOS 6.4 – 8.x (For non-production environments, as it is not officially supported by Oracle for their databases)   Veeam Explorer for Oracle supports restore from RMAN plug-in backups of the following versions of Oracle Database on Linux machines:   * Oracle Database 23ai * Oracle Database 21c  * Oracle Database 19c * Oracle Database 18c * Oracle Database 12c * Oracle Database 11g Release 2   Notes:   * Oracle Express Edition (XE) is not supported. * Oracle databases residing in OS-level containerized environments (for example: Docker, Podman) are not supported. * Support for Oracle database 23ai is limited to virtual machines in cloud deployments (for example: Oracle Cloud Infrastructure, Oracle Exadata Cloud) and Oracle Engineered Systems (for example: Oracle Exadata, Oracle Database Appliance). |
 
-Page updated 11/12/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/veod_considerations.md
+++ b/docs/veod_considerations.md
@@ -1,20 +1,19 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veod_considerations.html"
-last_updated: "11/20/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and limitations of Veeam Explorer for Microsoft OneDrive for Business.
 
 * Veeam Explorer for Microsoft OneDrive for Business must stay open during all data recovery operations. If the user who started the operation logs out or is logged out automatically, the operation will be terminated.
-
 * Restore of OneNote notebooks from backups of Microsoft OneDrive for Business data for organizations with modern app-only authentication is not supported.
-
 * If the size of a OneNote notebook is greater 2 GB, Veeam Explorer for Microsoft OneDrive for Business saves this OneNote notebook as a folder with OneNote items.
 * [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 
@@ -23,6 +22,4 @@ This section lists considerations and limitations of Veeam Explorer for Microsof
 | Note |
 | To use an internet proxy server to restore backups created by Veeam Backup for Microsoft 365, make sure to provide appropriate proxy server address and the port number. To do this, go to the Control Panel > Internet Options Connections tab, click LAN Settings, select the Use a proxy server for your LAN check box and specify a proxy server you want to use. Credentials for such a proxy (if needed) will be taken from the Control Panel > Credential Manager > Windows Credentials console.  Consider that this functionality is only available in Veeam Explorer for Microsoft OneDrive for Business that comes as part of the Veeam Backup for Microsoft 365 installation package. |
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/veor_considerations.md
+++ b/docs/veor_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veor_considerations.html"
-last_updated: "12/2/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for Oracle.
 
@@ -72,9 +73,10 @@ If you have selected the more secure, manual validation in the Veeam Backup & Re
 
 * [For data recovery to Oracle ASM disks] You cannot specify paths and file names for recovered database files. During recovery, Oracle ASM will automatically create and name the necessary files in the specified disk group using the OMF (Oracle Managed Files) feature.
 * Veeam Explorer for Oracle does not support recovery of Oracle databases deployed on Solaris OS or IBM AIX. You can restore such databases with Veeam Plug-In for Oracle RMAN. For details, see [Restore to Original Server](restore_rman.md) or [Restore to Another Server](restore_other_server_rman.md).
-* [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 
 * [For Linux-based backup servers] To recover Oracle data to a Microsoft Windows server, you must specify a Windows mount server for the backup repository or a default Windows mount server.
+
+* [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 
 Restore from Image-Level Backups
 
@@ -196,6 +198,4 @@ Export
 
 The databases from the Data Guard are exported as standalone Oracle databases, preserving no Data Guard infrastructure.
 
-Page updated 12/2/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vep_considerations.md
+++ b/docs/vep_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_considerations.html"
-last_updated: "12/23/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for PostgreSQL.
 
@@ -81,6 +82,4 @@ Export
 * PostgreSQL on the staging server and on the backed-up machine must be of the same major version. For example, if PostgreSQL 15.1 is installed on the backed-up machine, the staging server can have PostgreSQL 15.3.
 * You can use pg\_restore to reconstruct a database from a DUMP file exported with Veeam Explorer for PostgreSQL. If a new database is created in the process and the database in the DUMP file has tablespaces, you must manually create tablespaces with the same names as the ones in the DUMP file. Note that the --no-tablespace argument of the pg\_restore utility, which places the reconstructed database in the default tablespace, is not supported for DUMP files exported with Veeam Explorer for PostgreSQL. For more information, see [Restoring Exported Database](vep_export_restore_exported_databases.md).
 
-Page updated 12/23/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vep_systemreqs.md
+++ b/docs/vep_systemreqs.md
@@ -1,13 +1,14 @@
 ---
 title: "System Requirements"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_systemreqs.html"
-last_updated: "11/7/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # System Requirements
 
-In this article
 
 This section lists system requirements for Veeam Explorer for PostgreSQL.
 
@@ -15,6 +16,4 @@ This section lists system requirements for Veeam Explorer for PostgreSQL.
 | --- | --- |
 | PostgreSQL on Linux | Veeam Explorer for PostgreSQL supports restore of the following PostgreSQL versions on Linux machines:   * PostgreSQL 18 * PostgreSQL 17 * PostgreSQL 16 * PostgreSQL 15 * PostgreSQL 14 * PostgreSQL 13 |
 
-Page updated 11/7/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/verification_before_you_begin.md
+++ b/docs/verification_before_you_begin.md
@@ -1,17 +1,18 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/verification_before_you_begin.html"
-last_updated: "11/18/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create and start a SureBackup job, check the following prerequisites:
 
-* A valid Veeam Universal License of Veeam Backup & Replication must be installed on the backup server. When using a legacy socket-based license, Enterprise or higher edition is required.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * All applications and services on which verified machines are dependent must be virtualized in your environment.
 * To perform full recoverability testing, you must create or connect a virtual lab. For more information, see sections [Creating Virtual Lab](create_vlab.md) and [Connecting to Existing Virtual Lab](connect_to_vlab.md).
 * If you plan to verify Microsoft Windows machines, you must configure Microsoft Windows-based mount server. For more information, see [Mount Servers](mount_server.md).
@@ -27,6 +28,4 @@ Consider the following limitations:
 * The source backup or replication job has a higher priority than the SureBackup job. If the source backup or replication job starts when the SureBackup job is running, and this job is about to modify the restore point from which the VM is started, Veeam Backup & Replication automatically powers off VMs in the virtual lab and completes the SureBackup job.
 * The Microsoft SQL Server Checker script runs on the backup server side. For this reason, Named Pipes or TCP/IP connections must be enabled for the Microsoft SQL Server running in the virtual lab. For more information, see [Microsoft Docs](https://msdn.microsoft.com/en-us/library/dd983822%28v%3Dnav.71%29.aspx).
 
-Page updated 11/18/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vesp_recovery_specials.md
+++ b/docs/vesp_recovery_specials.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_recovery_specials.html"
-last_updated: "11/20/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and limitations of Veeam Explorer for Microsoft SharePoint.
 
@@ -35,6 +36,7 @@ If you start item-level recovery directly for the backup of the SharePoint VM, m
 Backup of the same VM by both Veeam Backup & Replication and Veeam Agent for Microsoft Windows may be required, for example, if Microsoft SQL Server running on the VM operates as part of a failover cluster.
 
 * Veeam Explorer for Microsoft SharePoint must stay open during all data recovery operations. If the user who started the operation logs out or is logged out automatically, the operation will be terminated.
+* [For machines with ReFS] The mount server, staging server, backup server and the machine where the console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
 
 |  |
 | --- |
@@ -158,6 +160,4 @@ Also, consider the following when planning for the restore of list items (with o
 * If the retention policy for the target list or target document library was configured to declare items as records automatically, only the last version of the item will be restored to the target list or target document library. Target retention policy settings will be applied to the restored item. Besides, if the Require content approval for submitted items option was enabled for the original list, then the item status will be set to Pending after restore.
 * Alternatively (with different retention policy settings), all versions of the original item will be restored to the target list or target document library. Besides, if the Require content approval for submitted items option was enabled for the original list, then after restore the item status in the content approval workflow will be also restored, except for the states listed. For more information, see [Status Restore Limitations](#status_restore_lim).
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vesp_systemreqs.md
+++ b/docs/vesp_systemreqs.md
@@ -1,13 +1,14 @@
 ---
 title: "System Requirements"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_systemreqs.html"
-last_updated: "11/7/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # System Requirements
 
-In this article
 
 This section lists system requirements for Veeam Explorer for Microsoft SharePoint.
 
@@ -20,11 +21,4 @@ The set of supported Microsoft SharePoint versions depends on the product Veeam 
 
 \*Government support is experimental. For more information on Veeam experimental support, see [this Veeam KB article](https://www.veeam.com/kb2976).
 
-|  |
-| --- |
-| Note |
-| [For machines with ReFS] The mount server, staging server, backup server and the machine where the console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability). |
 
-Page updated 11/7/2025
-
-Page content applies to build 13.0.1.1071

--- a/docs/vesql_configure_staging.md
+++ b/docs/vesql_configure_staging.md
@@ -1,15 +1,18 @@
 ---
 title: "Configuring Staging SQL Server"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_configure_staging.html"
-last_updated: "8/15/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Configuring Staging SQL Server
 
-In this article
 
-To enable advanced recovery functionality, you can use a Microsoft SQL Server machine as a staging server. This section explains the use cases of the staging server and how to configure it.
+To enable advanced recovery functionality, you can use a Microsoft SQL Server machine as a staging server. This section explains the use cases for the staging server, the required prerequisites and how to add it in Veeam Explorer for Microsoft SQL Server.
+
+Use Cases
 
 A staging server is required in the following cases:
 
@@ -18,11 +21,24 @@ A staging server is required in the following cases:
 * When you restore database schema and data, as described in [Restoring Database Schema and Data](vesql_restoring_schema.md).
 * When you add standalone Microsoft SQL Server databases to Veeam Explorer for Microsoft SQL Server, as described in [Adding Standalone Databases](vesql_add_database.md).
 
-A machine used as a staging server can reside in the same domain as the machine hosting Veeam Explorer for Microsoft SQL Server, as well as in a trusted domain or untrusted domain.
+Considerations and Limitations
+
+Before you add a staging server, consider the following:
+
+* As a staging server, you can use any edition of Microsoft SQL Server, including the Express Edition. You can download the necessary edition from the [Microsoft Download Center](https://www.microsoft.com/en-us/download).
+
+Note that databases that exceed 10 GB cannot be attached to the Microsoft SQL Server Express Edition due to Express Edition limitations. For more information, see the [Editions and supported features of SQL Server 2022](https://learn.microsoft.com/en-us/sql/sql-server/editions-and-components-of-sql-server-2022?view=sql-server-ver16) Microsoft article.
+
+* Make sure that the staging server has the same version of Microsoft SQL Server as the source server, or a later version.
+* A SQL Server included in Microsoft SQL Server failover cluster cannot be used as a staging system.
+
+* Using Availability Group Listeners as staging servers is not recommended.
+
+* A machine used as a staging server for data export, data recovery to a specific transaction and restoring schema and data can reside in the same domain as the machine where Veeam Explorer for Microsoft SQL Server is running, as well as in a trusted domain or untrusted domain.
 
 For the add standalone database operation, consider the following:
 
-* A machine used as a staging server can reside in the same domain as the machine hosting Veeam Explorer for Microsoft SQL Server or in a trusted domain. You cannot use a staging server that belongs to an untrusted domain to add a standalone database to Veeam Explorer for Microsoft SQL Server.
+* A machine used as a staging server can reside in the same domain as the machine hosting Veeam Explorer for Microsoft SQL Server or in a trusted domain. You cannot add a standalone database to Veeam Explorer for Microsoft SQL Server using a staging server that belongs to an untrusted domain.
 * Both Windows authentication and SQL Server authentication methods are supported for the staging server. If you want to use Windows authentication, complete the following steps to configure delegation settings:
 
 1. In Active Directory Users and Computers, select the staging server.
@@ -30,7 +46,9 @@ For the add standalone database operation, consider the following:
 3. Restart the staging server.
 4. Select a domain user account that you want to use when connecting to the staging server and make sure the Account is sensitive and cannot be delegated check box is not selected.
 
-To configure a staging server, do the following:
+Adding Staging Server
+
+To add the staging server, do the following:
 
 1. In the Veeam Explorer for Microsoft SQL Server main menu, click General Options.
 2. On the Staging Server tab, select the Use this helper SQL Server for advanced recovery functionality check box and do the following:
@@ -68,6 +86,4 @@ To browse for a Microsoft SQL Server instance, perform one of the following acti
 
 [![Browsing For Servers](images/browsing_for_staging.webp)](images/browsing_for_staging.webp "Browsing For Servers")
 
-Page updated 8/15/2024
 
-Page content applies to build 13.0.1.1071

--- a/docs/vesql_considerations.md
+++ b/docs/vesql_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_considerations.html"
-last_updated: "11/14/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and known limitations of Veeam Explorer for Microsoft SQL Server.
 
@@ -25,7 +26,6 @@ This does not apply to restore from Veeam Plug-In for Microsoft SQL Server and i
 * When recovering your Microsoft SQL Server data from CDP replicas, consider the following limitations:
 
 * Restore, publishing, instant recovery, and export operations of Microsoft SQL Server data from CDP replicas can only recover your data to the latest state of the selected long-term restore point. CDP policies do not copy Microsoft SQL Server transaction logs so data recovery to a point-in-time state is not supported.
-
 * When you recover your data from CDP replicas, you can only use long-term (both application-consistent and crash-consistent) restore points. Short-term restore points are not supported.
 * You can recover your data from a CDP replica if its CDP policy is currently running. During recovery, the CDP policy does not create new long-term restore points and does not delete existing ones. Short-term restore points are still created.
 * You cannot restore application items from a CDP replica in parallel with guest OS file restore, SureReplica, and failover.
@@ -45,8 +45,10 @@ The Config.xml files are located on the machine where Veeam Explorer for Microso
 If a configuration file named Config.xml does not exist in the necessary directory, create this file.
 
 * Veeam Explorer for Microsoft SQL Server does not support data recovery using a group Managed Service Account (gMSA) to connect to the target server.
-* [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 * [For Linux-based backup servers] To recover Microsoft SQL Server data, you must specify a Windows mount server for the backup repository or a default Windows mount server.
+* By default, the AUTO\_CLOSE option for Microsoft SQL Server databases is set to False. If AUTO\_CLOSE is enabled, your databases may be skipped from processing.
+* [For machines with ReFS] The mount server, target server, staging server, backup server and the machine where the Veeam Backup & Replication console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
+* [For Linux-based backup servers] All open Explorer sessions become non-responsive after backup server switchover or failback. To continue browsing and restoring your data, you must reopen the sessions.
 
 Restore from Image-Level Backups
 
@@ -126,6 +128,4 @@ As a workaround, you can perform instant recovery of multiple databases in paral
 * If you plan to perform scheduled or manual switchover, make sure that the mount server volume with the write cache has enough free disk space to store the changes of the published database. By default, the write cache is stored in the C:\ProgramData\Veeam\Backup\IRCache\ folder of the mount server. For more information on how to configure the write cache folder, see [Specify Mount Server Settings](repository_mount_server.md).
 * Instant recovery to a Microsoft SQL Server failover cluster requires 2 free drive letters on each cluster node to mount a volume from the backup. If the backed-up machine has multiple volumes, the number of free drive letters on each cluster node must be twice the number of volumes in the backup. For more information, see [How Instant Recovery Works](vesql_instant_hiw.md).
 
-Page updated 11/14/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vesql_systemreqs.md
+++ b/docs/vesql_systemreqs.md
@@ -3,7 +3,7 @@ title: "System Requirements"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_systemreqs.html"
-last_updated: "1/15/2026"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
@@ -19,28 +19,6 @@ This section lists system requirements that are relevant when recovering data fr
 | Component | Requirement |
 | --- | --- |
 | Microsoft SQL Server | Veeam Explorer for Microsoft SQL Server supports restore of the following Microsoft SQL Server versions:   * Microsoft SQL Server 2025 (only for Windows) * Microsoft SQL Server 2022 (only for Windows) * Microsoft SQL Server 2019 (only for Windows) * Microsoft SQL Server 2017 (only for Windows) * Microsoft SQL Server 2016 SP2 * Microsoft SQL Server 2014 SP3 * Microsoft SQL Server 2012 SP4   All editions of Microsoft SQL Server except LocalDB are supported.  The database whose logs you want to back up must use the Full or Bulk-logged recovery model. In this case, all changes of the Microsoft SQL Server state will be written to transaction logs, and you will be able to replay transaction logs to restore the Microsoft SQL Server. You can use the Microsoft SQL Server Management Studio to switch to one of these models. For more information, see [Microsoft Docs](https://docs.microsoft.com/en-us/sql/relational-databases/backup-restore/recovery-models-sql-server?view=sql-server-2017).  Restore of Microsoft SQL Server data may require an available staging Microsoft SQL Server. To learn how to configure this server, see [Configuring Staging SQL Server](vesql_configure_staging.md). |
-
-Consider the following:
-
-* By default, the AUTO\_CLOSE option for Microsoft SQL Server databases is set to False.
-
-If AUTO\_CLOSE is enabled, your databases may be skipped from processing.
-
-* [For machines with ReFS] The mount server, target server, staging server, backup server and the machine where the Veeam Backup & Replication console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
-
-* Nodes participating in Always On Availability Groups are supported, but using Availability Group Listeners as staging servers is not recommended.
-
-Staging SQL Server Requirements
-
-Consider the following:
-
-* Make sure that the staging server has the same version of Microsoft SQL Server as the source server, or a later version.
-* As a staging server, you can use any edition of Microsoft SQL Server, including the Express Edition. You can download the necessary edition from the [Microsoft Download Center](https://www.microsoft.com/en-us/download).
-
-Note that databases that exceed 10 GB cannot be attached to the Microsoft SQL Server Express Edition due to Express Edition limitations. For more information, see the [Editions and supported features of SQL Server 2022](https://learn.microsoft.com/en-us/sql/sql-server/editions-and-components-of-sql-server-2022?view=sql-server-ver16) Microsoft article.
-
-* A SQL Server included in Microsoft SQL Server failover cluster cannot be used as a staging system.
-* Configure domain trusts when planning to add databases to the Veeam Explorer for Microsoft SQL Server scope manually. For more information, see [Configuring Staging SQL Server](vesql_configure_staging.md).
 
 Restore from SQL Plug-in Backups
 

--- a/docs/vex_considerations.md
+++ b/docs/vex_considerations.md
@@ -1,13 +1,14 @@
 ---
 title: "Considerations and Limitations"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vex_considerations.html"
-last_updated: "11/20/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Considerations and Limitations
 
-In this article
 
 This section lists considerations and limitations of Veeam Explorer for Microsoft Exchange.
 
@@ -24,6 +25,9 @@ General
 * You cannot restore application items from a CDP replica in parallel with guest OS file restore, SureReplica, and failover.
 
 * Veeam Explorer for Microsoft Exchange must stay open during all data recovery operations. If the user who started the operation logs out or is logged out automatically, the operation will be terminated.
+
+* To work with database files, Veeam Explorer for Microsoft Exchange requires a dynamic link library ese.dll supplied with Microsoft Exchange. The ese.dll file must be of the same version as that of Microsoft Exchange in which database files were created.
+* [For machines with ReFS] The mount server, backup server and the machine where the console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
 
 Restore
 
@@ -60,6 +64,4 @@ Export
 
 * To avoid conflicts during export, make sure to exclude PST files from the indexing scope. Oftentimes conflicts may occur if a file you are exporting is being indexed at the same time. When exporting to shared folders, exclude Outlook files or disable Windows search on the destination computer.
 
-Page updated 11/20/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vex_systemreqs.md
+++ b/docs/vex_systemreqs.md
@@ -1,13 +1,14 @@
 ---
 title: "System Requirements"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vex_systemreqs.html"
-last_updated: "11/7/2025"
+last_updated: "1/21/2026"
 product_version: "13.0.1.1071"
 ---
 
 # System Requirements
 
-In this article
 
 This section lists system requirements for Veeam Explorer for Microsoft Exchange.
 
@@ -20,12 +21,4 @@ The set of supported Microsoft Exchange versions depends on the product Veeam Ex
 
 \*Government support is experimental. For more information on Veeam experimental support, see [this Veeam KB article](https://www.veeam.com/kb2976).
 
-Consider the following:
 
-* To work with database files, Veeam Explorer for Microsoft Exchange requires a dynamic link library ese.dll supplied with Microsoft Exchange. The ese.dll file must be of the same version as that of Microsoft Exchange in which database files were created.
-* To restore data that was backed up by Veeam Backup for Microsoft 365 using PowerShell, make sure to install Windows PowerShell 7.4.2 or later.
-* [For machines with ReFS] The mount server, backup server and the machine where the console is installed must support the same or a later ReFS version than that on the source machine. For more information on which OSes support which ReFS version, see [ReFS versions and compatibility matrix](https://gist.github.com/XenoPanther/15d8fad49fbd51c6bd946f2974084ef8#mountability).
-
-Page updated 11/7/2025
-
-Page content applies to build 13.0.1.1071

--- a/docs/vlab_before_you_begin_hv.md
+++ b/docs/vlab_before_you_begin_hv.md
@@ -1,17 +1,18 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vlab_before_you_begin_hv.html"
-last_updated: "8/11/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create a virtual lab, check the following prerequisites:
 
-* A valid license for Enterprise edition of Veeam Backup & Replication must be installed on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * You can configure a virtual lab on the following types of hosts:
 
 + Microsoft Windows Server 2022 with the Hyper-V role enabled
@@ -31,6 +32,4 @@ Before you create a virtual lab, check the following prerequisites:
 | Note |
 | Starting from Veeam Backup & Replication 12, you can verify VMware vSphere backups and Veeam Agent backups using Hyper-V virtual lab. To learn about SureBackup limitations for Veeam Agent backups, see [Veeam Agent Backup](agents_recovery_verification.md). |
 
-Page updated 8/11/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vlab_before_you_begin_vm.md
+++ b/docs/vlab_before_you_begin_vm.md
@@ -1,17 +1,18 @@
 ---
 title: "Before You Begin"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vlab_before_you_begin_vm.html"
-last_updated: "8/11/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Before You Begin
 
-In this article
 
 Before you create a virtual lab, check the following prerequisites:
 
-* A valid license for Enterprise edition of Veeam Backup & Replication must be installed on the backup server.
+* The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf).
 * The ESXi host on which you plan to deploy a virtual lab must have a VMkernel interface. Otherwise the vPower NFS datastore will not be mounted on the ESXi host. For more information, see [Veeam vPower NFS Service](vpower_nfs_service.md).
 * If you plan to use the advanced multi-host networking mode for VM replicas verification, you must configure a DVS beforehand. For more information, see [Advanced Multi-Host Virtual Labs](surereplica_advanced_mutihost.md).
 
@@ -20,6 +21,4 @@ Before you create a virtual lab, check the following prerequisites:
 | Note |
 | Starting from Veeam Backup & Replication 12, you can verify Microsoft Hyper-V backups and Veeam Agent backups using VMware vSphere virtual lab. To learn about SureBackup limitations for Veeam Agent backups, see [Veeam Agent Backup](agents_recovery_verification.md). |
 
-Page updated 8/11/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/vm_copy_vss.md
+++ b/docs/vm_copy_vss.md
@@ -1,13 +1,14 @@
 ---
 title: "Step 6. Specify Guest Processing Settings"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vm_copy_vss.html"
-last_updated: "4/29/2025"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # Step 6. Specify Guest Processing Settings
 
-In this article
 
 At the Guest Processing step of the wizard, you can enable the following settings for VM guest OS processing:
 
@@ -44,10 +45,8 @@ To check if Veeam Backup & Replication can communicate with VMs added to the job
 |  |
 | --- |
 | Note |
-| The guest interaction proxy functionality is included in the Veeam Universal License. When using a legacy socket-based license, Enterprise or higher edition is required. |
+| The availability of the guest interaction proxy functionality depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 ![Step 6. Specify Guest Processing Settings](images/vm_copy_job_vss.webp)
 
-Page updated 4/29/2025
 
-Page content applies to build 13.0.1.1071

--- a/docs/wan_acceleration.md
+++ b/docs/wan_acceleration.md
@@ -1,13 +1,14 @@
 ---
 title: "WAN Acceleration"
+product: "vbr"
+doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/wan_acceleration.html"
-last_updated: "5/29/2024"
+last_updated: "1/22/2026"
 product_version: "13.0.1.1071"
 ---
 
 # WAN Acceleration
 
-In this article
 
 WAN acceleration is a Veeam technology that optimizes data transfer to remote locations. It is specific for off-site backup copy jobs and replication jobs.
 
@@ -16,7 +17,7 @@ To enable WAN acceleration and data deduplication technologies, you must deploy 
 |  |
 | --- |
 | Note |
-| WAN acceleration is included in the Veeam Universal License. When using a legacy socket-based license, the Enterprise or Enterprise Plus editions of Veeam Backup & Replication are required. |
+| The availability of the feature depends on the license you use. For more details about licensing support, see [Veeam Data Platform Feature Comparison](https://www.veeam.com/veeam_data_platform_feature_comparison_ds.pdf). |
 
 Off-site backup copy and replication always involve moving large volumes of data between remote sites. The most common problems that backup administrators encounter during off-site backup and replication are insufficient network bandwidth to support VM data traffic and transmission of redundant data. To solve these problems, Veeam Backup & Replication offers the WAN acceleration technology that combines:
 
@@ -40,6 +41,4 @@ In This Section
 * [Data Block Verification](wan_crc.md)
 * [Data Transport on WAN Disconnect](resume_disconnect_wan.md)
 
-Page updated 5/29/2024
 
-Page content applies to build 13.0.1.1071


### PR DESCRIPTION
## Documentation Update - VBR

Scraped from [Veeam Help Center](https://helpcenter.veeam.com) on 2026-01-27.

### Summary

| Type | New | Updated (Content) | Updated (Metadata) | Deleted |
|------|-----|-------------------|-------------------|---------|
| Markdown | 7 | 88 | 3 | 0 |
| Images | 0 | 0 | - | 0 |
### New Pages (7)

#### Userguide (7)

- `docs/plugins_db2_object_storage_immutable.md` - Backup Immutability
- `docs/plugins_mssql_object_storage_immutable.md` - Backup Immutability
- `docs/plugins_rman_hana_object_storage_immutable.md` - Backup Immutability
- `docs/plugins_sap_hana_object_storage_immutable.md` - Backup Immutability
- `docs/plugins_sap_maxdb_overview_object_storage.md` - Backup to Object Storage
- `docs/plugins_sap_maxdb_overview_object_storage_immutable.md` - Backup Immutability
- `docs/plugins_sap_orcl_object_storage_immutable.md` - Backup Immutability


### Content Updates (88)

#### Userguide (88)

| File | Changes | Summary |
|------|---------|---------|
| `docs/about_backup.md` | +3/-4 | The page has been updated to include a note that Veeam Backup & Replication does not support Google Cloud object storage as a source for unstructured data backups. |
| `docs/adding_object_storage.md` | +8/-4 | A note has been added to mention that Veeam Backup & Replication does not support Google Cloud object storage as a source for unstructured data backups. |
| `docs/appgroup_before_you_begin.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/appgroup_before_you_begin_hv.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/archiver_appliance.md` | +4/-5 | The page has been updated to clarify the usage of the archiver appliance in scale-out backup repositories. |
| `docs/background_retention_job.md` | +9/-5 | The page has been updated to reflect that background retention requires free space in the target repository for the generated metadata file. |
| `docs/background_retention_job_hv.md` | +11/-5 | The page has been updated to reflect that background retention requires free space in the target repository for the generated metadata file. |
| `docs/backup_copy_before_you_begin.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_copy_path.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vbr_vss_proxy_choose.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vbr_vss_proxy_choose_hv.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vbr_vss_proxy_choose_hv_web.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vbr_vss_proxy_choose_web.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vss_exclude.md` | +4/-5 | The licensing information for VM guest OS file exclusion functionality was updated to reference the Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vss_exclude_hv.md` | +4/-5 | The licensing information for VM guest OS file exclusion functionality was updated to reference the Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vss_exclude_hv_web.md` | +4/-5 | The licensing information for VM guest OS file exclusion functionality was updated to reference the Veeam Data Platform Feature Comparison. |
| `docs/backup_job_vss_exclude_web.md` | +4/-5 | The licensing information for VM guest OS file exclusion functionality was updated to reference the Veeam Data Platform Feature Comparison. |
| `docs/backup_repository_sobr.md` | +4/-5 | The page has been updated to reflect that the availability of the scale-out backup repository depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/backup_to_tape_jobs.md` | +4/-5 | The page has been updated to reflect that the availability of the feature depends on the license used, with a link to Veeam Data Platform Feature Comparison. |
| `docs/before_you_begin_data_box.md` | +9/-5 | The page has been updated to provide more information on Azure Data Box devices and their performance. |
| ... | ... | ... and 68 more updates |


### Metadata-Only Updates (3)

<details><summary>3 files with only frontmatter changes (version, date)</summary>

- `docs/mongo_protected_computers_update.md`
- `docs/tape_decrypt_kms.md`
- `docs/tape_decrypt_password.md`

</details>

---
*Automatically generated by [veeam-docs-scraper](https://github.com/comnam90/veeam-docs-scraper)*
