### PR TITLE
docs(vbr): documentation update 2026-03-31

### DIFF
--- a/docs/agent_export_backup.md
+++ b/docs/agent_export_backup.md
@@ -3,7 +3,7 @@ title: "Exporting Restore Point to Full Backup File"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_export_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/backup_proxy_requirements.md
+++ b/docs/backup_proxy_requirements.md
@@ -3,8 +3,8 @@ title: "Requirements and Limitations for VMware Backup Proxies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_proxy_requirements.html"
-last_updated: "2/24/2026"
-product_version: "13.0.1.1071"
+last_updated: "3/23/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Requirements and Limitations for VMware Backup Proxies
@@ -46,7 +46,7 @@ In addition to the general requirements and limitations, the following ones appl
 
 * Linux-based backup proxies use the transport service for connection with backup infrastructure components. If the transport service cannot be installed, Linux-based backup proxy require SSH connection.
 
-* You can assign the role of a VMware backup proxy to a Linux server added with single-use credentials, for example, a Linux server used as a hardened repository. For this configuration, only the Network mode (NBD) is supported, other transport modes will not be available for selection.
+* The support of the transport modes depends on the backup infrastructure component that performs the backup proxy role. For more information, see [Transport Modes](transport_modes.md).
 * Linux-based backup proxies cannot be used with VMware Cloud on AWS. This is because VDDK settings required by VMware cannot be enabled on Linux-based backup proxies.
 * Linux-based backup proxies that use virtual appliance (HotAdd) transport mode do not support the VM copy scenario.
 * For [Direct SAN with iSCSI access](direct_san_access.md), note that Linux-based backup proxies must have the Open-iSCSI initiator enabled.

--- a/docs/cloud/cloud_connect_sp_vbr.md
+++ b/docs/cloud/cloud_connect_sp_vbr.md
@@ -3,7 +3,7 @@ title: "SP Veeam Backup Server"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_sp_vbr.html"
-last_updated: "3/10/2026"
+last_updated: "3/17/2026"
 product_version: "13.0.1.2067"
 ---
 
@@ -34,14 +34,14 @@ Limitations for SP Veeam Backup Server
 
 The SP Veeam backup server is intended to be used exclusively for configuring Veeam Cloud Connect infrastructure and providing cloud resources to tenants. The SP cannot perform the following operations on the SP Veeam backup server:
 
-* Perform restore tasks with tenant backups other than [Instant Recovery](cloud_connect_instant_recovery.md), [restore to Microsoft Azure](cc_restore_azure.md) and [restore to Amazon EC2](cc_restore_aws.md).
+* Perform restore tasks with tenant backups other than [Instant Recovery](cloud_connect_instant_recovery.md), [restore to Microsoft Azure](cc_restore_azure.md) and [restore to Amazon EC2](cc_restore_aws.md). Only these three operations are supported with tenant backups on the SP Veeam backup server.
 
 |  |
 | --- |
 | Important |
 | The SP must avoid the following operations with the tenant backups, for example, in an attempt to restore data from these backups:   * Import tenant backups on the SP Veeam backup server. * Decrypt tenant backups on the SP Veeam backup server. |
 
-To perform such data restore tasks, the SP must deploy a separate backup server in their backup infrastructure and do either of the following:
+To perform other data restore tasks, the SP must deploy a separate backup server in their backup infrastructure and do either of the following:
 
 * Import tenant backups. In this scenario, the SP must install a separate license key on this backup server. The trial license key works for this scenario.
 * Rescan the repository with tenant backups. To learn how to rescan a repository, see the [Rescanning Backup Repositories](https://helpcenter.veeam.com/docs/backup/vsphere/rescanning_backup_repositories.html?ver=120) section in the Veeam Backup & Replication User Guide. In this scenario, the SP can use its existing Veeam Cloud Connect license on the backup server.

--- a/docs/deployment_linux.md
+++ b/docs/deployment_linux.md
@@ -3,7 +3,7 @@ title: "Veeam Software Appliance Installation"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_automated_deployment.md
+++ b/docs/deployment_linux_automated_deployment.md
@@ -3,7 +3,7 @@ title: "Veeam Software Appliance Installation in Unattended Mode"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_automated_deployment.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_byb.md
+++ b/docs/deployment_linux_byb.md
@@ -3,7 +3,7 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_byb.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install.md
+++ b/docs/deployment_linux_iso_install.md
@@ -3,7 +3,7 @@ title: "Installing Veeam Software Appliance from ISO"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_host_administrator.md
+++ b/docs/deployment_linux_iso_install_host_administrator.md
@@ -3,7 +3,7 @@ title: "Step 8. Configure Host Administrator Account"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_host_administrator.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_hostname.md
+++ b/docs/deployment_linux_iso_install_hostname.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Hostname"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_hostname.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_license.md
+++ b/docs/deployment_linux_iso_install_license.md
@@ -3,7 +3,7 @@ title: "Step 4. Read and Accept License Agreements"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_license.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_mount.md
+++ b/docs/deployment_linux_iso_install_mount.md
@@ -3,7 +3,7 @@ title: "Step 1. Mount ISO File"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_mount.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_network.md
+++ b/docs/deployment_linux_iso_install_network.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Network Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_network.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_security_officer.md
+++ b/docs/deployment_linux_iso_install_security_officer.md
@@ -3,7 +3,7 @@ title: "Step 9. Configure Security Officer Account"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_security_officer.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_select_product.md
+++ b/docs/deployment_linux_iso_install_select_product.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Product"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_select_product.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_summary.md
+++ b/docs/deployment_linux_iso_install_summary.md
@@ -3,7 +3,7 @@ title: "Step 10. Finish Configuration"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_summary.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_time.md
+++ b/docs/deployment_linux_iso_install_time.md
@@ -3,7 +3,7 @@ title: "Step 7. Review Server Time Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_time.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_install_type.md
+++ b/docs/deployment_linux_iso_install_type.md
@@ -3,7 +3,7 @@ title: "Step 3. Begin Installation"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_install_type.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_iso_reinstall.md
+++ b/docs/deployment_linux_iso_reinstall.md
@@ -3,7 +3,7 @@ title: "Reinstalling Veeam Software Appliance from ISO"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_iso_reinstall.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_ova.md
+++ b/docs/deployment_linux_ova.md
@@ -3,7 +3,7 @@ title: "Installing Veeam Software Appliance from OVA"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_ova.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_silent_deploy_configure.md
+++ b/docs/deployment_linux_silent_deploy_configure.md
@@ -3,7 +3,7 @@ title: "Automating Installation with Initial Configuration"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_silent_deploy_configure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/deployment_linux_silent_deploy_install.md
+++ b/docs/deployment_linux_silent_deploy_install.md
@@ -3,7 +3,7 @@ title: "Automating Installation Without Initial Configuration"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_silent_deploy_install.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/direct_san_access.md
+++ b/docs/direct_san_access.md
@@ -3,8 +3,8 @@ title: "Direct SAN Access"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/direct_san_access.html"
-last_updated: "2/20/2026"
-product_version: "13.0.1.1071"
+last_updated: "3/23/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Direct SAN Access
@@ -28,15 +28,17 @@ The Direct SAN access transport mode can be used for all operations where the VM
 
 Requirements for the Direct SAN Access Mode
 
-To use the Direct SAN access transport mode, make sure that the following requirements are met:
-
 * It is strongly recommended that you assign the role of a VMware backup proxy working in the Direct SAN access mode to a physical machine. If you assign this role to a VM, the VMware backup proxy performance may not be optimal.
-* A VMware backup proxy using the Direct SAN access transport mode must have a direct access to the production storage using a hardware or software HBA. If a direct SAN connection is not configured or not available when a job or task starts, the job or task will fail.
+* A VMware backup proxy that uses the Direct SAN access transport mode must have a direct access to the production storage using a hardware or software HBA. If a direct SAN connection is not configured or not available when a job or task starts, the job or task will fail.
 * SAN storage volumes presented as VMware datastores must be exposed to the OS of the VMware backup proxy that works in the Direct SAN access transport mode.
 
 The volumes must be visible in Disk Management but must not be initialized by the OS. Otherwise, the VMFS filesystem will be overwritten with NTFS, and volumes will become unrecognizable by ESXi hosts. To prevent volumes initialization, Veeam Backup & Replication automatically sets the SAN Policy within each proxy to Offline Shared and also sets the SAN LUNs to the Offline state.
 
 * [For restore operations] A VMware backup proxy must have write access to LUNs where VM disks are located.
+* [For backup proxy deployed using [Veeam Infrastructure Appliance with iSCSI and NVMe/TCP](linux_infrastructure_appliance_install.md)] You can use the Direct SAN access mode over FC only if you manually specify datastores that the proxy can access.
+
+To specify the connected datastores, go to the [backup proxy settings](vmware_proxy_server.md). In the Connected datastores field, specify the required datastores. If any required datastore is not visible, reboot the backup proxy.
+
 * Veeam Backup & Replication supports the Direct SAN access transport mode over NVMe-FC with the following conditions:
 
 * Datastores must be specified manually in the Connected datastores field in the [backup proxy settings](vmware_proxy_server.md). Automatic datastore detection is not supported.
@@ -44,7 +46,7 @@ The volumes must be visible in Disk Management but must not be initialized by th
 
 Limitations for the Direct SAN Access Mode
 
-* The [Veeam Infrastructure Appliance](linux_infrastructure.md) does not support DirectSAN. For more information on transport mode availability and protocol support, see [Transport Mode Limitations](transport_modes.md#limitations).
+* Support for the Direct SAN access mode depends on the backup infrastructure component that performs the backup proxy role. For more information on transport mode availability and protocol support, see [Transport Mode Limitations](transport_modes.md#limitations).
 * The Direct SAN access transport mode can be used to restore only thick VM disks.
 * The transport mode is used for the entire VM, not for the virtual disk. It means that one VM can be processed in one transport mode only. If there are VM disks that cannot be processed in the Direct SAN access transport mode, then the rest of the disks also cannot be processed in this transport mode.
 

--- a/docs/direct_storage_access.md
+++ b/docs/direct_storage_access.md
@@ -3,8 +3,8 @@ title: "Direct Storage Access"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/direct_storage_access.html"
-last_updated: "1/25/2024"
-product_version: "13.0.1.1071"
+last_updated: "3/23/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Direct Storage Access
@@ -14,5 +14,6 @@ In the Direct storage access mode, Veeam Backup & Replication reads/writes data 
 
 * [Direct SAN access](direct_san_access.md)
 * [Direct NFS access](direct_nfs_access.md)
+* [Storage integration access](sia_transport.md)
 
 

--- a/docs/entra_id_tenant_restore_items.md
+++ b/docs/entra_id_tenant_restore_items.md
@@ -3,8 +3,8 @@ title: "Step 2. Choose Items to Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/entra_id_tenant_restore_items.html"
-last_updated: "2/27/2026"
-product_version: "13.0.1.1071"
+last_updated: "3/30/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 2. Choose Items to Restore

--- a/docs/file_share_backup_job_advanced_maintenance.md
+++ b/docs/file_share_backup_job_advanced_maintenance.md
@@ -3,8 +3,8 @@ title: "Maintenance Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_share_backup_job_advanced_maintenance.html"
-last_updated: "11/2/2023"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Maintenance Settings
@@ -12,9 +12,9 @@ product_version: "13.0.1.1071"
 
 You can instruct Veeam Backup & Replication to periodically perform a health check for the backup. The health check helps make sure that the backup is consistent, and you will be able to restore data from it.
 
-During the health check, Veeam Backup & Replication performs a CRC check for metadata and a hash check for data blocks in the file share backup files to verify their integrity. For more information, see the [Performing Health Check and Repair for Unstructured Data Backups](unstructured_data_backup_health_check.md) section.
+During the health check, Veeam Backup & Replication performs a CRC check for metadata and a hash check for data blocks in the file share backup files to verify their integrity. If you configured a secondary destination for the job, Veeam Backup & Replication also performs a health check for the backup files stored there. For more information, see the [Performing Health Check and Repair for Unstructured Data Backups](unstructured_data_backup_health_check.md) section.
 
-To configure the health-check settings for the backup job:
+To configure the health check settings for the backup job:
 
 1. At the Backup Repository step of the wizard, click Advanced.
 2. On the Maintenance tab, select Perform backup files health check to enable the health check option. It allows ensuring that all data and metadata is backed up correctly.

--- a/docs/file_share_backup_job_files_and_folders.md
+++ b/docs/file_share_backup_job_files_and_folders.md
@@ -3,8 +3,8 @@ title: "Step 3. Select Files and Folders to Back Up"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_share_backup_job_files_and_folders.html"
-last_updated: "3/5/2026"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 3. Select Files and Folders to Back Up
@@ -89,7 +89,7 @@ You can exclude a whole file share from processing. For example, you add the \\S
 |  |
 | --- |
 | Note |
-| Consider the following:   * Include and exclude masks are case insensitive. * You cannot exclude a whole file share from processing if the storage system, where file shares reside, is added to Veeam Backup & Replication as a NAS filer.   As a workaround, you can edit the storage in Storage Infrastructure and exclude the volumes on the NAS Filer step, as described in the [Adding NetApp Data ONTAP](netapp_nas_access.md), [Adding Lenovo ThinkSystem DM/DG Series](specify_nas_access.md), [Adding Dell PowerScale (formerly Isilon)](dell_powerscale_add_options.md) or [Adding Nutanix Files Storage](nutanix_add_nas.md) sections, depending on the type of the storage system you use.   * You cannot use mask with \* to specify folders to exclude from processing. For example, mask QA04:/NFS04/Documents/201\* will not work. * You cannot mix different exclusion options, for example, you cannot use a mask to exclude files with certain extensions from the specific folder. For example, QA04:/NFS04/Documents/2016/\*.xlsx will not work. |
+| Consider the following:   * Include and exclude masks are case insensitive. * Veeam Backup & Replication automatically excludes common NAS snapshot directories from processing. If you want to process them, remove the snapshot exclude masks. * You cannot exclude a whole file share from processing if the storage system, where file shares reside, is added to Veeam Backup & Replication as a NAS filer.   As a workaround, you can edit the storage in Storage Infrastructure and exclude the volumes on the NAS Filer step, as described in the [Adding NetApp Data ONTAP](netapp_nas_access.md), [Adding Lenovo ThinkSystem DM/DG Series](specify_nas_access.md), [Adding Dell PowerScale (formerly Isilon)](dell_powerscale_add_options.md) or [Adding Nutanix Files Storage](nutanix_add_nas.md) sections, depending on the type of the storage system you use.   * You cannot use mask with \* to specify folders to exclude from processing. For example, mask QA04:/NFS04/Documents/201\* will not work. * You cannot mix different exclusion options, for example, you cannot use a mask to exclude files with certain extensions from the specific folder. For example, QA04:/NFS04/Documents/2016/\*.xlsx will not work. |
 
 |  |
 | --- |

--- a/docs/hardened_repository_add_console_mount.md
+++ b/docs/hardened_repository_add_console_mount.md
@@ -3,8 +3,8 @@ title: "Step 5. Specify Mount Server Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hardened_repository_add_console_mount.html"
-last_updated: "9/19/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/27/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 5. Specify Mount Server Settings

--- a/docs/hardened_repository_limitations.md
+++ b/docs/hardened_repository_limitations.md
@@ -3,8 +3,8 @@ title: "Requirements and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hardened_repository_limitations.html"
-last_updated: "2/24/2026"
-product_version: "13.0.1.1071"
+last_updated: "3/30/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Requirements and Limitations
@@ -63,8 +63,6 @@ Repository
 Immutability Feature
 
 * To use the immutability feature for backup copy jobs, enable the GFS retention policy. For more information, see [Long-Term Retention Policy (GFS)](backup_copy_gfs.md).
-
-* Do not use the immutability feature for a [Nutanix Mine infrastructure](https://helpcenter.veeam.com/docs/backup/mine/overview.html). As Mine repositories contain thin-provisioned disks, there may be the case when Veeam Backup & Replication uses full storage capacity of a repository and cannot delete backup files from the file system.
 
 Veeam Infrastructure Appliance Hardened Repository
 

--- a/docs/hmc_about.md
+++ b/docs/hmc_about.md
@@ -3,7 +3,7 @@ title: "About Veeam Host Management"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_about.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_access.md
+++ b/docs/hmc_access.md
@@ -3,7 +3,7 @@ title: "Accessing Veeam Host Management Console"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_access.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_domain.md
+++ b/docs/hmc_configure_domain.md
@@ -3,7 +3,7 @@ title: "Managing Domain Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_domain.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_hostname.md
+++ b/docs/hmc_configure_hostname.md
@@ -3,7 +3,7 @@ title: "Changing Server Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_hostname.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_infrastructure.md
+++ b/docs/hmc_configure_infrastructure.md
@@ -3,7 +3,7 @@ title: "Configuring Backup Infrastructure Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_infrastructure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_interfaces.md
+++ b/docs/hmc_configure_interfaces.md
@@ -3,7 +3,7 @@ title: "Configuring Network Interfaces"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_interfaces.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_network.md
+++ b/docs/hmc_configure_network.md
@@ -3,7 +3,7 @@ title: "Configuring Network Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_network.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_proxies.md
+++ b/docs/hmc_configure_proxies.md
@@ -3,7 +3,7 @@ title: "Configuring HTTP/HTTPS Proxies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_proxies.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_remote_access.md
+++ b/docs/hmc_configure_remote_access.md
@@ -3,7 +3,7 @@ title: "Configuring Remote Access Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_remote_access.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_time.md
+++ b/docs/hmc_configure_time.md
@@ -3,7 +3,7 @@ title: "Configuring Server Time Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_time.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_updates.md
+++ b/docs/hmc_configure_updates.md
@@ -3,7 +3,7 @@ title: "Managing Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_updates.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_configure_users.md
+++ b/docs/hmc_configure_users.md
@@ -3,7 +3,7 @@ title: "Configuring Users"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_configure_users.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_manage_user_auth.md
+++ b/docs/hmc_manage_user_auth.md
@@ -3,7 +3,7 @@ title: "Managing User Authentication"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_manage_user_auth.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_perform_maintenance_tasks.md
+++ b/docs/hmc_perform_maintenance_tasks.md
@@ -3,7 +3,7 @@ title: "Performing Maintenance Tasks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_perform_maintenance_tasks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_perform_so_tasks.md
+++ b/docs/hmc_perform_so_tasks.md
@@ -3,7 +3,7 @@ title: "Performing Security Officer Tasks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_perform_so_tasks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_users.md
+++ b/docs/hmc_users.md
@@ -3,7 +3,7 @@ title: "Managing Users and Roles"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_users.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/hmc_users_security_officer.md
+++ b/docs/hmc_users_security_officer.md
@@ -3,7 +3,7 @@ title: "Performing Initial Security Officer Login"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hmc_users_security_officer.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore.md
+++ b/docs/integration_disk_restore.md
@@ -3,7 +3,7 @@ title: "Exporting Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_backup.md
+++ b/docs/integration_disk_restore_backup.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_complete.md
+++ b/docs/integration_disk_restore_complete.md
@@ -3,7 +3,7 @@ title: "Step 8. Complete Restore Process"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_complete.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_disks.md
+++ b/docs/integration_disk_restore_disks.md
@@ -3,7 +3,7 @@ title: "Step 4. Select Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_disks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_format.md
+++ b/docs/integration_disk_restore_format.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Destination and Disk Format"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_format.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_launch.md
+++ b/docs/integration_disk_restore_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Export Disk Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_point.md
+++ b/docs/integration_disk_restore_point.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_point.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_reason.md
+++ b/docs/integration_disk_restore_reason.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_reason.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_disk_restore_secure.md
+++ b/docs/integration_disk_restore_secure.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify Secure Restore Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_disk_restore_secure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_explorers.md
+++ b/docs/integration_explorers.md
@@ -3,7 +3,7 @@ title: "Restoring Application Items"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_explorers.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_flr.md
+++ b/docs/integration_flr.md
@@ -3,7 +3,7 @@ title: "Restoring Files and Folders"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_flr.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_hyperv.md
+++ b/docs/integration_instant_restore_hyperv.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to Hyper-V VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_hyperv.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_media.md
+++ b/docs/integration_instant_restore_media.md
@@ -3,7 +3,7 @@ title: "Restoring Data with Veeam Recovery Media"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_media.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_nutanix.md
+++ b/docs/integration_instant_restore_nutanix.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to Nutanix VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_nutanix.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_proxmox.md
+++ b/docs/integration_instant_restore_proxmox.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to Proxmox VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_proxmox.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_scale.md
+++ b/docs/integration_instant_restore_scale.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to Scale Computing HyperCore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_scale.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_instant_restore_vsphere.md
+++ b/docs/integration_instant_restore_vsphere.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to vSphere VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_instant_restore_vsphere.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish.md
+++ b/docs/integration_publish.md
@@ -3,7 +3,7 @@ title: "Publishing Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_after.md
+++ b/docs/integration_publish_after.md
@@ -3,7 +3,7 @@ title: "What You Do Next"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_after.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_before.md
+++ b/docs/integration_publish_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_before.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_computer.md
+++ b/docs/integration_publish_computer.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Computer"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_computer.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_disk.md
+++ b/docs/integration_publish_disk.md
@@ -3,7 +3,7 @@ title: "Step 4. Select Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_disk.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_disks.md
+++ b/docs/integration_publish_disks.md
@@ -3,7 +3,7 @@ title: "Performing Disk Publish"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_disks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_finish.md
+++ b/docs/integration_publish_finish.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_finish.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_point.md
+++ b/docs/integration_publish_point.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_point.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_reason.md
+++ b/docs/integration_publish_reason.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_reason.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_server.md
+++ b/docs/integration_publish_server.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Target Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_server.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_session.md
+++ b/docs/integration_publish_session.md
@@ -3,7 +3,7 @@ title: "Managing Publishing Disks Session"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_session.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_publish_wizard.md
+++ b/docs/integration_publish_wizard.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Publish Disks Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_publish_wizard.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_restore_ovirt.md
+++ b/docs/integration_restore_ovirt.md
@@ -3,7 +3,7 @@ title: "Restoring Veeam Agent Backup to oVirt KVM VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_restore_ovirt.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_restore_ovirt_disk.md
+++ b/docs/integration_restore_ovirt_disk.md
@@ -3,7 +3,7 @@ title: "Restoring Disk from Veeam Agent Backup to oVirt KVM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_restore_ovirt_disk.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_restore_to_amazon.md
+++ b/docs/integration_restore_to_amazon.md
@@ -3,7 +3,7 @@ title: "Restoring to Amazon EC2"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_restore_to_amazon.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_restore_to_azure.md
+++ b/docs/integration_restore_to_azure.md
@@ -3,7 +3,7 @@ title: "Restoring to Microsoft Azure"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_restore_to_azure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_restore_to_google.md
+++ b/docs/integration_restore_to_google.md
@@ -3,7 +3,7 @@ title: "Restoring to Google Compute Engine"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_restore_to_google.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore.md
+++ b/docs/integration_volume_restore.md
@@ -3,7 +3,7 @@ title: "Restoring Volumes"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_backup.md
+++ b/docs/integration_volume_restore_backup.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_before.md
+++ b/docs/integration_volume_restore_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_before.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_complete.md
+++ b/docs/integration_volume_restore_complete.md
@@ -3,7 +3,7 @@ title: "Step 8. Complete Restore Process"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_complete.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_disk_mapping.md
+++ b/docs/integration_volume_restore_disk_mapping.md
@@ -3,7 +3,7 @@ title: "Step 4. Map Restored Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_disk_mapping.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_launch.md
+++ b/docs/integration_volume_restore_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Volume Level Restore Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_point.md
+++ b/docs/integration_volume_restore_point.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_point.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_reason.md
+++ b/docs/integration_volume_restore_reason.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_reason.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_resize.md
+++ b/docs/integration_volume_restore_resize.md
@@ -3,7 +3,7 @@ title: "Step 5. Resize Restored Volumes"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_resize.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/integration_volume_restore_secure.md
+++ b/docs/integration_volume_restore_secure.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify Secure Restore Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/integration_volume_restore_secure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/linux_infrastructure_appliance_byb.md
+++ b/docs/linux_infrastructure_appliance_byb.md
@@ -3,7 +3,7 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_infrastructure_appliance_byb.html"
-last_updated: "3/11/2026"
+last_updated: "3/23/2026"
 product_version: "13.0.1.2067"
 ---
 
@@ -56,10 +56,7 @@ Before you install Veeam Infrastructure Appliance, consider the following:
 * You cannot install third-party software on a Veeam Infrastructure Appliance.
 * You cannot use third-party software to back up or restore a Veeam Infrastructure Appliance.
 
-* VMware proxies deployed with Veeam Infrastructure Appliance support the following transport modes:
-
-* Veeam Infrastructure Appliance  — Network, HotAdd, Direct NFS
-* Veeam Infrastructure Appliance (with iSCSI and NVMe-TCP) — Network, HotAdd, Direct NFS, Backup from Storage Snapshot
+* For the list of supported transport modes for VMware proxies deployed with Veeam Infrastructure Appliance support, check [Transport Modes](transport_modes.md).
 
 * Veeam Infrastructure Appliance uses DISA and FIPS-compliant Linux policies. These policies cannot be changed.
 

--- a/docs/mongo_protected_computers_update.md
+++ b/docs/mongo_protected_computers_update.md
@@ -3,7 +3,7 @@ title: "Upgrading Veeam Agent"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/mongo_protected_computers_update.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/multios_restore_before_you_begin.md
+++ b/docs/multios_restore_before_you_begin.md
@@ -3,7 +3,7 @@ title: "Linux File Recovery"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/multios_restore_before_you_begin.html"
-last_updated: "3/11/2026"
+last_updated: "3/30/2026"
 product_version: "13.0.1.2067"
 ---
 
@@ -15,6 +15,7 @@ This section lists considerations and limitations that apply to recovery from Li
 Infrastructure Components
 
 * [For source and target workload] Veeam Backup & Replication uses the ICMP ping command to define whether a workload is available over the network. If the workload must be available over the network, check that ICMP protocol is enabled on the workload.
+* Linux helper hosts must have a sufficient dynamic port range available (by default, this range is 32768 - 60999). If you restrict this range on the helper host, errors due to port exhaustion may occur. For more information, see the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#ip-variables).
 * Recovery from Linux workloads is possible only when using a Linux-based mount server (helper appliance, Linux mount server or Linux helper host).
 * The following applies if you recover VMware vSphere VMs:
 

--- a/docs/os_backup_job_advanced_maintenance.md
+++ b/docs/os_backup_job_advanced_maintenance.md
@@ -3,8 +3,8 @@ title: "Maintenance Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/os_backup_job_advanced_maintenance.html"
-last_updated: "12/18/2023"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Maintenance Settings
@@ -12,7 +12,7 @@ product_version: "13.0.1.1071"
 
 You can instruct Veeam Backup & Replication to periodically perform a health check for the backup. The health check ensures that the backup is consistent, and you will be able to restore data from it.
 
-During the health check, Veeam Backup & Replication performs a CRC check for metadata and a hash check for data blocks in the object storage backup files to verify their integrity. For more information, see the [Performing Health Check and Repair for Unstructured Data Backups](unstructured_data_backup_health_check.md) section.
+During the health check, Veeam Backup & Replication performs a CRC check for metadata and a hash check for data blocks in the object storage backup files to verify their integrity. If you configured a secondary destination for the job, Veeam Backup & Replication also performs a health check for the backup files stored there. For more information, see the [Performing Health Check and Repair for Unstructured Data Backups](unstructured_data_backup_health_check.md) section.
 
 To configure the health-check settings for backup job:
 

--- a/docs/performing_restore_tasks.md
+++ b/docs/performing_restore_tasks.md
@@ -3,7 +3,7 @@ title: "Restoring Data from Veeam Agent Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/performing_restore_tasks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/proxmox_ve.md
+++ b/docs/proxmox_ve.md
@@ -3,7 +3,7 @@ title: "Proxmox Virtual Environment"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/proxmox_ve.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_active_full_backup.md
+++ b/docs/pve_active_full_backup.md
@@ -3,7 +3,7 @@ title: "Active Full Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_active_full_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_active_full_create.md
+++ b/docs/pve_active_full_create.md
@@ -3,7 +3,7 @@ title: "Creating Active Full Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_active_full_create.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup.md
+++ b/docs/pve_backup.md
@@ -3,7 +3,7 @@ title: "Backup Chain"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_bottlenecks.md
+++ b/docs/pve_backup_job_bottlenecks.md
@@ -3,7 +3,7 @@ title: "Analyzing Performance Bottlenecks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_bottlenecks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_clone.md
+++ b/docs/pve_backup_job_clone.md
@@ -3,7 +3,7 @@ title: "Cloning Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_clone.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create.md
+++ b/docs/pve_backup_job_create.md
@@ -3,7 +3,7 @@ title: "Creating Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_advanced.md
+++ b/docs/pve_backup_job_create_advanced.md
@@ -3,7 +3,7 @@ title: "Configuring Advanced Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_advanced.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_assign_vms.md
+++ b/docs/pve_backup_job_create_assign_vms.md
@@ -3,7 +3,7 @@ title: "Step 3. Configure Backup Source Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_assign_vms.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_destination.md
+++ b/docs/pve_backup_job_create_destination.md
@@ -3,7 +3,7 @@ title: "Step 4. Configure Backup Destination Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_destination.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_general_settings.md
+++ b/docs/pve_backup_job_create_general_settings.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Job Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_general_settings.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gfs.md
+++ b/docs/pve_backup_job_create_gfs.md
@@ -3,7 +3,7 @@ title: "Configuring GFS Policy Schedules"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gfs.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_applications.md
+++ b/docs/pve_backup_job_create_gp_applications.md
@@ -3,7 +3,7 @@ title: "Step 5a. Enable Application-Aware Processing"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_applications.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_credentials.md
+++ b/docs/pve_backup_job_create_gp_credentials.md
@@ -3,7 +3,7 @@ title: "Step 5d. Manage VM Guest OS Credentials"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_credentials.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_indexing.md
+++ b/docs/pve_backup_job_create_gp_indexing.md
@@ -3,7 +3,7 @@ title: "Step 5b. Enable VM Guest OS File Indexing"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_indexing.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_mssql.md
+++ b/docs/pve_backup_job_create_gp_mssql.md
@@ -3,7 +3,7 @@ title: "Specifying Microsoft SQL Server Transaction Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_mssql.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_oracle.md
+++ b/docs/pve_backup_job_create_gp_oracle.md
@@ -3,7 +3,7 @@ title: "Specifying Oracle Archived Redo Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_oracle.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_postgresql.md
+++ b/docs/pve_backup_job_create_gp_postgresql.md
@@ -3,7 +3,7 @@ title: "Specifying PostgreSQL WAL Files Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_postgresql.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_proxy.md
+++ b/docs/pve_backup_job_create_gp_proxy.md
@@ -3,7 +3,7 @@ title: "Step 5c. Choose Guest Interaction Proxy"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_proxy.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_gp_scripts.md
+++ b/docs/pve_backup_job_create_gp_scripts.md
@@ -3,7 +3,7 @@ title: "Specifying Pre-Freeze and Post-Thaw Scripts"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_gp_scripts.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_guest_processing.md
+++ b/docs/pve_backup_job_create_guest_processing.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Guest Processing Options"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_guest_processing.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_launch.md
+++ b/docs/pve_backup_job_create_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Backup Job Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_prerequisites.md
+++ b/docs/pve_backup_job_create_prerequisites.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_prerequisites.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_schedule.md
+++ b/docs/pve_backup_job_create_schedule.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify Job Scheduling Options"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_schedule.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_create_summary.md
+++ b/docs/pve_backup_job_create_summary.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_create_summary.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_delete.md
+++ b/docs/pve_backup_job_delete.md
@@ -3,7 +3,7 @@ title: "Deleting Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_delete.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_disable.md
+++ b/docs/pve_backup_job_disable.md
@@ -3,7 +3,7 @@ title: "Enabling and Disabling Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_disable.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_edit.md
+++ b/docs/pve_backup_job_edit.md
@@ -3,7 +3,7 @@ title: "Editing Backup Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_edit.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_how.md
+++ b/docs/pve_backup_job_how.md
@@ -3,7 +3,7 @@ title: "VM Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_how.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_job_start.md
+++ b/docs/pve_backup_job_start.md
@@ -3,7 +3,7 @@ title: "Starting and Stopping Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_job_start.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_methods.md
+++ b/docs/pve_backup_methods.md
@@ -3,7 +3,7 @@ title: "Backup Methods"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_methods.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backup_retention.md
+++ b/docs/pve_backup_retention.md
@@ -3,7 +3,7 @@ title: "Backup Retention"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backup_retention.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_copy.md
+++ b/docs/pve_backups_copy.md
@@ -3,7 +3,7 @@ title: "Copying Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_copy.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_copy_tape.md
+++ b/docs/pve_backups_copy_tape.md
@@ -3,7 +3,7 @@ title: "Copying Backups to Tapes"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_copy_tape.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_delete.md
+++ b/docs/pve_backups_delete.md
@@ -3,7 +3,7 @@ title: "Deleting Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_delete.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_export.md
+++ b/docs/pve_backups_export.md
@@ -3,7 +3,7 @@ title: "Exporting Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_export.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_manage.md
+++ b/docs/pve_backups_manage.md
@@ -3,7 +3,7 @@ title: "Managing Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_manage.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_verify.md
+++ b/docs/pve_backups_verify.md
@@ -3,7 +3,7 @@ title: "Verifying Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_verify.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_backups_view_properties.md
+++ b/docs/pve_backups_view_properties.md
@@ -3,7 +3,7 @@ title: "Viewing Backup Properties"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_backups_view_properties.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_changed_block_tracking.md
+++ b/docs/pve_changed_block_tracking.md
@@ -3,7 +3,7 @@ title: "Changed Block Tracking"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_changed_block_tracking.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_configuration.md
+++ b/docs/pve_configuration.md
@@ -3,7 +3,7 @@ title: "Configuring Veeam Plug-In for Proxmox VE"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_configuration.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_configure_repository.md
+++ b/docs/pve_configure_repository.md
@@ -3,7 +3,7 @@ title: "Configuring Backup Repositories"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_configure_repository.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_connecting_manager.md
+++ b/docs/pve_connecting_manager.md
@@ -3,7 +3,7 @@ title: "Connecting Proxmox VE Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_connecting_manager.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_data_protection.md
+++ b/docs/pve_data_protection.md
@@ -3,7 +3,7 @@ title: "Performing Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_data_protection.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_data_recovery.md
+++ b/docs/pve_data_recovery.md
@@ -3,7 +3,7 @@ title: "Performing Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_data_recovery.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_deployment.md
+++ b/docs/pve_deployment.md
@@ -3,7 +3,7 @@ title: "Deployment"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_deployment.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_disk_export.md
+++ b/docs/pve_disk_export.md
@@ -3,7 +3,7 @@ title: "Exporting Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_disk_export.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_disk_publish.md
+++ b/docs/pve_disk_publish.md
@@ -3,7 +3,7 @@ title: "Publishing Disks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_disk_publish.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_email_settings.md
+++ b/docs/pve_email_settings.md
@@ -3,7 +3,7 @@ title: "Configuring Email Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_email_settings.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_export_logs.md
+++ b/docs/pve_export_logs.md
@@ -3,7 +3,7 @@ title: "Getting Technical Support"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_export_logs.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_forever_forward_backup.md
+++ b/docs/pve_forever_forward_backup.md
@@ -3,7 +3,7 @@ title: "Forever Forward Incremental Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_forever_forward_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_forward_backup.md
+++ b/docs/pve_forward_backup.md
@@ -3,7 +3,7 @@ title: "Forward Incremental Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_forward_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_general_settings.md
+++ b/docs/pve_general_settings.md
@@ -3,7 +3,7 @@ title: "Configuring General Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_general_settings.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_how_health_check_works.md
+++ b/docs/pve_how_health_check_works.md
@@ -3,7 +3,7 @@ title: "How Health Check Works"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_how_health_check_works.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_infrastructure_components.md
+++ b/docs/pve_infrastructure_components.md
@@ -3,7 +3,7 @@ title: "Solution Architecture"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_infrastructure_components.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_install_plugin.md
+++ b/docs/pve_install_plugin.md
@@ -3,7 +3,7 @@ title: "Installing Veeam Plug-In for Proxmox VE Manually"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_install_plugin.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_licensing.md
+++ b/docs/pve_licensing.md
@@ -3,7 +3,7 @@ title: "Licensing"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_licensing.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_limitations.md
+++ b/docs/pve_limitations.md
@@ -3,7 +3,7 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_limitations.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_multiple_networks.md
+++ b/docs/pve_multiple_networks.md
@@ -3,7 +3,7 @@ title: "Configuring Multiple Networks"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_multiple_networks.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_notifications.md
+++ b/docs/pve_notifications.md
@@ -3,7 +3,7 @@ title: "Configuring Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_notifications.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_overview.md
+++ b/docs/pve_overview.md
@@ -3,7 +3,7 @@ title: "Overview"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_overview.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_permissions.md
+++ b/docs/pve_permissions.md
@@ -3,7 +3,7 @@ title: "Account Permissions"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_permissions.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_planning_and_preparation.md
+++ b/docs/pve_planning_and_preparation.md
@@ -3,7 +3,7 @@ title: "Planning and Preparation"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_planning_and_preparation.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_app_items.md
+++ b/docs/pve_restore_app_items.md
@@ -3,7 +3,7 @@ title: "Performing Application Item Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_app_items.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm.md
+++ b/docs/pve_restore_entire_vm.md
@@ -3,7 +3,7 @@ title: "Performing VM Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_launch.md
+++ b/docs/pve_restore_entire_vm_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Entire VM Restore Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_mode.md
+++ b/docs/pve_restore_entire_vm_mode.md
@@ -3,7 +3,7 @@ title: "Step 3. Choose Restore Mode"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_mode.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_name.md
+++ b/docs/pve_restore_entire_vm_name.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify VM Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_name.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_network.md
+++ b/docs/pve_restore_entire_vm_network.md
@@ -3,7 +3,7 @@ title: "Step 7. Configure Network Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_network.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_reason.md
+++ b/docs/pve_restore_entire_vm_reason.md
@@ -3,7 +3,7 @@ title: "Step 8. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_reason.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_select_vms.md
+++ b/docs/pve_restore_entire_vm_select_vms.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_select_vms.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_storage.md
+++ b/docs/pve_restore_entire_vm_storage.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Storage"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_storage.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_summary.md
+++ b/docs/pve_restore_entire_vm_summary.md
@@ -3,7 +3,7 @@ title: "Step 9. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_summary.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_entire_vm_target.md
+++ b/docs/pve_restore_entire_vm_target.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target Host"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_entire_vm_target.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_how.md
+++ b/docs/pve_restore_how.md
@@ -3,7 +3,7 @@ title: "VM Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_how.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_how_entire.md
+++ b/docs/pve_restore_how_entire.md
@@ -3,7 +3,7 @@ title: "Entire VM Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_how_entire.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_how_flr.md
+++ b/docs/pve_restore_how_flr.md
@@ -3,7 +3,7 @@ title: "File-Level Recovery"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_how_flr.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_instant.md
+++ b/docs/pve_restore_instant.md
@@ -3,7 +3,7 @@ title: "Performing Instant VM Recovery"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_instant.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_to_amazon_ec2.md
+++ b/docs/pve_restore_to_amazon_ec2.md
@@ -3,7 +3,7 @@ title: "Performing VM Restore to Amazon Web Services"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_to_amazon_ec2.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_to_google.md
+++ b/docs/pve_restore_to_google.md
@@ -3,7 +3,7 @@ title: "Performing VM Restore to Google Cloud"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_to_google.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_restore_to_microsoft_azure.md
+++ b/docs/pve_restore_to_microsoft_azure.md
@@ -3,7 +3,7 @@ title: "Performing VM Restore to Microsoft Azure"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_restore_to_microsoft_azure.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_retention_policy.md
+++ b/docs/pve_retention_policy.md
@@ -3,7 +3,7 @@ title: "Retention Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_retention_policy.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_retrying_jobs.md
+++ b/docs/pve_retrying_jobs.md
@@ -3,7 +3,7 @@ title: "Retrying Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_retrying_jobs.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_apply.md
+++ b/docs/pve_server_add_apply.md
@@ -3,7 +3,7 @@ title: "Step 5. Apply Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_apply.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_credentials.md
+++ b/docs/pve_server_add_credentials.md
@@ -3,7 +3,7 @@ title: "Step 3. Enter Credentials"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_credentials.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_launch.md
+++ b/docs/pve_server_add_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Proxmox VE Server Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_name.md
+++ b/docs/pve_server_add_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Domain Name or IP Address of Proxmox VE server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_name.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_storage.md
+++ b/docs/pve_server_add_storage.md
@@ -3,7 +3,7 @@ title: "Step 4. Configure Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_storage.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_add_summary.md
+++ b/docs/pve_server_add_summary.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_add_summary.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_edit.md
+++ b/docs/pve_server_edit.md
@@ -3,7 +3,7 @@ title: "Editing Proxmox VE Server Properties"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_edit.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_remove.md
+++ b/docs/pve_server_remove.md
@@ -3,7 +3,7 @@ title: "Removing Proxmox VE Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_remove.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_server_rescan.md
+++ b/docs/pve_server_rescan.md
@@ -3,7 +3,7 @@ title: "Rescanning Proxmox VE Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_server_rescan.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_sever_add.md
+++ b/docs/pve_sever_add.md
@@ -3,7 +3,7 @@ title: "Adding Proxmox VE Server to Backup Infrastructure"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_sever_add.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_synthetic_full_backup.md
+++ b/docs/pve_synthetic_full_backup.md
@@ -3,7 +3,7 @@ title: "Synthetic Full Backup"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_synthetic_full_backup.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_system_requirements.md
+++ b/docs/pve_system_requirements.md
@@ -3,7 +3,7 @@ title: "System Requirements"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_system_requirements.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_uninstall_plugin.md
+++ b/docs/pve_uninstall_plugin.md
@@ -3,7 +3,7 @@ title: "Uninstalling Veeam Plug-In for Proxmox VE Manually"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_uninstall_plugin.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_upgrading.md
+++ b/docs/pve_upgrading.md
@@ -3,7 +3,7 @@ title: "Upgrading to Veeam Plug-In for Proxmox VE 3"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_upgrading.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_used_ports.md
+++ b/docs/pve_used_ports.md
@@ -3,7 +3,7 @@ title: "Ports"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_used_ports.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 
@@ -48,73 +48,100 @@ Backup Server
 
 Guest Processing Components
 
-The following table describes the network ports that must be opened to ensure proper communication between the backup server and the VMs that will be added to Managed Servers as Guest Interaction Proxy (Log Shipping Server).
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [guest processing](guest_processing.md):
 
-Guest Processing Components
+* [Guest interaction proxies](#guest_proxy)
+* [Protected workloads](#guest_workload)
+* [Gateway servers](#guest_gateway)
+* [Hypervisors](#guest_hypervisor)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest OS File Recovery](used_ports.md#guest_os_file_recovery).
+
+Guest Interaction Proxies
+
+The following table describes network ports that must be opened for [guest interaction proxies](guest_interaction_proxy.md) involved in the guest processing.
+
+Guest Interaction Proxies
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Guest interaction proxy | TCP | 445, 135 | Ports used for adding Windows VMs to managed servers using local administrator credentials. Note: Kerberos domain account with administrator privileges should be used. |
 | TCP | 6160 | Port used for adding both Windows and Linux VMs to managed servers using a certificate-based authentication. Note: Deployment kit should be pre-installed on VMs. |
 | TCP | 22 | Port used for adding Linux VMs to managed servers using SSH credentials. |
+| Connections for Non-Persistent Runtime Components | | | | |
+| Backup server | Guest interaction proxy | TCP | 6190 | Port used for communication of the backup server and backup infrastructure components with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing. |
 
-Connections with Non-Persistent Runtime Components
+Protected Workloads
 
-The following tables describe network ports that must be opened to ensure proper communication of the backup server and backup infrastructure components with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing.
+The following table describes network ports that must be opened for protected workloads involved in the guest processing.
 
-Connections with Non-Persistent Runtime Components
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Guest interaction proxy | TCP | 6190 | Port used for communication with the guest interaction proxy. |
-| Guest interaction proxy | ESXi server | TCP | 443 | Default port used for connections to ESXi host.  [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vCenter Web Services. |
-
-Network ports described in the following table are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct.
-
-Connections with Non-Persistent Runtime Components
+Protected Workloads
 
 | From | To | Protocol | Port | Notes |
-| Guest interaction proxy | VM guest OS (Microsoft Windows) | TCP | 445, 135 | Port used to deploy the runtime coordination process on the VM guest OS. |
-| TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. |
-| TCP | 6173 | Port used by the runtime process deployed inside the VM for guest OS interaction. |
-| VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. |
-
-Connections with Persistent Agent Components
-
-The following table describes network ports that must be opened to ensure proper communication of the backup server with the persistent agent components deployed inside the VM guest OS for application-aware processing and indexing.
-
-Connections with Persistent Agent Components
-
-| From | To | Protocol | Port | Notes |
+| Connections for Non-Persistent Runtime Components | | | | |
+| Guest interaction proxy | VM guest OS | TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. Note: These ports are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | VM guest OS (Microsoft Windows) | TCP | 445, 135 | Port used to deploy the runtime coordination process on the VM guest OS. Note: These ports are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| TCP | 6173 | Port used by the runtime process deployed inside the VM for guest OS interaction. Note: This port NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel. Note: This port NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Connections for Persistent Agent Components | | | | |
+| Backup server | VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel during persistent agent installation. |
+| TCP | 2500 to 3300 | Range of ports used only during the installation of the persistent agent.  Default range of ports used for communication with a guest OS. |
 | Guest interaction proxy | VM guest OS (Linux) | TCP | 6160 | Default port used by Veeam Installer Service for Linux. |
 | TCP | 6162 | Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| VM guest OS (Windows) | TCP | 6160, 11731 | Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
+| Guest interaction proxy | VM guest OS (Windows) | TCP | 6160, 11731 | Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing and file system indexing. |
+
+Gateway Servers
+
+The following table describes network ports that must be opened for [gateway servers](gateway_server.md) involved in the guest processing.
+
+Gateway Servers
+
+| From | To | Protocol | Port | Notes |
+| Guest interaction proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Hypervisors
+
+The following table describes network ports that must be opened for the hypervisors involved in the guest processing.
+
+Hypervisors
+
+| From | To | Protocol | Port | Notes |
+| Guest interaction proxy | ESXi server | TCP | 443 | Default port used for connections to ESXi host. This port must be opened to ensure proper communication with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing. [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vCenter Web Services. |
 
 Log Shipping Components
 
-The following tables describe network ports that must be opened to ensure proper communication between log shipping components.
+The following tables describe network ports that must be opened to ensure proper communication for components involved in log backup, such as [Microsoft SQL Server log backup](sql_backup.md), [Oracle log backup](oracle_backup.md) and [PostgreSQL WAL files backup](postgresql_backup.md):
 
-* [Log Shipping Server Connections](#log_shipping_server_connections)
-* [MS SQL Guest OS Connections](#sql_guest_os_connections)
-* [Oracle Guest OS Connections](#oracle_guest_os_connections)
-* [PostgreSQL Guest OS Connections](#postgresql_guest_os_connections)
+* [Log shipping servers](#log_shipping_server_connections)
+* [MS SQL guest OS](#sql_guest_os_connections)
 
-Log Shipping Server Connections
+* [Oracle guest OS](#oracle_guest_os_connections)
+* [PostgreSQL guest OS](#postgresql_guest_os_connections)
 
-Log Shipping Server Connections
+* [Backup repositories](#log_repo)
+* [Gateway servers](#log_gateway)
+* [Hypervisors](#log_hypervisor)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest OS File Recovery](used_ports.md#guest_os_file_recovery).
+
+Log Shipping Servers
+
+The following table describes network ports that must be opened for [log shipping servers](log_shipping_server.md) involved in the log backup.
+
+Log Shipping Servers
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Log shipping server | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
 | TCP | 6162 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine). |
-| Hyper-V host | Log shipping server (backup server) | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server | Backup repository or gateway server | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server (backup server) | Hyper-V host | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server | ESXi host | TCP | 443 | Default port used for communication with a log shipping server and transfer log backups over vSphere API. |
+| Hyper-V host | Log shipping server (backup server) | TCP | 6162, 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| VM guest OS (VM with MS SQL, Oracle, or PostgreSQL) | Log shipping server | TCP | 6162, 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-MS SQL Guest OS Connections
+MS SQL Guest OS
 
-MS SQL Guest OS Connections
+The following table describes network ports that must be opened for MS SQL VM guest OS involved in the log backup.
+
+MS SQL Guest OS
 
 | From | To | Protocol | Port | Notes |
 | Guest interaction proxy | MS SQL VM guest OS | TCP | 445, 135, 137, 139 | [Non-persistent runtime components only] Ports used for deploying Veeam Backup & Replication components including Veeam Log Shipper runtime component.  These ports are not required:   * When working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. * If the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.   Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
@@ -122,34 +149,60 @@ MS SQL Guest OS Connections
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing. |
 | TCP | 6160, 11731 | [Persistent agent components only] Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6167 | Port used by the Veeam Log Shipping Service for preparing the database and taking logs. |
-| MS SQL VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the MS SQL server has a direct connection to the backup repository. |
-| MS SQL VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-Oracle Guest OS Connections
+Oracle Guest OS
 
-Oracle Guest OS Connections
+The following table describes network ports that must be opened for Oracle VM guest OS involved in the log backup.
+
+Oracle Guest OS
 
 | From | To | Protocol | Port | Notes |
+| Guest interaction proxy | Oracle VM guest OS | TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | Guest interaction proxy | Oracle VM guest OS (Microsoft Windows) | TCP | 445, 135 | [Non-persistent runtime components only] Ports used for deploying Veeam Backup & Replication components including Veeam Log Shipper runtime component.  These ports are not required:   * When working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. * If the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.   Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing |
 | TCP | 6160, 11731 | [Persistent agent components only] Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6167 | Port used by the Veeam Log Shipping Service for preparing the database and taking logs. |
-| Oracle VM guest OS (Linux) | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | Oracle VM guest OS (Linux) | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | TCP | 6162 | [Persistent agent components only] Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
-| Oracle VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the Oracle server has a direct connection to the backup repository. |
-| Oracle VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-PostgreSQL Guest OS Connections
+PostgreSQL Guest OS
 
-PostgreSQL Guest OS Connections
+The following table describes network ports that must be opened for PostgreSQL VM guest OS involved in the log backup.
+
+PostgreSQL Guest OS
 
 | From | To | Protocol | Port | Notes |
 | Guest interaction proxy | PostgreSQL VM guest OS | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over vSphere Web Services. |
 | TCP | 6162 | [Persistent agent components only] Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  This port is NOT required when working in networkless mode over vSphere Web Services. |
-| PostgreSQL VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the PostgreSQL server has a direct connection to the backup repository. |
-| PostgreSQL VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
+| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over vSphere Web Services. |
+
+Backup Repositories
+
+The following table describes network ports that must be opened for backup repositories involved in the log backup.
+
+Backup Repositories
+
+| From | To | Protocol | Port | Notes |
+| Log shipping server | Backup repository | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| VM guest OS (VM with MS SQL, Oracle, or PostgreSQL) | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the MS SQL server has a direct connection to the backup repository. |
+
+Gateway Servers
+
+The following table describes network ports that must be opened for [gateway servers](gateway_server.md) involved in the log backup.
+
+Gateway Servers
+
+| From | To | Protocol | Port | Notes |
+| Log shipping server | Gateway server | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+
+Hypervisors
+
+The following table describes network ports that must be opened for hypervisors involved in the log backup.
+
+Hypervisors
+
+| From | To | Protocol | Port | Notes |
+| Log shipping server (backup server) | Hyper-V host | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| Log shipping server | ESXi host | TCP | 443 | Default port used for communication with a log shipping server and transfer log backups over vSphere API. |
 
 

--- a/docs/pve_veeamzip_create.md
+++ b/docs/pve_veeamzip_create.md
@@ -3,7 +3,7 @@ title: "Creating VeeamZIP Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_veeamzip_create.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_vm_guest_restore.md
+++ b/docs/pve_vm_guest_restore.md
@@ -3,7 +3,7 @@ title: "Performing File-Level Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_vm_guest_restore.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers.md
+++ b/docs/pve_workers.md
@@ -3,7 +3,7 @@ title: "Managing Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add.md
+++ b/docs/pve_workers_add.md
@@ -3,7 +3,7 @@ title: "Adding Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add_byb.md
+++ b/docs/pve_workers_add_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add_byb.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add_launch.md
+++ b/docs/pve_workers_add_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Proxmox Worker"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add_launch.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add_network.md
+++ b/docs/pve_workers_add_network.md
@@ -3,7 +3,7 @@ title: "Step 3. Configure Network Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add_network.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add_summary.md
+++ b/docs/pve_workers_add_summary.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add_summary.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_add_vm.md
+++ b/docs/pve_workers_add_vm.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Worker VM Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_add_vm.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_disable.md
+++ b/docs/pve_workers_disable.md
@@ -3,7 +3,7 @@ title: "Enabling and Disabling Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_disable.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_edit.md
+++ b/docs/pve_workers_edit.md
@@ -3,7 +3,7 @@ title: "Editing Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_edit.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_remove.md
+++ b/docs/pve_workers_remove.md
@@ -3,7 +3,7 @@ title: "Removing Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_remove.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_test.md
+++ b/docs/pve_workers_test.md
@@ -3,7 +3,7 @@ title: "Testing Workers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_test.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/pve_workers_update.md
+++ b/docs/pve_workers_update.md
@@ -3,7 +3,7 @@ title: "Disabling Automatic Worker Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/pve_workers_update.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/recovery_verification_surereplica.md
+++ b/docs/recovery_verification_surereplica.md
@@ -3,8 +3,8 @@ title: "SureReplica"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/recovery_verification_surereplica.html"
-last_updated: "7/23/2024"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # SureReplica
@@ -18,7 +18,6 @@ The SureReplica technology is not limited only to VM replica verification. Just 
 
 * SureReplica: automated VM replicas verification, including storage snapshot replicas.
 * On-Demand Sandbox: an isolated environment for testing VM replicas, training and troubleshooting.
-* U-AIR: recovery of individual items from applications running on VM replicas.
 
 Related Topics
 

--- a/docs/sia_transport.md
+++ b/docs/sia_transport.md
@@ -1,0 +1,29 @@
+---
+title: "Storage Integration Access"
+product: "vbr"
+doc_type: "userguide"
+source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sia_transport.html"
+last_updated: "3/23/2026"
+product_version: "13.0.1.2067"
+---
+
+# Storage Integration Access
+
+
+The Storage integration access transport mode is recommended for VMs whose disks are located on storage systems that are connected to ESXi hosts over any supported protocol. For more information on the protocols, see [Storage Systems System Requirements](system_requirements_storage_systems.md).
+
+In the Storage integration access transport mode, Veeam Backup & Replication bypasses the ESXi host and reads data directly from or writes data directly to storage systems.
+
+The Storage integration access transport mode can be used for the following features:
+
+* [Backup from Storage Snapshots](backup_from_storage_snapshots.md)
+* [Backup from Storage Snapshots with Snapshot Retention](snapshot_job_secondary.md)
+
+Requirements and Limitations for the Storage Integration Access Mode
+
+To use the Storage integration access transport mode, consider the following:
+
+* Make sure that [general requirements for the VMware backup proxy](backup_proxy_requirements.md) plus [proxy requirements for the storage system snapshot integration](storage_configure_proxy.md) are met.
+* For the correct configuration of the storage system integration feature, check [Storage System Snapshot Integration](storage_integration.md).
+
+

--- a/docs/surebackup_job_appgroup_hv.md
+++ b/docs/surebackup_job_appgroup_hv.md
@@ -3,8 +3,8 @@ title: "Step 4. Select Application Group"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_job_appgroup_hv.html"
-last_updated: "11/22/2023"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 4. Select Application Group
@@ -20,7 +20,7 @@ To select an application group:
 
 1. From the Application group list, select an application group. The list contains all application groups that are created on the backup server.
 2. In the Application group info list, refer to the Source Status column to make sure that backups and replicas for machines in the application group are created.
-3. To leave machines from the application group running after the SureBackup job finishes, select the Keep the application group running after the job completes check box. With this option enabled, the lab will not be powered off when the SureBackup job completes, and you will be able to perform application item-level restore ([U-AIR](https://www.veeam.com/veeam_backup_12_uair_wizard_user_guide_pg.pdf)) and manually test machines started in the virtual lab.
+3. To leave machines from the application group running after the SureBackup job finishes, select the Keep the application group running after the job completes check box. With this option enabled, the lab will not be powered off when the SureBackup job completes, and you will be able to manually test machines started in the virtual lab.
 
 ![Step 4. Select Application Group](images/surebackup_job_app_group.webp)
 

--- a/docs/surebackup_job_appgroup_vm.md
+++ b/docs/surebackup_job_appgroup_vm.md
@@ -3,8 +3,8 @@ title: "Step 4. Select Application Group"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_job_appgroup_vm.html"
-last_updated: "10/16/2023"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 4. Select Application Group
@@ -20,7 +20,7 @@ To select an application group:
 
 1. From the Application group list, select an application group. The list contains all application groups that are created on the backup server.
 2. In the Application group info list, refer to the Source Status column to make sure that backups and replicas for VMs in the application group are created.
-3. To leave machines from the application group running after the SureBackup job finishes, select the Keep the application group running after the job completes check box. With this option enabled, the lab will not be powered off when the SureBackup job completes, and you will be able to perform application item-level restore ([U-AIR](https://www.veeam.com/veeam_backup_12_uair_wizard_user_guide_pg.pdf)) and manually test machines started in the virtual lab.
+3. To leave machines from the application group running after the SureBackup job finishes, select the Keep the application group running after the job completes check box. With this option enabled, the lab will not be powered off when the SureBackup job completes, and you will be able to manually test machines started in the virtual lab.
 
 ![Step 4. Select Application Group](images/surebackup_job_app_group.webp)
 

--- a/docs/surereplica_hiw.md
+++ b/docs/surereplica_hiw.md
@@ -3,8 +3,8 @@ title: "How SureReplica Works"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surereplica_hiw.html"
-last_updated: "8/20/2024"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # How SureReplica Works
@@ -14,9 +14,7 @@ SureReplica is Veeam’s technology that lets you test a VM replica for recovera
 
 SureReplica supports regular VM replicas and VM replicas added to a CDP policy. SureReplica verification does not prevent CDP policy from running.
 
-The SureReplica technology does not require the vPower engine. A VM replica is essentially an exact copy of a VM with a set of restore points. The VM replica data is stored in the raw decompressed format native to VMware. Therefore, to start a VM replica in the virtual lab, you do not need to present its data through the vPower NFS datastore to the ESXi host. Veeam Backup & Replication re-configures the VM replica settings for recovery verification, connects the VM replica to the isolated virtual lab and powers it on.
-
-As there is no need to publish the VM from the backup file, the SureReplica processing is typically faster than SureBackup. Subsequently, the [U-AIR](https://www.veeam.com/veeam_backup_12_uair_wizard_user_guide_pg.pdf) and On-Demand Sandbox operations are faster, too.
+The SureReplica technology does not require the vPower engine. A VM replica is essentially an exact copy of a VM with a set of restore points. The VM replica data is stored in the raw decompressed format native to VMware. Therefore, to start a VM replica in the virtual lab, you do not need to present its data through the vPower NFS datastore to the ESXi host. Veeam Backup & Replication re-configures the VM replica settings for recovery verification, connects the VM replica to the isolated virtual lab and powers it on. As there is no need to publish the VM from the backup file, the SureReplica processing is typically faster than SureBackup.
 
 During VM replica verification, Veeam Backup & Replication performs the following actions:
 

--- a/docs/transport_modes.md
+++ b/docs/transport_modes.md
@@ -3,8 +3,8 @@ title: "Transport Modes"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/transport_modes.html"
-last_updated: "12/5/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/30/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Transport Modes
@@ -28,8 +28,9 @@ Veeam Backup & Replication leverages VMware vStorage APIs for Data Protection (V
 
 Applicability and efficiency of each transport mode primarily depends on the type of datastore used by the source host — local or shared, and on the VMware backup proxy type — physical or virtual. The following table shows recommendations for installing the VMware backup proxy, depending on the storage type and desired transport mode.
 
+Transport Modes
+
 | Production Storage Type | Direct Storage Access | Virtual Appliance | Network Mode |
-| --- | --- | --- | --- |
 | Fibre Channel (FC) SAN | Install a VMware backup proxy on a physical server with a direct FC access to the SAN. | Install a VMware backup proxy on a VM running on an ESXi host connected to the storage device. | This mode is not recommended on 1 Gb Ethernet but works well with 10 Gb Ethernet.  Install a VMware backup proxy on any machine on the storage network. |
 | iSCSI SAN | Install a VMware backup proxy on a physical or virtual machine. |
 | NFS Storage |
@@ -47,14 +48,15 @@ Transport Mode Limitations
 
 The transport mode limitations are defined by the backup proxy configuration. The following table describes transport mode availability and protocol support for different backup infrastructure components assigned the role of the backup proxy in VMware vSphere environments and storage system integration.
 
+Transport Mode Limitations
+
 | Component Used as Backup Proxy | Direct Storage Access | | | Virtual Appliance | Network Mode |
-| --- | --- | --- | --- | --- | --- |
-| Direct SAN Access1 | Direct NFS Access | Storage Integration1 |
+| Direct SAN Access1 | Direct NFS Access | Storage Integration Access1 |
 | Veeam Software Appliance | ✕ | ✕ | ✕ | ✕ | ✓ |
 | Veeam Infrastructure Appliance2 | ✕ | ✓ | NFS | ✓ | ✓ |
-| Veeam Infrastructure Appliance with iSCSI and NVMe/TCP2 | ✕ | ✓ | iSCSI, NFS, NVMe-TCP | ✓ | ✓ |
+| Veeam Infrastructure Appliance with iSCSI and NVMe/TCP2 | ✓ | ✓ | iSCSI, FC, NFS, NVMe-TCP | ✓ | ✓ |
 | Veeam Hardened Repository | ✕ | ✕ | ✕ | ✕ | ✓ |
-| Windows-based backup server | ✓ | ✓ | iSCSI, FC, NFS | ✓ | ✓ |
+| Microsoft Windows-based backup server | ✓ | ✓ | iSCSI, FC, NFS | ✓ | ✓ |
 | Microsoft Windows server | ✓ | ✓ | iSCSI, FC, NFS | ✓ | ✓ |
 | Linux server added with persistent credentials | ✓ | ✓ | iSCSI, FC, NFS, NVMe-FC, NVMe-TCP, NVMe-RDMA | ✓ | ✓ |
 | Linux server added with single-use credentials as Hardened Repository | ✕ | ✕ | ✕ | ✕ | ✓ |

--- a/docs/update_appliance_check_updates.md
+++ b/docs/update_appliance_check_updates.md
@@ -3,7 +3,7 @@ title: "Checking for Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/update_appliance_check_updates.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/update_appliance_configure_updates.md
+++ b/docs/update_appliance_configure_updates.md
@@ -3,7 +3,7 @@ title: "Configuring Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/update_appliance_configure_updates.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/update_appliance_hiw.md
+++ b/docs/update_appliance_hiw.md
@@ -3,7 +3,7 @@ title: "How Updates Work"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/update_appliance_hiw.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/update_appliance_install_updates.md
+++ b/docs/update_appliance_install_updates.md
@@ -3,7 +3,7 @@ title: "Installing Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/update_appliance_install_updates.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/update_appliance_view_history.md
+++ b/docs/update_appliance_view_history.md
@@ -3,7 +3,7 @@ title: "Viewing Update History"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/update_appliance_view_history.html"
-last_updated: "3/27/2026"
+last_updated: "3/31/2026"
 product_version: "13.0.1.2067"
 ---
 

--- a/docs/used_ports.md
+++ b/docs/used_ports.md
@@ -3,430 +3,363 @@ title: "Ports"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/used_ports.html"
-last_updated: "3/24/2026"
+last_updated: "3/30/2026"
 product_version: "13.0.1.2067"
 ---
 
 # Ports
 
 
-On backup infrastructure components, Veeam Backup & Replication automatically creates firewall rules for the required ports on Windows-based machines. If you are using a third-party firewall, these rules must be created manually. These rules allow components to communicate with each other. You can find the full list of the ports for standard installations in this section.
+This section describes incoming connections for different components in the backup infrastructure. The first part describes ports that must be opened on the core backup infrastructure components. These ports allow basic operations for data protection such as backup and replication. The second part describes ports required for different features.
 
-|  |
-| --- |
-| Important |
-| Some Linux distributions also require firewall and security rules to be created manually. For details, see [this Veeam KB article](https://www.veeam.com/kb2986). |
+On backup infrastructure components, Veeam Backup & Replication automatically creates firewall rules for the required ports on Microsoft Windows-based machines. If you are using a third-party firewall, these rules must be created manually. These rules allow components to communicate with each other. You can find the full list of the ports for standard installations in this section.
 
-If you use an HTTP/HTTPS proxy server to access the Internet, make sure that WinHTTP settings are properly configured on Microsoft Windows machines with Veeam backup infrastructure components. For information on how to configure WinHTTP settings, see [Microsoft Docs](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/configure-proxy-internet).
+Considerations
 
-|  |
-| --- |
-| Note |
-| Tenants cannot access Veeam Cloud Connect infrastructure components through HTTP/HTTPS proxy servers. For information on supported protocols for Veeam Cloud Connect, see the [Ports](https://helpcenter.veeam.com/docs/vbr/cloud/ports.html?ver=13) section in the Veeam Cloud Connect Guide. |
-
-All Backup Infrastructure Components
-
-All Backup Infrastructure Components
-
-| From | To | Protocol | Port | Notes |
-| Any backup infrastructure component | DNS server | UDP, TCP | 53 | Port used for communication with the DNS server. It is required for forward/reverse name resolution of all backup and infrastructure servers including Active Directory domain controllers. |
+* Ports described for the core backup infrastructure components are considered basic ports that must be opened whenever these components are used for any data protection tasks.
+* If a backup infrastructure component performs multiple roles (for example, acts as both a backup proxy and a repository), make sure all required ports for each role are opened.
+* Some Linux distributions also require firewall and security rules to be created manually. For details, see [this Veeam KB article](https://www.veeam.com/kb2986).
+* If you use an HTTP/HTTPS proxy server to access the Internet, make sure that WinHTTP settings are properly configured on Microsoft Windows machines with Veeam backup infrastructure components. For information on how to configure WinHTTP settings, see [Microsoft Docs](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/configure-proxy-internet).
+* Tenants cannot access Veeam Cloud Connect infrastructure components through HTTP/HTTPS proxy servers. For information on supported protocols for Veeam Cloud Connect, see the [Ports](https://helpcenter.veeam.com/docs/vbr/cloud/ports.html?ver=13) section in the Veeam Cloud Connect Guide.
 
 Backup Server
 
-The following tables describe network ports that must be opened to ensure proper communication of the backup server with backup infrastructure components:
+The following table describes basic network ports that must be opened to ensure proper communication with the [backup server](backup_server.md). For the high availability cluster feature, also see [High Availability (HA) Cluster Components](#ha).
 
-* [Incoming Connections](#backup_server_in)
-* [Outgoing Connections](#backup_server_out)
-
-Incoming Connections
-
-Incoming Connections
+Backup Server
 
 | From | To | Protocol | Port | Notes |
-| PC where web UI is open | Backup server | TCP | 443 | Port used to connect to the Veeam Backup & Replication web UI. |
-| TCP | 10443 | Port used by the Host Management console to connect to Linux-based backup servers deployed from the Veeam Software Appliance ISO. |
-| Remote access PC | TCP | 22 | Port used to connect to Linux-based backup servers deployed from the Veeam Software Appliance ISO through SSH. |
+| PC where web UI is open,  Remote Veeam Backup & Replication console,  Mount server | Backup server | TCP | 443 | Port used to communicate with the backup server. |
+| PC where web UI is open | Backup server | TCP | 10443 | Port used by the Host Management console to connect to Linux-based backup servers deployed from the Veeam Software Appliance ISO. |
+| Remote access PC | Backup server | TCP | 22 | Port used to connect to Linux-based backup servers deployed from the Veeam Software Appliance ISO through SSH. |
 | TCP | 3389 | Default port used by Remote Desktop Services to connect to Windows-based backup servers.  If you use third-party solutions to connect to the backup server, other ports may need to be open. |
-| Remote Veeam Backup & Replication console | TCP | 443 | Port used to communicate with the backup server. |
-| Backup proxy | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) for ransomware index transfer.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository (Linux) | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository (Microsoft Windows) | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Tape server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Mount server | TCP | 9401 | Port used for communication with the Veeam Backup Service.  Also required to perform Copy to and Mount to console operations during Windows file-level recovery. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 443 | Port used for communication with the backup server. |
-| REST client | TCP | 9419 | Default ports for communication with REST API service. |
-| CDP components | TCP | 33034 | [CDP only] Port used by the following CDP components to communicate with Veeam CDP Coordinator Service:   * CDP proxy (source and target) * ESXi host (source and target) * vCenter Server (source and target)   For more information, see [Continuous Data Protection (CDP) for VMware vSphere](cdp_replication.md). |
-| ESXi host | TCP | 33035 | [CDP only] Port used to install I/O filter components on the source and target ESXi hosts. For more information, see [Continuous Data Protection (CDP) for VMware vSphere](cdp_replication.md). |
-| vCenter Server | TCP | 33035 | [CDP only] Port used to install I/O filter components on the source and target vCenter servers. For more information, see [Continuous Data Protection (CDP) for VMware vSphere](cdp_replication.md). |
-| SCVMM | TCP | 443 | Port used for Veeam PowerShell Management Service authorization on the SCVMM server. |
+| Veeam Backup & Replication console | Backup server | TCP | 9420 | [For console version 12.3.2 P1 (build 12.3.2.4165)] Port used by the Veeam Backup & Replication console to communicate with the backup server for console automatic update. |
+| Backup proxy | Backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) for ransomware index transfer.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup repository (Linux),  Backup repository (Microsoft Windows),  Gateway server,  Mount server | Backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Mount server | Backup server | TCP | 9401 | Port used for communication with the Veeam Backup Service.  Also required to perform Copy to and Mount to console operations during Windows file-level recovery. |
+| REST client | Backup server | TCP | 9419 | Default ports for communication with REST API service. |
+| Veeam Infrastructure Appliance | Backup server | TCP | 443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO to authenticate incoming connections from Veeam Backup & Replication. |
 
-Outgoing Connections
+Veeam Servers and Services
 
-Outgoing Connections
+The following table describes basic network ports that must be opened to ensure proper communication with Veeam servers and services.
+
+Veeam Servers and Services
 
 | From | To | Protocol | Port | Notes |
-| Communication with Virtualization Servers | | | | |
-| Backup server | vCenter Server | TCP | 443 | Port used for connections to vCenter Server.  Note: The backup server should have a direct connection to vCenter Server. HTTP/HTTPS proxy servers are not supported.  If you use VMware Cloud Director, make sure you open port 443 on underlying vCenter Servers. |
-| ESXi server | TCP | 443 | Port used for connections to ESXi host.  This port is not required for VMware Cloud on AWS. |
-| TCP | 902 | Port used for data transfer to ESXi host. It is also used during guest OS file recovery if you recover files from replicas.  This port is not required for VMware Cloud on AWS. |
-| VMware Cloud Director | TCP | 443 | Port used for connections to VMware Cloud Director.  Note: The backup server should have a direct connection to VMware Cloud Director. HTTP/HTTPS proxy servers are not supported. |
-| SCVMM | TCP | 8732 | Port used to communicate with the VMM server. |
-| TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 6160 | Port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Microsoft Hyper-V server | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 6163 | Default port used to communicate with Veeam Hyper-V Integration Service. |
-| TCP | 2179 | Port used to connect to VMs using the Virtual Machine Connection during [Instant Recovery to Microsoft Hyper-V](instant_recovery_to_hv.md) and [Recovery Verification for Microsoft Hyper-V](recovery_verification_overview_hv.md). |
-| TCP | 49152 to 65535 | Dynamic RPC port range for Microsoft Windows 2008 and later. For more information, see [this Microsoft KB article](https://support.microsoft.com/kb/929851/en-us).  Note: If you use default Microsoft Windows firewall settings, you do not need to configure dynamic RPC ports. During setup, Veeam Backup & Replication automatically creates a firewall rule for the runtime process. If you use firewall settings other than default ones or application-aware processing fails with the "RPC function call failed" error, you need to configure dynamic RPC ports. For more information on how to configure RPC dynamic port allocation to work with firewalls, see [this Microsoft KB article](https://support.microsoft.com/en-us/help/154596/how-to-configure-rpc-dynamic-port-allocation-to-work-with-firewalls). |
+| Communication with Update Repositories | | | | |
+| Backup server,  Veeam Infrastructure Appliance | Veeam Update Repository  (repository.veeam.com) | TCP | 443 or 80 | Port used to connect to the Veeam Update Repository. The port is used by Linux-based backup servers deployed from the Veeam Software Appliance ISO and by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO.  The repository is Veeam-maintained and provides product, operating system, and security updates. For more information, see [How Updates Work](update_appliance_hiw.md). |
+| Backup server,  Veeam Infrastructure Appliance | Veeam Update Repository (local mirror)  (<localmirrorrepository.domain>) | TCP | 443 or 80 | Port used to connect to a local mirror of the Veeam Update Repository. For more information, see [Configuring Updates](update_appliance_configure_updates.md).  This port is used by Linux-based backup servers deployed from the Veeam Software Appliance ISO and by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO.  Consider that the address must be replaced with the actual URL of your mirror repository. |
+| Backup server | Veeam License Update Server  (vbr.butler.veeam.com, autolk.veeam.com) | TCP | 443 | Default port used to automatically update license from the Veeam License Update Server over HTTPS. Veeam Threat Hunter and Veeam Data Cloud Vault also require this communication to work properly. |
+| Backup server | Veeam License Update Server  (\*.ss2.us, \*.amazontrust.com) | TCP | 80 | Port used for certificate validation when Veeam Backup & Replication connects to Veeam License Update Server to check if the new license is available and download it. Veeam Threat Hunter also requires this communication to work properly.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
+| Backup server | Veeam Update Notification Server  (dev.veeam.com, vbrad.butler.veeam.com, vbrce.butler.veeam.com) | TCP | 443 | Default port used to download information about available updates from the Veeam Update Notification Server over HTTPS. |
+| Communication with Veeam AI Assistant | | | | |
+| Veeam Backup & Replication console,  PC where web UI is open | Veeam AI Assistant  (rest-ai.veeam.com) | TCP | 443 | Default port for communication with the Veeam AI Assistant service. |
+| Communication with Veeam ONE | | | | |
+| Backup server | Veeam ONE Server | TCP | 2741 | Default port used for communication with Veeam ONE internal Web API.  Required for the Analytics view. For more information, see [Configuring Analytics View](configure_analytics.md). |
+| 2805 | Port used for communication between Veeam Analytics Service and Veeam ONE Monitoring service. This is required for Veeam ONE data collection. |
+| Backup server | Veeam ONE Web Services | TCP | 1239 | Default port used by Veeam ONE Web Services.  Required for the Analytics view. For more information, see [Configuring Analytics View](configure_analytics.md). |
+
+Databases and External Services
+
+The following table describes basic network ports that must be opened to ensure proper communication with databases and different external servers such as mail servers, time servers and others.
+
+Databases and External Services
+
+| From | To | Protocol | Port | Notes |
 | Communication with Configuration Databases | | | | |
-| Backup server | PostgreSQL configuration database | TCP | 5432 | Port used for communication with PostgreSQL configuration database. Also required for the High Availability clusters. |
-| Primary backup server with PostgreSQL configuration database | Standby backup server with PostgreSQL configuration database | TCP | 8008 | Port used by PostgreSQL database service to manage the High Availability clusters. |
-| TCP | 8500 | Port used by PostgreSQL database service to manage the High Availability clusters. |
+| Backup server | PostgreSQL configuration database | TCP | 5432 | Port used for communication with PostgreSQL configuration database. |
 | Backup server | Microsoft SQL Server hosting the Veeam Backup & Replication configuration database | TCP | 1433 | Port used for communication with Microsoft SQL Server on which the Veeam Backup & Replication configuration database is deployed (if you use a Microsoft SQL Server default instance).  Additional ports may need to be open depending on your configuration. For more information, see [Microsoft Docs](https://msdn.microsoft.com/en-us/library/cc646023%28v%3Dsql.120%29.aspx#BKMK_ssde). |
 | Communication with Mail Servers | | | | |
 | Backup server | SMTP server | TCP | 25 | Port used by the SMTP server. |
 | TCP | 587 | Port used by the SMTP server if SSL is enabled. |
-| Gmail REST API  (gmail.googleapis.com) | TCP | 443 | Port used to communicate with Google Mail services.  For the authentication process, you need to access accounts.google.com and also gstatic.com for resources like javascript. |
-| Microsoft Graph REST API  (graph.microsoft.com, login.microsoftonline.com) | TCP | 443 | Port used to communicate with Microsoft Exchange Online organizations. |
-| Other Communications | | | | |
-| Backup server | Veeam Update Repository  (repository.veeam.com) | TCP | 443 or 80 | Port used by Linux-based backup servers deployed from the Veeam Software Appliance ISO. It is used to connect to the Veeam Update Repository.  The repository is Veeam-maintained and provides product, operating system, and security updates. For more information, see [How Updates Work](update_appliance_hiw.md). |
-| Veeam Update Repository (local mirror)  (<localmirrorrepository.domain>) | TCP | 443 or 80 | Port used by Linux-based backup servers deployed from the Veeam Software Appliance ISO. It is used to connect to a local mirror of the Veeam Update Repository. For more information, see [Configuring Updates](update_appliance_configure_updates.md).  Consider that the address must be replaced with the actual URL of your mirror repository. |
-| Veeam License Update Server  (vbr.butler.veeam.com, autolk.veeam.com) | TCP | 443 | Default port used to automatically update license from the Veeam License Update Server over HTTPS. Veeam Threat Hunter and Veeam Data Cloud Vault also require this communication to work properly. |
-| Veeam License Update Server  (\*.ss2.us, \*.amazontrust.com) | TCP | 80 | Port used for certificate validation when Veeam Backup & Replication connects to Veeam License Update Server to check if the new license is available and download it. Veeam Threat Hunter also requires this communication to work properly.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
-| Certificate Revocation Lists | TCP | 80 or 443 | Port used for access to the Certificate Revocation Lists (CRL) of the Certificate Authority (CA) that issued the certificate for each backup infrastructure component.  Note: The specific CRL endpoint that must be connected to depends on the CA that issued the certificate.  You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
-| DNS server | UDP, TCP | 53 | Port used for communication with the DNS server. It is required for forward/reverse name resolution of all backup and infrastructure servers including Active Directory domain controllers. |
-| KMS server | TCP | 5696 | Default port used for communication with the Key Management System server. |
-| Syslog server | TCP, UDP | 514 | Default port used to communicate with the syslog server. |
+| Backup server | Gmail REST API  (gmail.googleapis.com) | TCP | 443 | Port used to communicate with Google Mail services.  For the authentication process, you need to access accounts.google.com and also gstatic.com for resources like javascript. |
+| Backup server | Microsoft Graph REST API  (graph.microsoft.com, login.microsoftonline.com) | TCP | 443 | Port used to communicate with Microsoft Exchange Online organizations. |
+| Communication with Time Servers | | | | |
+| Backup server,  Veeam Infrastructure Appliance | NTP server | UDP | 123 | Port used for synchronization with NTP time servers. The port is used by Linux-based backup servers deployed from the Veeam Software Appliance ISO and by backup infrastructure components deployed from the Veeam Infrastructure Appliance  ISO. |
+| Backup server,  Veeam Infrastructure Appliance | NTS server | UDP | 123 | Ports used for synchronization with NTS time servers. The port is used by Linux-based backup servers deployed from the Veeam Software Appliance ISO and by backup infrastructure components deployed from theVeeam Infrastructure Appliance ISO. |
+| TCP | 4460 |  |
+| Other Communication | | | | |
+| Any backup infrastructure component | DNS server | UDP, TCP | 53 | Port used for communication with the DNS server. It is required for forward/reverse name resolution of all backup and infrastructure servers including Active Directory domain controllers. |
+| Backup server | Certificate Revocation Lists | TCP | 80 or 443 | Port used for access to the Certificate Revocation Lists (CRL) of the Certificate Authority (CA) that issued the certificate for each backup infrastructure component.  Note: The specific CRL endpoint that must be connected to depends on the CA that issued the certificate.  You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
+| Backup server | KMS server | TCP | 5696 | Default port used for communication with the Key Management System server. |
+| Backup server | Syslog server | TCP, UDP | 514 | Default port used to communicate with the syslog server. |
 | TCP | 6514 | Default port used to communicate with the syslog server over TLS. |
-| Veeam ONE Server | TCP | 2741 | Default port used for communication with Veeam ONE internal Web API.  Required for the Analytics view. For more information, see [Configuring Analytics View](configure_analytics.md). |
-| 2805 | Port used for communication between Veeam Analytics Service and Veeam ONE Monitoring service. This is required for Veeam ONE data collection. |
-| Veeam ONE Web Services | TCP | 1239 | Default port used by Veeam ONE Web Services.  Required for the Analytics view. For more information, see [Configuring Analytics View](configure_analytics.md). |
-| Microsoft SMB3 server (Hyper-V storage) | TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500-3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 6163 | Default port used by the Hyper-V Integration Service. |
-| Veeam Update Notification Server  (dev.veeam.com, vbrad.butler.veeam.com, vbrce.butler.veeam.com) | TCP | 443 | Default port used to download information about available updates from the Veeam Update Notification Server over HTTPS. |
-| NTP server | UDP | 123 | Port used by Linux-based backup servers deployed from the Veeam Software Appliance ISO for synchronization with NTP time servers. |
-| NTS server | UDP | 123 | Ports used by Linux-based backup servers deployed from the Veeam Software Appliance ISO for synchronization with NTS time servers. |
-| TCP | 4460 |
-| Active Directory Domain Controllers | TCP | 636, 3268, 3269 | Ports used for communications over LDAP and LDAPS protocols. |
+| Backup server,  Veeam Infrastructure Appliance | Active Directory Domain Controllers | TCP | 636, 3268, 3269 | Ports used for communication over LDAP and LDAPS protocols. |
 | UDP, TCP | 389 |
-| UDP, TCP | 445, 139 | Ports used for communications over SMB protocol. |
+| UDP, TCP | 445, 139 | Ports used for communication over SMB protocol. |
 | UDP, TCP | 88 | Port used for Kerberos authentication. |
+| Communication for SMB (CIFS) Repositories | | | | |
+| Gateway server or  Backup proxy | Active Directory Domain Controllers | TCP | 389 | Port used for communication over LDAP and LDAPS protocols. |
+| TCP | 88 | Port used for Kerberos authentication. |
 
-Backup & Replication Console
+Veeam Infrastructure Appliances
 
-The following table describes network ports that must be opened to ensure proper communication with the Veeam Backup & Replication console.
-
-Backup & Replication Console
-
-| From | To | Protocol | Port | Notes |
-| Veeam Backup & Replication console | Mount server | TCP | 6162, 2500 to 3300 | [Remote console only] Ports used as data transmission channels for guest OS file-level restore. For every TCP connection that a job uses, one port from this range is assigned.  These ports are used if the mount server is not located on the console.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Veeam AI Assistant  (rest-ai.veeam.com) | TCP | 443 | Default port for communication with the Veeam AI Assistant service. |
-| Backup server | TCP | 9420 | [For console version 12.3.2 P1 (build 12.3.2.4165)] Port used by the Veeam Backup & Replication console to communicate with the backup server for console automatic update. |
-| PC where web UI is open | Veeam AI Assistant  (rest-ai.veeam.com) | TCP | 443 | Default port for communication with the Veeam AI Assistant service. |
-
-Veeam Infrastructure Appliance
-
-The following table describes network ports that must be opened to ensure proper communication between Veeam Infrastructure Appliances and other backup components.
+The following table describes basic network ports that must be opened to ensure proper communication with [Veeam Infrastructure Appliances](linux_infrastructure.md).
 
 |  |
 | --- |
 | Note |
 | The following ports are required by all Veeam Infrastructure Appliances. You must also open additional ports based on the role you have assigned to the Veeam Infrastructure Appliance. They can be found on this page in the relevant section for the role. For example, [Backup Proxy](#proxy) or [Gateway Server](#gateway).  For more information on the roles that can be assigned to a Veeam Infrastructure Appliance, see [Considerations and Limitations](linux_infrastructure_appliance_byb.md). |
 
-Veeam Infrastructure Appliance
+Veeam Infrastructure Appliances
 
 | From | To | Protocol | Port | Notes |
-| Veeam Infrastructure Appliance | Veeam Update Repository  (repository.veeam.com) | TCP | 443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. It is used to connect to the Veeam Update Repository. The repository is Veeam-maintained and provides product, operating system, and security updates. For more information, see [How Updates Work](update_appliance_hiw.md). |
-| Veeam Update Repository (local mirror)  (<localmirrorrepository.domain>) | TCP | 443 or 80 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. It is used to connect to a local mirror of the Veeam Update Repository. For more information, see [Configuring Updates](update_appliance_configure_updates.md).  Consider that the address must be replaced with the actual URL of your mirror repository. |
-| Backup server | TCP | 443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO to authenticate incoming connections from Veeam Backup & Replication. |
-| NTP server | UDP | 123 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO for synchronization with NTP time servers. |
-| NTS server | UDP | 123 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO for synchronization with NTS time servers. |
-| TCP | 4460 |
-| DNS server | UDP | 53 | Port used for communication with the DNS server. It is required for forward/reverse name resolution of all backup and infrastructure servers including Active Directory domain controllers. |
-| Active Directory Domain Controllers | TCP | 636, 3268, 3269 | Ports used for communications over LDAP and LDAPS protocols. |
-| UDP, TCP | 389 |
-| UDP, TCP | 445, 139 | Ports used for communications over SMB protocol. |
-| UDP, TCP | 88 | Port used for Kerberos authentication. |
 | Backup server | Veeam Infrastructure Appliance | TCP | 443 | Port used by Veeam Backup & Replication to synchronize Veeam Updater settings on backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. |
-| PC where web UI is open | TCP | 10443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. Required to connect to the Host Management console. |
+| PC where web UI is open | Veeam Infrastructure Appliance | TCP | 10443 | Port used by backup infrastructure components deployed from the Veeam Infrastructure Appliance ISO. Required to connect to the Host Management console. |
 
-Backup Proxy
+Backup Proxies
 
-The following table describes network ports that must be opened to ensure proper communication of backup proxies with other backup components. For more information about ports that must be opened between the backup proxy and specific backup repository, see [Backup Repositories](#backup_repos).
+The following table describes basic network ports that must be opened to ensure proper communication with [backup proxies](proxies.md). For more information about ports that must be opened for backup repositories, see [Backup Repositories](#backup_repos).
 
-Backup Proxy
+Backup Proxies
 
 | From | To | Protocol | Port | Notes |
-| Communication with Backup Server | | | | |
-| Backup server | Backup proxy (Microsoft Windows) | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| Backup server,  Backup proxy,  Microsoft Windows/Linux-based backup repository,  Mount server | Backup proxy | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  [For Linux backup proxy] You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Backup proxy (Microsoft Windows) | TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy (Linux) | TCP | 22 | Default SSH port used as a control channel. |
+| Backup server | Backup proxy (Linux) | TCP | 22 | Default SSH port used as a control channel. |
 | TCP | 6160 | Default port used by Veeam Installer Service for Linux. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Communication with Virtualization Servers | | | | |
-| Backup proxy | vCenter Server | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. |
-| ESXi server | TCP | 902 | Default VMware port used for data transfer.  This port is not required for VMware Cloud on AWS. |
-| TCP | 443 | Default VMware web service port that can be customized in ESXi host settings. Not required if vCenter connection is used.  This port is not required for VMware Cloud on AWS. |
-| Other Communications | | | | |
-| Backup proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Microsoft Windows/Linux-based backup repository | Backup proxy | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Mount server | Backup proxy | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Communication for Veeam Data Cloud Vault, Object Storage Repositories, External Repositories | | | | |
+| On-premises backup repository,  Gateway server | Backup proxy (direct connection) | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-Off-Host Backup Proxy
+Gateway Servers
 
-The following table describes network ports that must be opened to ensure proper communication of off-host backup proxies with other backup components. For more information about ports that must be opened between the off-host backup proxy and the specific backup repository, see [Backup Repositories](#backup_repos).
+The following table describes basic network ports that must be opened to ensure proper communication with [gateway servers](gateway_server.md). For more information about ports that must be opened for backup repositories, see [Backup Repositories](#backup_repos).
 
-Off-Host Backup Proxy
+Gateway Servers
 
 | From | To | Protocol | Port | Notes |
-| Communication with Backup Server | | | | |
-| Backup server | Hyper-V server/Off-host backup proxy | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| Backup server,  Backup proxy,  Hyper-V server/Off-host backup proxy,  VM Guest OS | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  [For Linux gateway server] You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Gateway server (Microsoft Windows) | TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 6163 | Default port used by the Hyper-V Integration Service. |
-| TCP | 49152 to 65535 | Dynamic RPC port range for Microsoft Windows 2008 and later. For more information, see [this Microsoft KB article](https://support.microsoft.com/kb/929851/en-us).  Note: If you use default Microsoft Windows firewall settings, you do not need to configure dynamic RPC ports. During setup, Veeam Backup & Replication automatically creates a firewall rule for the runtime process. If you use firewall settings other than default ones or application-aware processing fails with the "RPC function call failed" error, you need to configure dynamic RPC ports. For more information on how to configure RPC dynamic port allocation to work with firewalls, see [this Microsoft KB article](https://support.microsoft.com/en-us/help/154596/how-to-configure-rpc-dynamic-port-allocation-to-work-with-firewalls). |
-| Off-host backup proxy | TCP | 6210 | Default port used by the Veeam Backup VSS Integration Service for taking a VSS snapshot during the SMB file share backup. |
-| Other Communications | | | | |
-| Hyper-V server/Off-host backup proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during replication.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during replication.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
-Gateway Server
-
-The following table describes network ports that must be opened to ensure proper communication with gateway servers. For more information about ports that must be opened between the gateway server and specific backup repository, see [Backup Repositories](#backup_repos).
-
-Gateway Server
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Gateway server (Microsoft Windows) | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Gateway server (Linux) | TCP | 22 | Default SSH port used as a control channel. |
+| Backup server | Gateway server (Linux) | TCP | 22 | Default SSH port used as a control channel. |
 | TCP | 6160 | Default port used by Veeam Installer Service for Linux. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy or Hyper-V server/Off-host backup proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Guest interaction proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Log shipping server | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| VM Guest OS | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Mount server running vPower NFS Service | Gateway server working with backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during Instant Recovery, SureBackup or Linux file-level recovery.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Communication for Veeam Data Cloud Vault, Object Storage Repositories, External Repositories | | | | |
+| On-premises backup repository,  Gateway server | Gateway server for Veeam Data Cloud Vault | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
 Backup Repositories
 
-* [Microsoft Windows/Linux-Based Backup Repository](#repo)
-* [NFS Backup Repository](#nfs_repository)
-* [SMB Backup Repository](#smb_repository)
+The following section describes ports that must be opened to ensure proper communication with different backup repositories:
+
+* [Common ports](#repo_common)
+* [Microsoft Windows/Linux-Based backup repositories](#repo)
+* [NFS backup repositories](#nfs_repository)
+* [SMB backup repositories](#smb_repository)
 * [Dell Data Domain System](#emc)
-* [ExaGrid](#exagrid)
+* [ExaGrid, Quantum DXi, Fujitsu ETERNUS CS800, Infinidat InfiniGuard](#exagrid)
 * [HPE StoreOnce](#storeonce)
-* [Quantum DXi](#quantum)
-* [Fujitsu ETERNUS CS800](#fujitsu_eternus)
-* [Infinidat InfiniGuard](#infinidat_infiniguard)
 * [Veeam Data Cloud Vault](#VDCvault)
-* [Object Storage Repository](#osrc)
-* [Scale-Out Backup Repository](#scaleout)
-* [External Repository](#external_repo)
-* [Archive Object Storage Repository](#archive_tier)
+* [Object storage repositories](#osrc)
+* [Scale-out backup repositories](#scaleout)
+* [External repositories](#external_repo)
+* [Archive object storage repositories](#archive_tier)
 
-Microsoft Windows/Linux-Based Backup Repository
+Common Ports
 
-The following table describes network ports that must be opened to ensure proper communication with Microsoft Windows/Linux-based backup repositories.
+The following table describes basic network ports that must be opened to ensure proper communication with backup repositories. These ports must be opened for all types of the backup repositories.
 
-Microsoft Windows/Linux-Based Backup Repository
+Common Ports
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Backup repository (Microsoft Windows) | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository (Linux) | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 6160 | Default port used by Veeam Installer Service for Linux. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy or Hyper-V server/Off-host backup proxy | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during backup and restore operations.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository | Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during restore operations.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Mount server running vPower NFS Service | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during Instant Recovery, SureBackup or Linux file-level recovery.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Veeam Backup & Replication console,  Backup proxy,  Hyper-V server/Off-host backup proxy | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  [For Linux repository] You can specify a different port while adding the Linux server to the Veeam Backup & Replication infrastructure. Note that you can specify a different port only if there is no previously installed Veeam Transport Service or Veeam Data Mover components on this Linux server. For more information, see [Specify Credentials and SSH Settings](linux_server_ssh.md).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Microsoft Windows/Linux-Based Backup Repositories
+
+The following table describes basic network ports that must be opened to ensure proper communication with Microsoft Windows/Linux-based backup repositories. You must also open ports described in [Backup Repository Common Ports](#repo_common).
+
+Microsoft Windows/Linux-Based Backup Repositories
+
+| From | To | Protocol | Port | Notes |
+| Backup server | Backup repository | TCP | 6160 | Default port used by Veeam Installer Service. |
+| Backup server | Backup repository (Microsoft Windows) | TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| Backup server | Backup repository (Linux) | TCP | 22 | Default SSH port used as a control channel. |
 | Source backup repository | Target backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  If the backup copy job utilizes WAN accelerators, make sure that [ports specific for WAN accelerators](used_ports.md#wan) are opened.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-NFS Backup Repository
+NFS Backup Repositories
 
-The following table describes network ports that must be opened to ensure proper communication with NFS shares added as backup repositories.
+The following table describes basic network ports that must be opened to ensure proper communication with [NFS shares added as backup repositories](nfs_share.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
-NFS Backup Repository
+NFS Backup Repositories
 
 | From | To | Protocol | Port | Notes |
-| Gateway server or backup proxy | NFS backup repository | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service.  Also used as a transmission channel from the gateway server to the target NFS backup repository if a gateway server is specified explicitly in NFS backup repository settings. |
-| Gateway server or backup proxy | NFS backup repository | TCP, UDP | mountd\_port | Dynamic port used for mountd service. Can be assigned statically. |
+| Gateway server or  Backup proxy | NFS backup repository | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service.  Also used as a transmission channel from the gateway server to the target NFS backup repository if a gateway server is specified explicitly in NFS backup repository settings. |
+| Gateway server or  Backup proxy | NFS backup repository (NFS v3) | TCP, UDP | mountd\_port | Dynamic port used for mountd service. Can be assigned statically. |
 | TCP, UDP | statd\_port | Dynamic port used for statd service. Can be assigned statically. |
 | TCP, UDP | lockd\_port | Dynamic port used for lockd service. Can be assigned statically. |
 
-SMB Backup Repository
+SMB Backup Repositories
 
-The following table describes network ports that must be opened to ensure proper communication with SMB (CIFS) shares added as backup repositories.
+The following table describes basic network ports that must be opened to ensure proper communication with [SMB (CIFS) shares added as backup repositories](smb_share.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
-SMB Backup Repository
+SMB Backup Repositories
 
 | From | To | Protocol | Port | Notes |
-| Gateway server or backup proxy | SMB (CIFS) backup repository (Microsoft Windows) | TCP | 445 | Port used as a transmission channel from the gateway server to the target SMB (CIFS) backup repository if a gateway server is specified explicitly in SMB (CIFS) backup repository settings. |
-| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
-| TCP | 88 | Port used for Kerberos authentication. |
+| Gateway server or  Backup proxy | SMB (CIFS) backup repository (Microsoft Windows) | TCP | 445 | Port used as a transmission channel from the gateway server to the target SMB (CIFS) backup repository if a gateway server is specified explicitly in SMB (CIFS) backup repository settings. |
 
 Dell Data Domain System
+
+The following table describes basic network ports that must be opened to ensure proper communication with [Dell Data Domain storage systems added as deduplicating appliances](dell_dd.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
 For more information, see [Dell Documents](https://www.dell.com/support/kbdoc/en-us/000126375/powerprotect-and-data-domain-core-documents).
 
 Dell Data Domain System
 
 | From | To | Protocol | Port | Notes |
-| Backup server or gateway server | Dell Data Domain | TCP | 111 | Port used to assign a random port for the mountd service used by NFS and DDBOOST. Mountd service port can be statically assigned. |
+| Backup server,  Gateway server | Dell Data Domain | TCP | 111 | Port used to assign a random port for the mountd service used by NFS and DDBOOST. Mountd service port can be statically assigned. |
 | TCP | 2049 | Main port used by NFS. Can be modified using the ‘nfs set server-port’ command. Command requires SE mode. |
 | TCP | 2052 | Main port used by NFS MOUNTD. Can be modified using the 'nfs set mountd-port' command in SE mode. |
 
-ExaGrid
+ExaGrid, Quantum DXi, Fujitsu ETERNUS CS800, Infinidat InfiniGuard
 
-ExaGrid
+The following table describes basic network ports that must be opened to ensure proper communication with storage systems added as deduplicating appliances:
+
+* [ExaGrid](deduplicating_appliance_exgrid.md)
+* [Quantum DXi](deduplicating_appliance_quantum.md)
+* [Fujitsu ETERNUS CS800](fujitsu.md)
+* [Infinidat InfiniGuard](infinidat_infiniguard.md)
+
+You must also open ports described in [Backup Repository Common Ports](#repo_common).
+
+ExaGrid, Quantum DXi, Fujitsu ETERNUS CS800, Infinidat InfiniGuard
 
 | From | To | Protocol | Port | Notes |
-| Backup server | ExaGrid | TCP | 22 | Default command port used for communication with ExaGrid and initial installation of Veeam components. |
+| Backup server | Deduplicating appliance | TCP | 22 | Default command port used for communication with the deduplicating appliance and initial installation of Veeam components. |
 | TCP | 6160 | Default port used by Veeam Installer Service for components management and upgrade. |
 | TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy | ExaGrid | TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
 HPE StoreOnce
+
+The following table describes basic network ports that must be opened to ensure proper communication with [HPE StoreOnce storage systems added as deduplicating appliances](deduplicating_appliance_storeonce.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
 HPE StoreOnce
 
 | From | To | Protocol | Port | Notes |
-| Backup server or gateway server | HPE StoreOnce | TCP | 9387 | Default command port used for communication with HPE StoreOnce. |
+| Backup server or  Gateway server | HPE StoreOnce | TCP | 9387 | Default command port used for communication with HPE StoreOnce. |
 | TCP | 9388 | Default data port used for communication with HPE StoreOnce. |
 
-Quantum DXi
-
-Quantum DXi
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Quantum DXi | TCP | 22 | Default command port used for communication with Quantum DXi and initial installation of Veeam components. |
-| TCP | 6160 | Default port used by Veeam Installer Service for components management and upgrade. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy | Quantum DXi | TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
-Fujitsu ETERNUS CS800
-
-Fujitsu ETERNUS CS800
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Fujitsu ETERNUS CS800 | TCP | 22 | Default command port used for communication with Fujitsu ETERNUS CS800 and initial installation of Veeam components. |
-| TCP | 6160 | Default port used by Veeam Installer Service for components management and upgrade. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy | Fujitsu ETERNUS CS800 | TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
-Infinidat InfiniGuard
-
-Infinidat InfiniGuard
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Infinidat InfiniGuard | TCP | 22 | Default command port used for communication with Infinidat InfiniGuard and initial installation of Veeam components. |
-| TCP | 6160 | Default port used by Veeam Installer Service for components management and upgrade. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup proxy | Infinidat InfiniGuard | TCP | 6162, 2500 to 3300 | Default port used by Veeam Data Mover Service.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
 Veeam Data Cloud Vault
 
-The following table describes network ports and endpoints that must be opened to ensure proper communication with Veeam Data Cloud Vault. Note that a connection between the backup server and Veeam License Update Server is also required. For more information, see [Backup Server](#backup).
+The following table describes network ports and endpoints that must be opened to ensure proper communication with Veeam Data Cloud Vault. You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
 Veeam Data Cloud Vault
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Veeam Data Cloud Vault  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  Consider that the <storage-account> part of the address must be replaced with the ID of your storage vault. You can find the storage vault ID in the Storage Vaults > Vault ID section in Veeam Data Cloud Vault. For more information, see the [Managing Storage Vaults](https://helpcenter.veeam.com/docs/vdc/userguide/vault_storage_vaults_edit.html#viewing-storage-vault-details) section in the Veeam Data Cloud User Guide. |
-| Veeam Data Cloud Vault | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
-| Microsoft Entra ID  (login.microsoftonline.com, login.windows.net) | TCP | 443 | Port used for Entra ID authentication. |
-| Backup proxy (direct connection)/Gateway server/Instant Recovery to Azure helper appliance | Veeam Data Cloud Vault  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  Consider that the <storage-account> part of the address must be replaced with the ID of your storage vault. You can find the storage vault ID in the Storage Vaults > Vault ID section in Veeam Data Cloud Vault. For more information, see the [Managing Storage Vaults](https://helpcenter.veeam.com/docs/vdc/userguide/vault_storage_vaults_edit.html#viewing-storage-vault-details) section in the Veeam Data Cloud User Guide. |
-| Veeam Data Cloud Vault | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
-| On-premises backup repository/ Gateway server for on-premises backup repository | Backup proxy (direct connection)/ Gateway server for Veeam Data Cloud Vault | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server,  Backup proxy (direct connection)/  Gateway server/  Instant Recovery to Azure helper appliance | Veeam Data Cloud Vault  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  Consider that the <storage-account> part of the address must be replaced with the ID of your storage vault. You can find the storage vault ID in the Storage Vaults > Vault ID section in Veeam Data Cloud Vault. For more information, see the [Managing Storage Vaults](https://helpcenter.veeam.com/docs/vdc/userguide/vault_storage_vaults_edit.html#viewing-storage-vault-details) section in the Veeam Data Cloud User Guide. |
+| Backup server,  Backup proxy (direct connection)/  Gateway server/  Instant Recovery to Azure helper appliance | Veeam Data Cloud Vault | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server, or proxy, or gateway server, or helper appliance can reach these verification endpoints. |
+| Backup server | Microsoft Entra ID  (login.microsoftonline.com, login.windows.net) | TCP | 443 | Port used for Entra ID authentication. |
 
-Object Storage Repository
+Object Storage Repositories
 
-The following table describes network ports and endpoints that must be opened to ensure proper communication with object storage repositories. For more information, see [Object Storage Repository](object_storage_repository.md).
+The following table describes network ports and endpoints that must be opened to ensure proper communication with [object storage repositories](object_storage_repository.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
-Object Storage Repository
+Object Storage Repositories
 
 | From | To | Protocol | Port | Notes |
-| Gateway server | Backup proxy (direct connection)/Gateway server or backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup server | Smart Object Storage API (SOSAPI) compatible S3 object storage | TCP | 443 | Port used by Veeam Backup & Replication for auxiliary communications with object storage repositories that support Smart Object Storage API (SOSAPI). |
-| Backup proxy (direct connection)/Gateway server or backup server/Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with the Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
-| Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
-| Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
-| Google Cloud storage  (storage.googleapis.com) | TCP | 443 | Port used to communicate with Google Cloud storage.  All cloud endpoints are specified in [this Google article](https://cloud.google.com/storage/docs/request-endpoints). |
-| Google Cloud storage  (ocsp.pki.goog, pki.goog, crl.pki.goog) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
-| IBM Cloud object storage | TCP | Depends on device configuration | Port used to communicate with IBM Cloud object storage. |
-| S3 compatible object storage | TCP | Depends on device configuration | Port used to communicate with S3 compatible object storage. |
+| Backup server | Smart Object Storage API (SOSAPI) compatible S3 object storage | TCP | 443 | Port used by Veeam Backup & Replication for auxiliary communication with object storage repositories that support Smart Object Storage API (SOSAPI). |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with the Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | S3 compatible object storage | TCP | Depends on device configuration | Port used to communicate with S3 compatible object storage. |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Google Cloud storage  (storage.googleapis.com) | TCP | 443 | Port used to communicate with Google Cloud storage.  All cloud endpoints are specified in [this Google article](https://cloud.google.com/storage/docs/request-endpoints). |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | Google Cloud storage  (ocsp.pki.goog, pki.goog, crl.pki.goog) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or gateway server, or helper appliance can reach these verification endpoints. |
+| Backup proxy (direct connection)/  Gateway server or backup server/  Instant Recovery to Azure helper appliance | IBM Cloud object storage | TCP | Depends on device configuration | Port used to communicate with IBM Cloud object storage. |
 
-Scale-Out Backup Repository
+Scale-Out Backup Repositories
 
-The following table describes network ports that must be opened to ensure proper communication with scale-out backup repository. For more information, see [Scale-Out Backup Repositories](backup_repository_sobr.md).
+The following table describes basic network ports that must be opened to ensure proper communication with [scale-out backup repositories](backup_repository_sobr.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
-Scale-Out Backup Repository
+Scale-Out Backup Repositories
 
 | From | To | Protocol | Port | Notes |
 | Source extent | Target extent | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 | Target extent | Source extent | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-External Repository
+External Repositories
 
-The following table describes network ports and endpoints that must be opened to ensure proper communication with external repositories. For more information, see [External Repository](external_repository.md).
+The following table describes basic network ports that must be opened to ensure proper communication with [external repositories](external_repository.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
 
-External Repository
-
-| From | To | Protocol | Port | Notes |
-| Gateway server | Backup proxy (direct connection)/Gateway server or backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Gateway server/backup server/Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
-| Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
-| Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
-| Google Cloud storage  (storage.googleapis.com) | TCP | 443 | Port used to communicate with Google Cloud storage.  All cloud endpoints are specified in [this Google article](https://cloud.google.com/storage/docs/request-endpoints). |
-| Google Cloud storage  (ocsp.pki.goog, pki.goog, crl.pki.goog) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
-
-Archive Object Storage Repository
-
-The following table describes network ports and endpoints that must be opened to ensure proper communication with object storage repositories used as a part of Archive Tier. For more information, see [Archive Tier](archive_tier.md).
-
-Archive Object Storage Repository
+External Repositories
 
 | From | To | Protocol | Port | Notes |
-| Gateway server or backup server | Amazon EC2 helper appliance | TCP | 443 | Port used by default to communicate with the Amazon EC2 helper appliance through public/private IPv4 addresses of EC2 appliances.  If you use Amazon S3 Glacier object storage, the gateway server should have direct connection to AWS service endpoints. HTTP/HTTPS proxy servers are not supported.  If there is no gateway server selected, the backup server will be used as a gateway server. |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Google Cloud storage  (storage.googleapis.com) | TCP | 443 | Port used to communicate with Google Cloud storage.  All cloud endpoints are specified in [this Google article](https://cloud.google.com/storage/docs/request-endpoints). |
+| Gateway server/  Backup server/  Instant Recovery to Azure helper appliance | Google Cloud storage  (ocsp.pki.goog, pki.goog, crl.pki.goog) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy, or backup server, or helper appliance can reach these verification endpoints. |
+
+Archive Object Storage Repositories
+
+The following table describes basic network ports that must be opened to ensure proper communication with object storage repositories used as a part of [Archive Tier](archive_tier.md). You must also open ports described in [Backup Repository Common Ports](#repo_common).
+
+Archive Object Storage Repositories
+
+| From | To | Protocol | Port | Notes |
+| Gateway server or  Backup server | Amazon EC2 helper appliance | TCP | 443 | Port used by default to communicate with the Amazon EC2 helper appliance through public/private IPv4 addresses of EC2 appliances.  If you use Amazon S3 Glacier object storage, the gateway server should have direct connection to AWS service endpoints. HTTP/HTTPS proxy servers are not supported.  If there is no gateway server selected, the backup server will be used as a gateway server. |
 | TCP | 22 | Default SSH port used as a control channel. |
-| Microsoft Azure proxy appliance | TCP | 443 | Port used by default to communicate with the Microsoft Azure helper appliance through public/private IPv4 addresses of Azure appliances.  If there is no gateway server selected, the backup server will be used as a gateway server. |
+| Gateway server or  Backup server | Microsoft Azure proxy appliance | TCP | 443 | Port used by default to communicate with the Microsoft Azure helper appliance through public/private IPv4 addresses of Azure appliances.  If there is no gateway server selected, the backup server will be used as a gateway server. |
 | TCP | 22 | Default SSH port used as a control channel. |
 | Amazon EC2 helper appliance | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with the Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
-| Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the helper appliance can reach these verification endpoints. |
+| Amazon EC2 helper appliance | Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify the certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the helper appliance can reach these verification endpoints. |
 | Microsoft Azure proxy appliance | Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with the Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy appliance can reach these verification endpoints. |
+| Microsoft Azure proxy appliance | Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the proxy appliance can reach these verification endpoints. |
+
+Mount Servers
+
+The following table describes basic network ports that must be opened to ensure proper communication with mount servers. The mount server can be used in different data protection operations. For more information, see [Mount Servers](mount_server.md) and [Veeam vPower NFS Service](vpower_nfs_service.md).
+
+Mount Servers
+
+| From | To | Protocol | Port | Notes |
+| Veeam Backup & Replication console | Mount server | TCP | 6162, 2500 to 3300 | [Remote console only] Ports used as data transmission channels for guest OS file-level restore. For every TCP connection that a job uses, one port from this range is assigned.  These ports are used if the mount server is not located on the console.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Mount server | TCP | 445 | Port used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component. |
+| TCP | 6160 | Default port used by Veeam Installer Service including checking the compatibility between components before starting the recovery process. |
+| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| TCP | 6170 | Port used for communication with a local or remote Mount Service. |
+| Connections of Mount Servers with vPower NFS Service | | | | |
+| Backup server | Mount server running vPower NFS Service | TCP | 6160 | Default port used by Veeam Installer Service. |
+| TCP | 6161 | Default port used by the Veeam vPower NFS Service. |
+| ESXi host | Mount server running vPower NFS Service | TCP UDP | 111 | Standard port used by the port mapper service. |
+| TCP UDP | 1058+ or 1063+ | Default mount port. The number of port depends on where the vPower NFS Service is located:   * 1058+: If the vPower NFS Service is located on the backup server. * 1063+: If the vPower NFS Service is located on a separate Microsoft Windows machine.   If port 1058/1063 is occupied, the succeeding port numbers will be used. |
+| TCP UDP | 2049+ | Standard NFS port. If port 2049 is occupied, the succeeding port numbers will be used. |
+| Backup repository or  Gateway server working with backup repository | Mount server running vPower NFS Service | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during Instant Recovery, SureBackup or Linux file-level recovery.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
 Storage Systems
 
-* [Dell Unity XT, Unity Storage](#dell_unity)
-* [Dell PowerScale (formerly Isilon) Storage](#dell_isilon)
-* [HPE 3PAR StoreServ Storage](#3par)
-* [HPE Alletra Storage MP B10000, Alletra 9000, Primera Storage](#hpe_primera)
-* [HPE Alletra 5000, Alletra 6000, Nimble Storage](#nimble)
-* [Lenovo ThinkSystem DM/DG Series Storage](#lenovo_thinksystem)
-* [NetApp ONTAP Storage](#netapp)
-* [Nutanix Files Storage](#nutanix_files_storage)
-* [Universal Storage API Integrated System](#usais)
+The following tables describe basic network ports that must be opened to ensure proper communication with [storage systems](storage_infrastructure.md).
+
+The following section describes ports that must be opened to ensure proper communication with different storage systems involved in [storage system snapshot integration](storage_integration.md):
+
+* [Dell Unity XT, Unity storage](#dell_unity) [Storage System Snapshot Integration](storage_integration.md)
+* [Dell PowerScale (formerly Isilon) storage](#dell_isilon)
+* [HPE 3PAR StoreServ storage](#3par)
+* [HPE Alletra Storage MP B10000, Alletra 9000, Primera storage](#hpe_primera)
+* [HPE Alletra 5000, Alletra 6000, Nimble storage](#nimble)
+* [Lenovo ThinkSystem DM/DG Series storage](#lenovo_thinksystem)
+* [NetApp ONTAP storage](#netapp)
+* [Nutanix Files storage](#nutanix_files_storage)
+* [Universal storage API integrated system](#usais)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
 Dell Unity XT, Unity Storage
+
+The following table describes basic network ports that must be opened to ensure proper communication with Dell Unity XT, Unity.
 
 Dell Unity XT, Unity Storage
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Dell Unity XT/Unity storage system | TCP | 443 | Default port used for communication with Dell Unity XT/Unity over HTTPS and sending REST API calls. |
-| Backup proxy | Dell Unity XT/Unity storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server | Dell Unity XT, Unity storage system | TCP | 443 | Default port used for communication with Dell Unity XT/Unity over HTTPS and sending REST API calls. |
+| Backup proxy | Dell Unity XT, Unity storage system | TCP | 3260 | Default iSCSI target port. |
 | TCP, UDP | 111, 2049 | Default NFS ports. Port 111 is used by the port mapper service. |
 
 Dell PowerScale (Formerly Isilon) Storage
+
+The following table describes basic network ports that must be opened to ensure proper communication with Dell PowerScale (Formerly Isilon).
 
 Dell PowerScale (Formerly Isilon) Storage
 
@@ -436,6 +369,8 @@ Dell PowerScale (Formerly Isilon) Storage
 | TCP | 445 | Default SMB port. |
 
 HPE 3PAR StoreServ Storage
+
+The following table describes basic network ports that must be opened to ensure proper communication with HPE 3PAR StoreServ.
 
 HPE 3PAR StoreServ Storage
 
@@ -447,45 +382,45 @@ HPE 3PAR StoreServ Storage
 
 HPE Alletra Storage MP B10000, Alletra 9000, Primera Storage
 
+The following table describes basic network ports that must be opened to ensure proper communication with HPE Alletra Storage MP B10000, Alletra 9000, Primera.
+
 HPE Alletra Storage MP B10000, Alletra 9000, Primera Storage
 
 | From | To | Protocol | Port | Notes |
-| Backup server | HPE Alletra Storage MP B10000/Alletra 9000/Primera storage system | TCP | 443 | Default port used for communication with HPE Alletra Storage MP B10000/Alletra 9000/Primera over HTTPS. |
+| Backup server | HPE Alletra Storage MP B10000,  Alletra 9000, Primera storage system | TCP | 443 | Default port used for communication with HPE Alletra Storage MP B10000/Alletra 9000/Primera over HTTPS. |
 | TCP | 22 | Default command port used for communication with HPE Alletra Storage MP B10000/Alletra 9000/Primera over SSH. |
-| Backup proxy | HPE Alletra Storage MP B10000/Alletra 9000/Primera storage system | TCP | 3260 | Default iSCSI target port. |
-| HPE Alletra Storage MP B10000/Alletra 9000 | TCP | 4420, 8009 | Default NVMe-oF ports. |
+| Backup proxy | HPE Alletra Storage MP B10000, Alletra 9000, Primera storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup proxy | HPE Alletra Storage MP B10000, Alletra 9000 | TCP | 4420, 8009 | Default NVMe-oF ports. |
 
 HPE Alletra 5000, Alletra 6000, Nimble Storage
+
+The following table describes basic network ports that must be opened to ensure proper communication with HPE Alletra 5000, Alletra 6000, Nimble.
 
 HPE Alletra 5000, Alletra 6000, Nimble Storage
 
 | From | To | Protocol | Port | Notes |
-| Backup server | HPE Alletra 5000/Alletra 6000/Nimble storage system | TCP | 5392 | Default command port used for communication with HPE Alletra 5000/Alletra 6000/Nimble. |
-| Backup proxy | HPE Alletra 5000/Alletra 6000/Nimble storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server | HPE Alletra 5000, Alletra 6000/Nimble storage system | TCP | 5392 | Default command port used for communication with HPE Alletra 5000/Alletra 6000/Nimble. |
+| Backup proxy | HPE Alletra 5000, Alletra 6000/Nimble storage system | TCP | 3260 | Default iSCSI target port. |
 
-Lenovo ThinkSystem DM/DG Series Storage
+Lenovo ThinkSystem DM/DG Series Storage, NetApp ONTAP Storage
 
-Lenovo ThinkSystem DM/DG Series Storage
+The following table describes network ports that must be opened to ensure proper communication with the following storage systems:
+
+* Lenovo ThinkSystem DM/DG Series
+* NetApp ONTAP
+
+Lenovo ThinkSystem DM/DG Series Storage, NetApp ONTAP Storage
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Lenovo ThinkSystem DM/DG Series storage system | TCP | 80 | Default command port used for communication with Lenovo ThinkSystem DM/DG Series over HTTP. |
+| Backup server | Storage system | TCP | 80 | Default command port used for communication with Lenovo ThinkSystem DM/DG Series over HTTP. |
 | TCP | 443 | Default command port used for communication with Lenovo ThinkSystem DM/DG Series over HTTPS. |
-| Backup proxy | Lenovo ThinkSystem DM/DG Series storage system | TCP, UDP | 111, 2049, 635 | Default NFS ports. Port 111 is used by the port mapper service. |
-| TCP | 445 | Default SMB port. |
-| TCP | 3260 | Default iSCSI target port. |
-
-NetApp ONTAP Storage
-
-NetApp ONTAP Storage
-
-| From | To | Protocol | Port | Notes |
-| Backup server | NetApp ONTAP storage system | TCP | 80 | Default command port used for communication with NetApp ONTAP over HTTP. |
-| TCP | 443 | Default command port used for communication with NetApp ONTAP over HTTPS. |
-| Backup proxy | NetApp ONTAP storage system | TCP, UDP | 111, 2049, 635 | Default NFS ports. Port 111 is used by the port mapper service. |
+| Backup proxy | Storage system | TCP, UDP | 111, 2049, 635 | Default NFS ports. Port 111 is used by the port mapper service. |
 | TCP | 445 | Default SMB port. |
 | TCP | 3260 | Default iSCSI target port. |
 
 Nutanix Files Storage
+
+The following table describes basic network ports that must be opened to ensure proper communication with Nutanix Files.
 
 Nutanix Files Storage
 
@@ -498,29 +433,32 @@ Universal Storage API Integrated System
 
 The following tables describe network ports that must be opened to ensure proper communication with Universal Storage API integrated systems:
 
-* [DataCore SANsymphony](#DataCore)
+* [DataCore SANsymphony](#DataCore), [Dell PowerMax](#dell_powermax), [Hitachi VSP/VSP One Block](#vsp), [HPE XP](#xp), [INFINIDAT InfiniBox](#infinidat), [NetApp SolidFire/HCI](#solidfire)
 * [Dell SC Series](#DellEMC)
-* [Dell PowerMax](#dell_powermax)
 * [Dell PowerStore](#dell_powerstore)
-* [Fujitsu ETERNUS DX/AF](#fujitsu)
-* [Hitachi VSP/VSP One Block](#vsp)
-* [HPE XP](#xp)
-* [IBM FlashSystem (formerly Spectrum Virtualize) Storage](#ibm)
-* [INFINIDAT InfiniBox](#infinidat)
-* [NEC Storage M Series](#necm)
-* [NetApp SolidFire/HCI](#solidfire)
-* [Pure Storage FlashArray](#pure)
-* [Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)](#WesternDigital)
+* [Fujitsu ETERNUS DX/AF](#fujitsu), [IBM FlashSystem (formerly Spectrum Virtualize) Storage](#ibm), [NEC Storage M Series](#necm)
+* [Pure Storage FlashArray](#pure), [Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)](#WesternDigital)
 
-DataCore SANsymphony
+DataCore SANsymphony, Dell PowerStore, Hitachi VSP/VSP One Block, HPE XP, INFINIDAT InfiniBox,  NetApp SolidFire/HCI
 
-DataCore SANsymphony
+The following table describes network ports that must be opened to ensure proper communication with the following storage systems:
+
+* DataCore SANsymphony
+* Dell PowerStore
+* Hitachi VSP/VSP One Block
+* HPE XP
+* INFINIDAT InfiniBox
+* NetApp SolidFire/HCI
+
+DataCore SANsymphony, Dell PowerStore, Hitachi VSP/VSP One Block, HPE XP, INFINIDAT InfiniBox, NEC Storage V Series,NetApp SolidFire/HCI
 
 | From | To | Protocol | Port | Notes |
-| Backup server | DataCore SANsymphony storage system | TCP | 443 | Default command port used for communication with DataCore SANsymphony over HTTPS. |
-| Backup proxy | DataCore SANsymphony storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server | Storage system | TCP | 443 | Default command port used for communication with DataCore SANsymphony over HTTPS. |
+| Backup proxy | Storage system | TCP | 3260 | Default iSCSI target port. |
 
 Dell SC Series
+
+The following table describes basic network ports that must be opened to ensure proper communication with Dell SC Series.
 
 Dell SC Series
 
@@ -530,265 +468,361 @@ Dell SC Series
 
 Dell PowerMax
 
+The following table describes basic network ports that must be opened to ensure proper communication with Dell PowerMax.
+
 Dell PowerMax
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Dell PowerMax storage system | TCP | 8443 | Default command port used for communication with Dell PowerMax over HTTPS. |
 | Backup proxy | Dell PowerMax storage system | TCP | 3260 | Default iSCSI target port. |
 
-Dell PowerStore
+Fujitsu ETERNUS DX/AF, IBM FlashSystem (formerly Spectrum Virtualize) Storage, NEC Storage M Series
 
-Dell PowerStore
+The following table describes network ports that must be opened to ensure proper communication with the following storage systems:
 
-| From | To | Protocol | Port | Notes |
-| Backup server | Dell PowerStore storage system | TCP | 443 | Default command port used for communication with Dell PowerStore over HTTPS. |
-| Backup proxy | Dell PowerStore storage system | TCP | 3260 | Default iSCSI target port. |
+* Fujitsu ETERNUS DX/AF
+* IBM FlashSystem (formerly Spectrum Virtualize) Storage
+* NEC Storage M Series
 
-Fujitsu ETERNUS DX/AF
-
-Fujitsu ETERNUS DX/AF
+Fujitsu ETERNUS DX/AF, IBM FlashSystem (formerly Spectrum Virtualize) Storage, NEC Storage M Series
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Fujitsu ETERNUS DX/AF storage system | TCP | 22 | Default command port used for communication with Fujitsu ETERNUS DX/AF over SSH. |
-| Backup proxy | Fujitsu ETERNUS DX/AF storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server | Storage system | TCP | 22 | Default command port used for communication with Fujitsu ETERNUS DX/AF over SSH. |
+| Backup proxy | Storage system | TCP | 3260 | Default iSCSI target port. |
 
-Hitachi VSP/VSP One Block
+Pure Storage FlashArray, Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)
 
-Hitachi VSP/VSP One Block
+The following table describes network ports that must be opened to ensure proper communication with the following storage systems:
 
-| From | To | Protocol | Port | Notes |
-| Backup server | Hitachi VSP/VSP One Block storage system | TCP | 443 | Default command port used for communication with Hitachi VSP/VSP One Block over HTTPS. |
-| Backup proxy | Hitachi VSP/VSP One Block storage system | TCP | 3260 | Default iSCSI target port. |
+* Pure Storage FlashArray
+* Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)
 
-HPE XP
-
-HPE XP
+Pure Storage FlashArray, Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)
 
 | From | To | Protocol | Port | Notes |
-| Backup server | HPE XP storage system | TCP | 443 | Default command port used for communication with HPE XP over HTTPS. |
-| Backup proxy | HPE XP storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server | Storage system | TCP | 443 | Default command port used for communication with Pure Storage FlashArray over HTTPS. |
+| Backup proxy | Storage system | TCP | 3260 | Default iSCSI target port. |
+| TCP, UDP | 111, 2049 | Default NFS ports. Port 111 is used by the port mapper service. |
 
-IBM FlashSystem (formerly Spectrum Virtualize) Storage
+High Availability (HA) Cluster Components
 
-IBM FlashSystem (formerly Spectrum Virtualize) Storage
+The following table describes network ports that must be opened to ensure proper communication for the [high availability cluster feature](high_availability_infrastructure.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-| From | To | Protocol | Port | Notes |
-| Backup server | IBM FlashSystem storage system | TCP | 22 | Default command port used for communication with IBM FlashSystem over SSH. |
-| Backup proxy | IBM FlashSystem storage system | TCP | 3260 | Default iSCSI target port. |
-
-INFINIDAT InfiniBox
-
-INFINIDAT InfiniBox
+High Availability (HA) Cluster Components
 
 | From | To | Protocol | Port | Notes |
-| Backup server | INFINIDAT InfiniBox storage system | TCP | 443 | Default command port used for communication with INFINIDAT InfiniBox over HTTPS. |
-| Backup proxy | INFINIDAT InfiniBox storage system | TCP | 3260 | Default iSCSI target port. |
+| Backup server (primary or standby) | PostgreSQL configuration database | TCP | 5432 | Port used for communication with PostgreSQL configuration database.  Note: The connection should be opened from the primary backup server to its configuration database, and from the standby backup server to its configuration database. |
+| Primary backup server with PostgreSQL configuration database | Standby backup server with PostgreSQL configuration database | TCP | 8008, 8500 | Port used by PostgreSQL database service to manage the High Availability clusters. |
 
-NEC Storage M Series
+VMware vSphere Components
 
-NEC Storage M Series
+The following table describes network ports that must be opened to ensure proper communication for [VMware vSphere](vmware_vsphere.md) and [VMware Cloud Director](vcloud_director.md) protection. If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-| From | To | Protocol | Port | Notes |
-| Backup server | NEC Storage M Series storage system | TCP | 22 | Default command port used for communication with NEC Storage M Series over SSH. |
-| Backup proxy | NEC Storage M Series storage system | TCP | 3260 | Default iSCSI target port. |
-
-NetApp SolidFire/HCI
-
-NetApp SolidFire/HCI
+VMware vSphere Components
 
 | From | To | Protocol | Port | Notes |
-| Backup server | NetApp SolidFire/HCI storage system | TCP | 443 | Default command port used for communication with NetApp SolidFire/HCI over HTTPS. |
-| Backup proxy | NetApp SolidFire/HCI storage system | TCP | 3260 | Default iSCSI target port. |
+| Communication with vCenter Servers | | | | |
+| Backup server | vCenter Server | TCP | 443 | Port used for connections to vCenter Server.  Note: The backup server should have a direct connection to vCenter Server. HTTP/HTTPS proxy servers are not supported.  If you use VMware Cloud Director, make sure you open port 443 on underlying vCenter Servers. |
+| Backup proxy | vCenter Server | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. |
+| Communication with ESXi Servers | | | | |
+| Backup proxy | ESXi server | TCP | 902 | Default VMware port used for data transfer.  This port is not required for VMware Cloud on AWS. |
+| TCP | 443 | Default VMware web service port that can be customized in ESXi host settings. Not required if vCenter connection is used.  This port is not required for VMware Cloud on AWS. |
+| Backup server | ESXi server | TCP | 443 | Port used for connections to ESXi host.  This port is not required for VMware Cloud on AWS. |
+| TCP | 902 | Port used for data transfer to ESXi host. It is also used during guest OS file recovery if you recover files from replicas.  This port is not required for VMware Cloud on AWS. |
+| Communication with VMware Cloud Director | | | | |
+| Backup server | VMware Cloud Director | TCP | 443 | Port used for connections to VMware Cloud Director.  Note: The backup server should have a direct connection to VMware Cloud Director. HTTP/HTTPS proxy servers are not supported. |
 
-Pure Storage FlashArray
+Microsoft Hyper-V Components
 
-Pure Storage FlashArray
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [Microsoft Hyper-V protection](ms_hyperv.md):
+
+* [Virtualization servers](#hv_virt)
+* [Off-host backup proxies](#hv_proxy)
+* [Other backup infrastructure components](#hv_other)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+Virtualization Servers
+
+The following table describes network ports that must be opened for [virtualization servers](setup_add_server.md) involved in Microsoft Hyper-V protection.
+
+Virtualization Servers
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Pure Storage FlashArray system | TCP | 443 | Default command port used for communication with Pure Storage FlashArray over HTTPS. |
-| Backup proxy | Pure Storage FlashArray system | TCP | 3260 | Default iSCSI target port. |
-| Pure Storage FlashArray system | TCP, UDP | 111, 2049 | Default NFS ports. Port 111 is used by the port mapper service. |
+| Backup server | SCVMM | TCP | 8732 | Port used to communicate with the VMM server. |
+| TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| TCP | 6160 | Port used by Veeam Installer Service. |
+| TCP | 6162, 2500 to 3300 | Port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Hyper-V server | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| TCP | 6160 | Default port used by Veeam Installer Service. |
+| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| TCP | 6163 | Default port used to communicate with Veeam Hyper-V Integration Service. |
+| TCP | 2179 | Port used to connect to VMs using the Virtual Machine Connection during [Instant Recovery to Microsoft Hyper-V](instant_recovery_to_hv.md) and [Recovery Verification for Microsoft Hyper-V](recovery_verification_overview_hv.md). |
+| TCP | 49152 to 65535 | Dynamic RPC port range for Microsoft Windows 2008 and later. For more information, see [this Microsoft KB article](https://support.microsoft.com/kb/929851/en-us).  Note: If you use default Microsoft Windows firewall settings, you do not need to configure dynamic RPC ports. During setup, Veeam Backup & Replication automatically creates a firewall rule for the runtime process. If you use firewall settings other than default ones or application-aware processing fails with the "RPC function call failed" error, you need to configure dynamic RPC ports. For more information on how to configure RPC dynamic port allocation to work with firewalls, see [this Microsoft KB article](https://support.microsoft.com/en-us/help/154596/how-to-configure-rpc-dynamic-port-allocation-to-work-with-firewalls). |
+| Microsoft Windows/Linux-based backup repository | Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during restore operations.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Hyper-V server/Off-host backup proxy | Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during replication.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Microsoft SMB3 server (Hyper-V storage) | TCP | 6160 | Default port used by Veeam Installer Service. |
+| TCP | 6162, 2500-3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| TCP | 6163 | Default port used by the Hyper-V Integration Service. |
 
-Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)
+Off-Host Backup Proxies
 
-Tintri IntelliFlash (formerly Western Digital IntelliFlash, Tegile)
+The following table describes network ports that must be opened for [off-host backup proxies](offhost_backup_proxy.md) involved in Microsoft Hyper-V protection.
+
+Off-Host Backup Proxies
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Tintri IntelliFlash system | TCP | 443 | Default command port used for communication with Tintri IntelliFlash over HTTPS. |
-| Backup proxy | Tintri IntelliFlash system | TCP | 3260 | Default iSCSI target port. |
-| Tintri IntelliFlash system | TCP, UDP | 111, 2049 | Default NFS ports. Port 111 is used by the port mapper service. |
+| Communication with Off-Host Backup Proxies | | | | |
+| Backup server | Hyper-V server/Off-host backup proxy | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| TCP | 6160 | Default port used by Veeam Installer Service. |
+| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| TCP | 6163 | Default port used by the Hyper-V Integration Service. |
+| TCP | 49152 to 65535 | Dynamic RPC port range for Microsoft Windows 2008 and later. For more information, see [this Microsoft KB article](https://support.microsoft.com/kb/929851/en-us).  Note: If you use default Microsoft Windows firewall settings, you do not need to configure dynamic RPC ports. During setup, Veeam Backup & Replication automatically creates a firewall rule for the runtime process. If you use firewall settings other than default ones or application-aware processing fails with the "RPC function call failed" error, you need to configure dynamic RPC ports. For more information on how to configure RPC dynamic port allocation to work with firewalls, see [this Microsoft KB article](https://support.microsoft.com/en-us/help/154596/how-to-configure-rpc-dynamic-port-allocation-to-work-with-firewalls). |
+| Backup server | Off-host backup proxy | TCP | 6210 | Default port used by the Veeam Backup VSS Integration Service for taking a VSS snapshot during the SMB file share backup. |
+
+Other Backup Infrastructure Components
+
+The following table describes network ports that must be opened for other backup infrastructure components involved in Microsoft Hyper-V protection.
+
+Other Backup Infrastructure Components
+
+| From | To | Protocol | Port | Notes |
+| SCVMM | Backup server | TCP | 443 | Port used for Veeam PowerShell Management Service authorization on the SCVMM server. |
+| Hyper-V server/Off-host backup proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during replication.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
 Unstructured Data Backup Components
 
-The following tables describe network ports that must be opened to ensure proper communication between unstructured data backup components.
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [unstructured data backup](unstructured_data_backup_infrastructure.md):
 
-* [File Share Connections](#nas_shares_connections)
-* [Cache Repository Connections](#cache_repository_connections)
-* [Archive Repository Connections](#archive_repository_connections)
-* [NDMP Server Connections](#ndmp)
+* [Unstructured data sources](#nas_shares_connections)
+* [Cache repositories](#cache_repository_connections)
+* [Repositories](#archive_repository_connections)
+* [NDMP servers](#ndmp)
+* [Other backup infrastructure components](#unstr_other)
+* [Active Directory Domain Controllers](#unstructured_ad)
 
-File Share Connections
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-File Share Connections
+Unstructured Data Sources
+
+The following table describes network ports that must be opened for the [unstructured data sources](unstructured_data_backup_infrastructure.md) involved in unstructured data backup.
+
+Unstructured Data Sources
 
 | From | To | Protocol | Port | Notes |
-| File server (Windows or Linux), Backup proxy | Backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup server | File server (Windows or Linux), Backup proxy | TCP | 6160 | Default port used by Veeam Installer Service. |
+| Backup server | File server (Windows or Linux) | TCP | 6160 | Default port used by Veeam Installer Service. |
 | TCP | 6210 | Default port used by the Veeam Backup VSS Integration Service for taking a VSS snapshot during the SMB file share backup (if Veeam Backup & Replication is installed on the Microsoft Windows machine). For more information, see [Microsoft Windows Services](services_and_components.md#win_services). |
 | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Mount server | TCP | 443, 445, 6170 | Ports used during Instant File Share Recovery. |
 | Backup proxy | NAS filer (NetApp Data ONTAP or Lenovo ThinkSystem DM/DG Series storage system) | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
 | TCP | 445 | Standard SMB port. |
 | TCP, UDP | 635 | The default port used by the NetApp Data ONTAP storage controller. |
 | TCP | 80, 443 | Ports used by NetApp SnapDiff when changed file tracking (CFT) is enabled. |
-| NAS filer (Dell PowerScale (formerly Isilon) or Nutanix Files storage system) | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
+| Backup proxy | NAS filer (Dell PowerScale (formerly Isilon) or Nutanix Files storage system) | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
 | TCP | 445 | Standard SMB port. |
 | TCP | 20048 | Port used for the NFS mountd access and service request monitoring. |
-| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
-| TCP | 88 | Port used for Kerberos authentication. |
-| File server (Windows or Linux), backup proxy or tape server | NFS share | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
-| SMB share | TCP | 445 | Standard SMB port. |
-| Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
-| Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the file server, or backup proxy, or tape server can reach these verification endpoints. |
-| Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the file server, or backup proxy, or tape server can reach these verification endpoints. |
-| S3 compatible object storage | TCP | Depends on device configuration | Port used to communicate with S3 compatible object storage. |
-| Active Directory Domain Controllers | TCP | 389 | Port used for communications over LDAP and LDAPS protocols. |
-| TCP | 88 | Port used for Kerberos authentication. |
-| Mount server | SMB share | TCP | 445 | Standard SMB port. |
-| SMB share | TCP | 137-139 | Standard CIFS ports range. |
+| Cache repository | NAS filer (NetApp Data ONTAP) | TCP | 80, 443, 2049 | Ports used by NetApp SnapDiff when changed file tracking (CFT) is enabled.  Port 2049 is required if the cache repository is a Linux machine. |
+| File server (Windows or Linux),  Backup proxy,  Tape server | NFS share | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
+| File server (Windows or Linux),  Mount server,  Backup proxy,  Tape server | SMB share | TCP | 445 | Standard SMB port. |
+| Mount server | SMB share | TCP | 137-139 | Standard CIFS ports range. |
+| File server (Windows or Linux),  Backup proxy,  Tape server | Amazon S3 object storage  (\*.amazonaws.com, \*.amazonaws.com.cn) | TCP | 443 | Port used to communicate with Amazon S3 object storage.  The endpoint used by the connection depends on the region:   * \*.amazonaws.com is used for the Global and Government regions. * \*.amazonaws.com.cn is used for the China region.   All AWS service endpoints are specified in the [AWS documentation](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region). |
+| File server (Windows or Linux),  Backup proxy,  Tape server | Amazon S3 object storage  (\*.amazontrust.com) | TCP | 80 | Port used to verify certificate status.  Consider that certificate verification endpoints (CRL URLs and OCSP servers) are subject to change. You can find the actual list of addresses in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the file server, or backup proxy, or tape server can reach these verification endpoints. |
+| File server (Windows or Linux),  Backup proxy,  Tape server | Microsoft Azure object storage  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net, <storage-account>.blob.core.chinacloudapi.cn, <storage-account>.blob.core.usgovcloudapi.net) | TCP | 443 | Port used to communicate with Microsoft Azure object storage.  The endpoints used by the connection depend on the region:   * <storage-account>.blob.core.windows.net is used for the Global region. * <storage-account>.blob.storage.azure.net is used for the Global region. * <storage-account>.blob.core.chinacloudapi.cn is used for the China region. * <storage-account>.blob.core.usgovcloudapi.net is used for the Government region.   Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
+| File server (Windows or Linux),  Backup proxy,  Tape server | Microsoft Azure object storage | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the file server, or backup proxy, or tape server can reach these verification endpoints. |
+| File server (Windows or Linux),  Backup proxy,  Tape server | S3 compatible object storage | TCP | Depends on device configuration | Port used to communicate with S3 compatible object storage. |
 
-Cache Repository Connections
+Cache Repositories
 
-Cache Repository Connections
+The following table describes network ports that must be opened for [cache repositories](unstructured_data_backup_infrastructure.md) involved in the unstructured data backup.
+
+Cache Repositories
 
 | From | To | Protocol | Port | Notes |
-| File server (Windows or Linux), Backup proxy | Cache repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server,  File server (Windows or Linux),  Backup proxy | Cache repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 | Backup server | Cache repository | TCP | 6160 | Default ports used by Veeam Installer Service. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Cache repository (Linux) | TCP | 22 | Default SSH port used as a control channel. |
-| Old cache repository, new cache repository | TCP | 6162, 2500 to 3300 | Default range of ports used for metadata migration during cache repository change. For more information, see [Changing Cache Repository](unstructured_data_backup_in_object_storage.md#change_cache_repo).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Cache repository | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Primary or secondary backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| NAS filer (NetApp Data ONTAP) | TCP | 80, 443, 2049 | Ports used by NetApp SnapDiff when changed file tracking (CFT) is enabled.  Port 2049 is required if the cache repository is a Linux machine. |
+| Backup server | Cache repository (Linux) | TCP | 22 | Default SSH port used as a control channel. |
+| Backup server | Old cache repository | TCP | 6162, 2500 to 3300 | Default range of ports used for metadata migration during cache repository change. For more information, see [Changing Cache Repository](unstructured_data_backup_in_object_storage.md#change_cache_repo).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | New cache repository | TCP | 6162, 2500 to 3300 | Default range of ports used for metadata migration during cache repository change. For more information, see [Changing Cache Repository](unstructured_data_backup_in_object_storage.md#change_cache_repo).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-Archive Repository Connections
+Repositories
 
-Archive Repository Connections
+The following table describes network ports that must be opened for [primary, secondary or archive repositories](unstructured_data_backup_infrastructure.md) involved in the unstructured data backup.
+
+Repositories
 
 | From | To | Protocol | Port | Notes |
 | Primary backup repository | Archive repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Cache repository | Primary or secondary backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-NDMP Server Connections
+NDMP Servers
 
-The following table describes network ports that must be opened to ensure proper communication with NDMP servers.
+The following table describes network ports that must be opened for [NDMP servers](ndmp_servers.md) involved in the unstructured data backup.
 
-NDMP Server Connections
+NDMP Servers
 
 | From | To | Protocol | Port | Notes |
 | Gateway server | NDMP server | NDMP | 10000 | Default port used to manage the NMDP server.  Note: The port range used for data transfer depends on your NDMP server configuration. For more information, contact your hardware vendor. |
 
-Tape Server
+Other Backup Infrastructure Components
 
-The following table describes network ports that must be opened to ensure proper communication with tape servers.
+The following table describes network ports that must be opened for other backup infrastructure components involved in the unstructured data backup.
 
-Tape Server
+Other Backup Infrastructure Components
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Tape server | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| File server (Windows or Linux),  Backup proxy | Backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Backup proxy | TCP | 6160 | Default port used by Veeam Installer Service. |
+| TCP | 6210 | Default port used by the Veeam Backup VSS Integration Service for taking a VSS snapshot during the SMB file share backup (if Veeam Backup & Replication is installed on the Microsoft Windows machine). For more information, see [Microsoft Windows Services](services_and_components.md#win_services). |
+| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Backup server | Mount server | TCP | 443, 445, 6170 | Ports used during Instant File Share Recovery. |
+| Cache repository | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Active Directory Domain Controllers
+
+The following table describes network ports that must be opened for Active Directory Domain Controllers involved in the unstructured data backup.
+
+Active Directory Domain Controllers
+
+| From | To | Protocol | Port | Notes |
+| Backup proxy,  File server (Windows or Linux),  Backup proxy or  Tape server | Active Directory Domain Controllers | TCP | 389 | Port used for communication over LDAP and LDAPS protocols. |
+| TCP | 88 | Port used for Kerberos authentication. |
+
+Tape Device Support Components
+
+The following table describes network ports that must be opened to ensure proper communication for the [tape device support](tape_device_support.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+Tape Device Support Components
+
+| From | To | Protocol | Port | Notes |
+| Communication for Backup Server | | | | |
+| Tape server | Backup server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Communication for Tape Servers | | | | |
+| Backup server | Tape server | TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
 | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 | TCP | 6166 | Controlling port for RPC calls. |
-| Tape server | Backup repository or gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| NFS share | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
-| SMB share | TCP | 445 | Standard SMB port. |
+| Backup server | Tape server (Linux) | TCP | 22 | Default SSH port used as a control channel. |
+| Communication for Backup Repositories and Gateway Servers | | | | |
+| Tape server | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Tape server | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Communication for Shares | | | | |
+| Tape server | NFS share | TCP, UDP | 111, 2049 | Standard NFS ports. Port 111 is used by the port mapper service. |
+| Tape server | SMB share | TCP | 445 | Standard SMB port. |
 
-WAN Accelerator
+WAN Acceleration Components
 
-The following table describes network ports that must be opened to ensure proper communication between WAN accelerators used in backup copy jobs and replication jobs.
+The following table describes network ports that must be opened to ensure proper communication for the [WAN acceleration](wan_acceleration.md) used in backup copy jobs and replication jobs. If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-WAN Accelerator
+WAN Acceleration Components
 
 | From | To | Protocol | Port | Notes |
-| Backup server | WAN accelerator | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
+| Communication with WAN Accelerators | | | | |
+| Backup server | WAN accelerator  (source and target) | TCP | 445, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
 | TCP | 6162 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine). |
 | TCP | 6164 | Controlling port for RPC calls. |
-| WAN accelerator (target) | Backup repository (target) | TCP | 2500 to 3300 | Default range of ports used as data transmission channels. For every TCP connection that a job uses, one port from this range is selected dynamically. |
-| WAN accelerator (source) | Backup repository (source) | TCP | 2500 to 3300 | Default range of ports used as data transmission channels. For every TCP connection that a job uses, one port from this range is selected dynamically. |
+| Backup server | WAN accelerator  (target) | TCP | 6220 | Port used for traffic control (throttling) for tenants that use WAN accelerators.  This port is required only in the Veeam Cloud Connect infrastructure. |
 | WAN accelerator (source and target) | WAN accelerator (source and target) | TCP | 6164 | Controlling port for RPC calls. |
 | TCP | 6165 | Default port used for data transfer between WAN accelerators. Ensure this port is open in firewall between sites where WAN accelerators are deployed. |
-| Backup server | WAN accelerator  (target) | TCP | 6220 | Port used for traffic control (throttling) for tenants that use WAN accelerators.  This port is required only in the Veeam Cloud Connect infrastructure. |
+| Communication with Backup Repositories | | | | |
+| WAN accelerator (target) | Backup repository (target) | TCP | 2500 to 3300 | Default range of ports used as data transmission channels. For every TCP connection that a job uses, one port from this range is selected dynamically. |
+| WAN accelerator (source) | Backup repository (source) | TCP | 2500 to 3300 | Default range of ports used as data transmission channels. For every TCP connection that a job uses, one port from this range is selected dynamically. |
 
 Guest Processing Components
 
-The following table describes the network ports that must be opened to ensure proper communication between the backup server and the VMs that will be added to Managed Servers as Guest Interaction Proxy (Log Shipping Server).
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [guest processing](guest_processing.md):
 
-Guest Processing Components
+* [Guest interaction proxies](#guest_proxy)
+* [Protected workloads](#guest_workload)
+* [Gateway servers](#guest_gateway)
+* [Hypervisors](#guest_hypervisor)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest OS File Recovery](used_ports.md#guest_os_file_recovery).
+
+Guest Interaction Proxies
+
+The following table describes network ports that must be opened for [guest interaction proxies](guest_interaction_proxy.md) involved in the guest processing.
+
+Guest Interaction Proxies
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Guest interaction proxy | TCP | 445, 135 | Ports used for adding Windows VMs to managed servers using local administrator credentials. Note: Kerberos domain account with administrator privileges should be used. |
 | TCP | 6160 | Port used for adding both Windows and Linux VMs to managed servers using a certificate-based authentication. Note: Deployment kit should be pre-installed on VMs. |
 | TCP | 22 | Port used for adding Linux VMs to managed servers using SSH credentials. |
+| Connections for Non-Persistent Runtime Components | | | | |
+| Backup server | Guest interaction proxy | TCP | 6190 | Port used for communication of the backup server and backup infrastructure components with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing. |
 
-Connections with Non-Persistent Runtime Components
+Protected Workloads
 
-The following tables describe network ports that must be opened to ensure proper communication of the backup server and backup infrastructure components with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing.
+The following table describes network ports that must be opened for protected workloads involved in the guest processing.
 
-Connections with Non-Persistent Runtime Components
-
-| From | To | Protocol | Port | Notes |
-| Backup server | Guest interaction proxy | TCP | 6190 | Port used for communication with the guest interaction proxy. |
-| Guest interaction proxy | ESXi server | TCP | 443 | Default port used for connections to ESXi host.  [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vCenter Web Services. |
-
-Network ports described in the following table are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct.
-
-Connections with Non-Persistent Runtime Components
+Protected Workloads
 
 | From | To | Protocol | Port | Notes |
-| Guest interaction proxy | VM guest OS (Microsoft Windows) | TCP | 445, 135 | Port used to deploy the runtime coordination process on the VM guest OS. |
-| TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. |
-| TCP | 6173 | Port used by the runtime process deployed inside the VM for guest OS interaction. |
-| VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. |
-
-Connections with Persistent Agent Components
-
-The following table describes network ports that must be opened to ensure proper communication of the backup server with the persistent agent components deployed inside the VM guest OS for application-aware processing and indexing.
-
-Connections with Persistent Agent Components
-
-| From | To | Protocol | Port | Notes |
+| Connections for Non-Persistent Runtime Components | | | | |
+| Guest interaction proxy | VM guest OS | TCP | 2500 to 3300 | Default range of ports used as transmission channels for log shipping. Note: These ports are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | VM guest OS (Microsoft Windows) | TCP | 445, 135 | Port used to deploy the runtime coordination process on the VM guest OS. Note: These ports are NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| TCP | 6173 | Port used by the runtime process deployed inside the VM for guest OS interaction. Note: This port NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel. Note: This port NOT required in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Connections for Persistent Agent Components | | | | |
+| Backup server | VM guest OS (Linux) | TCP | 22 | Default SSH port used as a control channel during persistent agent installation. |
+| TCP | 2500 to 3300 | Range of ports used only during the installation of the persistent agent.  Default range of ports used for communication with a guest OS. |
 | Guest interaction proxy | VM guest OS (Linux) | TCP | 6160 | Default port used by Veeam Installer Service for Linux. |
 | TCP | 6162 | Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| VM guest OS (Windows) | TCP | 6160, 11731 | Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
+| Guest interaction proxy | VM guest OS (Windows) | TCP | 6160, 11731 | Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing and file system indexing. |
+
+Gateway Servers
+
+The following table describes network ports that must be opened for [gateway servers](gateway_server.md) involved in the guest processing.
+
+Gateway Servers
+
+| From | To | Protocol | Port | Notes |
+| Guest interaction proxy | Gateway server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Hypervisors
+
+The following table describes network ports that must be opened for the hypervisors involved in the guest processing.
+
+Hypervisors
+
+| From | To | Protocol | Port | Notes |
+| Guest interaction proxy | ESXi server | TCP | 443 | Default port used for connections to ESXi host. This port must be opened to ensure proper communication with the non-persistent runtime components deployed inside the VM guest OS for application-aware processing and indexing. [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vCenter Web Services. |
 
 Log Shipping Components
 
-The following tables describe network ports that must be opened to ensure proper communication between log shipping components.
+The following tables describe network ports that must be opened to ensure proper communication for components involved in log backup, such as [Microsoft SQL Server log backup](sql_backup.md), [Oracle log backup](oracle_backup.md) and [PostgreSQL WAL files backup](postgresql_backup.md):
 
-* [Log Shipping Server Connections](#log_shipping_server_connections)
-* [MS SQL Guest OS Connections](#sql_guest_os_connections)
-* [Oracle Guest OS Connections](#oracle_guest_os_connections)
-* [PostgreSQL Guest OS Connections](#postgresql_guest_os_connections)
+* [Log shipping servers](#log_shipping_server_connections)
+* [MS SQL guest OS](#sql_guest_os_connections)
 
-Log Shipping Server Connections
+* [Oracle guest OS](#oracle_guest_os_connections)
+* [PostgreSQL guest OS](#postgresql_guest_os_connections)
 
-Log Shipping Server Connections
+* [Backup repositories](#log_repo)
+* [Gateway servers](#log_gateway)
+* [Hypervisors](#log_hypervisor)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest OS File Recovery](used_ports.md#guest_os_file_recovery).
+
+Log Shipping Servers
+
+The following table describes network ports that must be opened for [log shipping servers](log_shipping_server.md) involved in the log backup.
+
+Log Shipping Servers
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Log shipping server | TCP | 445, 135, 137, 139 | Ports used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.  Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
 | TCP | 6160 | Default port used by Veeam Installer Service. |
 | TCP | 6162 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine). |
-| Hyper-V host | Log shipping server (backup server) | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server | Backup repository or gateway server | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server (backup server) | Hyper-V host | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
-| Log shipping server | ESXi host | TCP | 443 | Default port used for communication with a log shipping server and transfer log backups over vSphere API. |
+| Hyper-V host | Log shipping server (backup server) | TCP | 6162, 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| VM guest OS (VM with MS SQL, Oracle, or PostgreSQL) | Log shipping server | TCP | 6162, 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-MS SQL Guest OS Connections
+MS SQL Guest OS
 
-MS SQL Guest OS Connections
+The following table describes network ports that must be opened for MS SQL VM guest OS involved in the log backup.
+
+MS SQL Guest OS
 
 | From | To | Protocol | Port | Notes |
 | Guest interaction proxy | MS SQL VM guest OS | TCP | 445, 135, 137, 139 | [Non-persistent runtime components only] Ports used for deploying Veeam Backup & Replication components including Veeam Log Shipper runtime component.  These ports are not required:   * When working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. * If the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.   Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
@@ -796,277 +830,330 @@ MS SQL Guest OS Connections
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing. |
 | TCP | 6160, 11731 | [Persistent agent components only] Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6167 | Port used by the Veeam Log Shipping Service for preparing the database and taking logs. |
-| MS SQL VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the MS SQL server has a direct connection to the backup repository. |
-| MS SQL VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-Oracle Guest OS Connections
+Oracle Guest OS
 
-Oracle Guest OS Connections
+The following table describes network ports that must be opened for Oracle VM guest OS involved in the log backup.
+
+Oracle Guest OS
 
 | From | To | Protocol | Port | Notes |
+| Guest interaction proxy | Oracle VM guest OS | TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | Guest interaction proxy | Oracle VM guest OS (Microsoft Windows) | TCP | 445, 135 | [Non-persistent runtime components only] Ports used for deploying Veeam Backup & Replication components including Veeam Log Shipper runtime component.  These ports are not required:   * When working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. * If the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component.   Note: 137 and 139 are legacy ports. If your backup infrastructure components do not use SMB 1.0, they are not required. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | TCP | 6173 | Port used by the Veeam Guest Helper for guest OS processing |
 | TCP | 6160, 11731 | [Persistent agent components only] Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6167 | Port used by the Veeam Log Shipping Service for preparing the database and taking logs. |
-| Oracle VM guest OS (Linux) | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
+| Guest interaction proxy | Oracle VM guest OS (Linux) | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
 | TCP | 6162 | [Persistent agent components only] Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over VMware VIX/vSphere Web Services or PowerShell Direct. |
-| Oracle VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the Oracle server has a direct connection to the backup repository. |
-| Oracle VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
 
-PostgreSQL Guest OS Connections
+PostgreSQL Guest OS
 
-PostgreSQL Guest OS Connections
+The following table describes network ports that must be opened for PostgreSQL VM guest OS involved in the log backup.
+
+PostgreSQL Guest OS
 
 | From | To | Protocol | Port | Notes |
 | Guest interaction proxy | PostgreSQL VM guest OS | TCP | 22 | [Non-persistent runtime components only] Default SSH port used as a control channel.  This port is NOT required when working in networkless mode over vSphere Web Services. |
 | TCP | 6162 | [Persistent agent components only] Default Management Agent port. Required if it is used as a control channel instead of SSH. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  This port is NOT required when working in networkless mode over vSphere Web Services. |
-| PostgreSQL VM guest OS | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the PostgreSQL server has a direct connection to the backup repository. |
-| PostgreSQL VM guest OS | Log shipping server | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a log shipping server and transfer log backups. |
+| TCP | 2500 to 3300 | Default range of ports used for communication with a guest OS.  These ports are NOT required when working in networkless mode over vSphere Web Services. |
 
-CDP Components
+Backup Repositories
 
-The following table describes network ports that must be opened to ensure proper communication of Veeam CDP components with other backup components.
+The following table describes network ports that must be opened for backup repositories involved in the log backup.
 
-CDP Components
+Backup Repositories
 
 | From | To | Protocol | Port | Notes |
-| ESXi host (source) | CDP proxy (source) | TCP | 33032 | Default port used as a transmission channel to the source CDP proxy. |
-| ESXi host (source) | TCP | 33036 | Port used on the source ESXi host for communication between CDP components over HTTPS without HTTP Reverse Proxy. |
-| CDP proxy (source) | CDP proxy (target) | TCP | 33033 | Default port used as a transmission channel to the target CDP proxy. |
-| ESXi host (source and target) | TCP | 902 | Default VMware port used for data transfer. Used during initial synchronization and restore operations. |
-| vCenter Server (source and target) | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. Used during initial synchronization and restore operations. |
-| CDP proxy (target) | ESXi host (target) | TCP | 33032 | Default port used as a transmission channel to the target ESXi host. |
-| ESXi host (source and target) | TCP | 902 | Default VMware port used for data transfer. Used during initial synchronization and restore operations. |
-| vCenter Server (source and target) | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. Used during initial synchronization and restore operations. |
-| ESXi host (target) | ESXi host (target) | TCP | 33036 | Port used on the target ESXi host for communication between CDP components over HTTPS without HTTP Reverse Proxy. |
-| Backup server | ESXi host (source and target) | TCP | 443 | Port used as a control channel. |
-| ESXi host (source and target) | TCP | 33035 | Port used to install I/O filter components on ESXi hosts. |
-| vCenter Server (source and target) | TCP | 443 | Port used as a control channel. |
-| CDP proxy (source and target) | TCP | 6182 | Port used as a control channel. |
+| Log shipping server | Backup repository | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| VM guest OS (VM with MS SQL, Oracle, or PostgreSQL) | Backup repository | TCP | 6162 or 2500 to 3300 | Default port or range of ports used for communication with a backup repository and transfer log backups. Should be opened if log shipping servers are not used in the infrastructure and the MS SQL server has a direct connection to the backup repository. |
 
-Universal CDP Components
+Gateway Servers
 
-The following table describes network ports that must be opened to ensure proper communication of Veeam Universal CDP components with other backup components.
+The following table describes network ports that must be opened for [gateway servers](gateway_server.md) involved in the log backup.
 
-Universal CDP Components
+Gateway Servers
 
 | From | To | Protocol | Port | Notes |
-| Source workload | CDP proxy (source) | TCP | 33032 | Default port used as a transmission channel to the source CDP proxy. |
+| Log shipping server | Gateway server | TCP | 6162 or 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+
+Hypervisors
+
+The following table describes network ports that must be opened for hypervisors involved in the log backup.
+
+Hypervisors
+
+| From | To | Protocol | Port | Notes |
+| Log shipping server (backup server) | Hyper-V host | TCP | 6162 or 2500 to 3300 | Port or range of ports used for communication with the Hyper-V host and for transfer log backups.  These ports are required only if the log shipping server transfers data over PowerShell Direct. In this case, the backup server performs the role of the log shipping server.  Note: The port range 2500 - 3300 is optional. You can use it for failover if port 6162 is unavailable. |
+| Log shipping server | ESXi host | TCP | 443 | Default port used for communication with a log shipping server and transfer log backups over vSphere API. |
+
+VMware CDP and Universal CDP Components
+
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [universal CDP](uni_cdp_infrastructure.md) and [VMware CDP](cdp_infrastructure.md):
+
+* [CDP proxies](#cdp_proxy)
+* [Virtualization servers](#cdp_hypervisor)
+* [Source workloads](#cdp_workload)
+* [Backup server](#cdp_backup)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+CDP Proxies
+
+The following table describes network ports that must be opened for the [CDP proxies](cdp_proxy.md) involved in the universal CDP and VMware CDP.
+
+CDP Proxies
+
+| From | To | Protocol | Port | Notes |
+| ESXi host (source) | CDP proxy (source) | TCP | 33032 | [For regular CDP] Default port used as a transmission channel to the source CDP proxy. |
+| Source workload | CDP proxy (source) | TCP | 33032 | [For universal CDP] Default port used as a transmission channel to the source CDP proxy. |
 | CDP proxy (source) | CDP proxy (target) | TCP | 33033 | Default port used as a transmission channel to the target CDP proxy. |
-| ESXi host (target) | TCP | 902 | Default VMware port used for data transfer. Used during initial synchronization and restore operations. |
-| vCenter Server (target) | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. Used during initial synchronization and restore operations. |
-| CDP proxy (target) | ESXi host (target) | TCP | 33032 | Default port used as a transmission channel to the target ESXi host. |
-| ESXi host (target) | TCP | 902 | Default VMware port used for data transfer. Used during initial synchronization and restore operations. |
-| vCenter Server (target) | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. Used during initial synchronization and restore operations. |
+| Backup server | CDP proxy (source and target) | TCP | 6182 | Port used as a control channel. |
+
+Virtualization Servers
+
+The following table describes network ports that must be opened for the virtualization servers involved in the universal CDP and VMware CDP.
+
+Virtualization Servers
+
+| From | To | Protocol | Port | Notes |
+| Communication with vCenter Servers | | | | |
+| CDP proxy (source and target) | vCenter Server (VMware CDP — source and target;  universal CDP — target) | TCP | 443 | Default VMware web service port that can be customized in vCenter settings. Used during initial synchronization and restore operations. |
+| Backup server | vCenter Server (VMware CDP — source and target;  universal CDP — target) | TCP | 443 | Port used as a control channel. |
+| Communication with ESXi Hosts | | | | |
+| ESXi host (source) | ESXi host (source) | TCP | 33036 | [For VMware CDP] Port used on the source ESXi host for communication between CDP components over HTTPS without HTTP Reverse Proxy. |
+| CDP proxy (source and target) | ESXi host (VMware CDP — source and target;  universal CDP — target) | TCP | 902 | Default VMware port used for data transfer. Used during initial synchronization and restore operations. |
 | ESXi host (target) | ESXi host (target) | TCP | 33036 | Port used on the target ESXi host for communication between CDP components over HTTPS without HTTP Reverse Proxy. |
-| Backup server | Source workload | TCP | 33050 | Port used on the source workload for communication between the Veeam CDP Coordinator Service and Veeam CDP Agent Service over HTTPS. |
-| ESXi host (target) | TCP | 443 | Port used as a control channel. |
-| ESXi host (target) | TCP | 33035 | Port used to install I/O filter components on ESXi hosts. |
-| vCenter Server (target) | TCP | 443 | Port used as a control channel. |
-| CDP proxy (source and target) | TCP | 6182 | Port used as a control channel. |
+| Backup server | ESXi host  (VMware CDP — source and target;  universal CDP — target) | TCP | 443 | Port used as a control channel. |
+| Backup server | ESXi host (VMware CDP — source and target;  universal CDP — target) | TCP | 33035 | Port used to install I/O filter components on ESXi hosts. |
+| CDP proxy (target) | ESXi host (target) | TCP | 33032 | Default port used as a transmission channel to the target ESXi host. |
 
-Recovery Components
+Source Workloads
 
-* [Guest OS File Recovery](#guest_os_file_recovery)
-* [Veeam vPower NFS Service](#vpower)
+The following table describes network ports that must be opened for the source workloads involved in the universal CDP and VMware CDP.
+
+Source Workloads
+
+| From | To | Protocol | Port | Notes |
+| Backup server | Source workload | TCP | 33050 | [For universal CDP] Port used on the source workload for communication between the Veeam CDP Coordinator Service and Veeam CDP Agent Service over HTTPS. |
+
+Backup Server
+
+The following table describes network ports that must be opened for the backup server involved in the universal CDP and VMware CDP.
+
+Backup Server
+
+| From | To | Protocol | Port | Notes |
+| CDP proxy  (source and target),  ESXi host  (VMware CDP — source and target; universal CDP — target),  vCenter Server  (VMware CDP — source and target; universal CDP — target) | Backup server | TCP | 33034 | Port used for communication with Veeam CDP Coordinator Service: |
+| vCenter Server,  ESXi host | Backup server | TCP | 33035 | Port used to install I/O filter components on the source and target vCenter servers and ESXi hosts. |
+
+Data Recovery Components
+
+The following section describes ports that must be opened to ensure proper communication for different data recovery operations:
+
+* [Guest OS file recovery](#guest_os_file_recovery)
 * [SureBackup](#surebackup)
-* [SureReplica Recovery Verification](#surereplica)
-* [Microsoft Active Directory Domain Controller Connections During Application Item Restore](#ad)
-* [Microsoft Exchange Server Connections During Application Item Restore](#ex)
-* [Microsoft SQL Server Connections During Application Item Restore](#sql)
-* [Restore to Amazon EC2](#restore_to_amazon)
-* [Restore to Google Cloud](#restore_to_google_cloud)
+* [SureReplica recovery verification](#surereplica)
+* [Application item restore](#item_restore)
+* [Restore to Amazon EC2 and restore to Google Cloud](#restore_to_amazon)
 * [Restore to Microsoft Azure](#restore_to_azure)
 * [Instant Recovery to Microsoft Azure](#instant_recovery_to_azure)
 
-Guest OS File Recovery
+Guest OS File Recovery Components
 
-The following table describes network ports that must be opened to ensure proper communication between components for guest OS file recovery.
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [guest OS file recovery](guest_file_recovery.md):
 
-* [Mount Server Connections](#mount_server)
-* [Helper Appliance Connections](#helper_appliance)
-* [Helper Host Connections](#helper_host)
-* [Guest OS Connections](#guest_os_recovery_connections)
+* [Helper appliances](#helper_appliance)
+* [Helper hosts](#helper_host)
+* [Guest OS](#guest_os_recovery_connections)
+* [Backup repositories](#guest_repo)
+* [Virtualization servers](#guest_hypervisor)
+* [Veeam Update servers](#guest_veeam)
 
-Mount Server Connections
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-Mount Server Connections
+Helper Appliances
 
-| From | To | Protocol | Port | Notes |
-| Mount server | Backup server | TCP | 443 | Port used to communicate with the backup server. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine). |
-| Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| ESXi host | TCP | 443 | Default port used for connections to the ESXi host. |
-| vCenter server | TCP | 443 | Default port used for connections to the vCenter server. |
-| Veeam Signature Update Server  (avupdate.veeam.com) | TCP | 443 | Default port used by Veeam Threat Hunter to download information about new malware signatures from the Veeam Signature Update Server over HTTPS. |
-| Backup server | Mount server | TCP | 445 | Port used for deploying Veeam Backup & Replication components. These ports are not required if the [Veeam Deployment Kit](deployment_kit.md) is installed on the backup infrastructure component. |
-| TCP | 6160 | Default port used by Veeam Installer Service including checking the compatibility between components before starting the recovery process. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 6170 | Port used for communication with a local or remote Mount Service. |
+The following table describes network ports that must be opened for the [helper appliances](guest_file_recovery.md) involved in guest OS file recovery.
 
-Helper Appliance Connections
-
-Helper Appliance Connections
+Helper Appliances
 
 | From | To | Protocol | Port | Notes |
-| Helper appliance | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Helper appliance | ESXi server | TCP | 443 | Default port used for connections to the ESXi host if restore is performed over VIX API/vSphere Web Services.  [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vSphere Web Services. |
-| Backup server | Helper appliance | TCP | 22 | Default SSH port used as a control channel. |
+| Backup server,  Mount server | Helper appliance | TCP | 22 | Default SSH port used as a control channel. |
 | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Mount server | Helper appliance | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
-Helper Host Connections
-
-Helper Host Connections
-
-| From | To | Protocol | Port | Notes |
-| Helper host | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Helper host | ESXi server | TCP | 443 | Default port used for connections to the ESXi host if restore is performed over VIX API/vSphere Web Services.  [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 must also be open to vSphere Web Services. |
-| Backup server | Helper host | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 32768 to 60999 | Dynamic port range for Linux distributions. Used for communication with a helper host. For more information, see the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#ip-variables). |
-| Mount server | Helper host | TCP | 22 | Default SSH port used as a control channel. |
-| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| TCP | 32768 to 60999 | Dynamic port range for Linux distributions. Used for communication with a helper host. For more information, see the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html#ip-variables). |
-
-Guest OS Connections
-
-Guest OS Connections
-
-| From | To | Protocol | Port | Notes |
 | VM guest OS (Linux/Unix) | Helper appliance | TCP | 21 | Default port used for protocol control messages if FTP server is enabled. |
+
+Helper Hosts
+
+The following table describes network ports that must be opened for the [helper hosts](guest_file_recovery.md) involved in guest OS file recovery.
+
+Helper Hosts
+
+| From | To | Protocol | Port | Notes |
+| Backup server,  Mount server | Helper host | TCP | 22 | Default SSH port used as a control channel. |
+| TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Guest OS
+
+The following table describes network ports that must be opened for the VM guest OS involved in guest OS file recovery.
+
+Guest OS
+
+| From | To | Protocol | Port | Notes |
+| Helper appliance,  Helper host | VM guest OS (Linux/Unix) | TCP | 2500 to 3300 | Default range of ports used for communication with a VM guest OS. |
 | Helper appliance | VM guest OS (Linux/Unix) | TCP | 20 | Default port used for data transfer if FTP server is enabled. |
-| TCP | 2500 to 3300 | Default range of ports used for communication with a VM guest OS. |
-| Helper host | VM guest OS (Linux/Unix) | TCP | 2500 to 3300 | Default range of ports used for communication with a VM guest OS. |
 | Backup server | VM guest OS (Linux/Unix) | TCP | 22 | Default SSH port used as a control channel. |
 | Mount server | VM guest OS (Microsoft Windows) | TCP | 445, 135 | Required to deploy the runtime coordination process on the VM guest OS. |
 | TCP | 6160, 11731 | Default ports used by Veeam Installer Service.  Port 11731 is used for failover if port 6160 is unavailable. |
 | TCP | 6162 | Port used by the Veeam Transport Service for file-level restore. |
 | Backup server | VM guest OS | TCP | 2500 to 3300 | Default range of ports used for communication with a VM guest OS. |
 
-Veeam vPower NFS Service
+Backup Repositories
 
-Veeam vPower NFS Service
+The following table describes network ports that must be opened for the backup repositories involved in guest OS file recovery.
 
-| From | To | Protocol | Port | Notes |
-| Backup server | Mount server running vPower NFS Service | TCP | 6160 | Default port used by Veeam Installer Service. |
-| TCP | 6161 | Default port used by the Veeam vPower NFS Service. |
-| ESXi host | Mount server running vPower NFS Service | TCP UDP | 111 | Standard port used by the port mapper service. |
-| TCP UDP | 1058+ or 1063+ | Default mount port. The number of port depends on where the vPower NFS Service is located:   * 1058+: If the vPower NFS Service is located on the backup server. * 1063+: If the vPower NFS Service is located on a separate Microsoft Windows machine.   If port 1058/1063 is occupied, the succeeding port numbers will be used. |
-| TCP UDP | 2049+ | Standard NFS port. If port 2049 is occupied, the succeeding port numbers will be used. |
-| Backup repository or  gateway server working with backup repository | Mount server running vPower NFS Service | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during Instant Recovery, SureBackup or Linux file-level recovery.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Mount server running vPower NFS Service | Backup repository or  gateway server working with backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during Instant Recovery, SureBackup or Linux file-level recovery.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-
-SureBackup
-
-The following table describes network ports that must be opened to ensure proper communication between SureBackup components.
-
-SureBackup
+Backup Repositories
 
 | From | To | Protocol | Port | Notes |
+| Mount server,  Helper appliance,  Helper host | Backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine).  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+
+Virtualization Servers
+
+The following table describes network ports that must be opened for the virtualization servers involved in guest OS file recovery.
+
+Virtualization Servers
+
+| From | To | Protocol | Port | Notes |
+| Mount server | vCenter server | TCP | 443 | Default port used for connections to the vCenter server. |
+| Mount server | ESXi host | TCP | 443 | Default port used for connections to the ESXi host. |
+| Helper appliance,  Helper host | ESXi host | TCP | 443 | Default port used for connections to the ESXi host if restore is performed over VIX API/vSphere Web Services.  [For VMware vSphere earlier than 6.5] Not required if vCenter connection is used. In VMware vSphere versions 6.5 and later, port 443 is required by vSphere Web Services. |
+
+Veeam Update Servers
+
+The following table describes network ports that must be opened for the Veeam servers involved in guest OS file recovery.
+
+Veeam Update Servers
+
+| From | To | Protocol | Port | Notes |
+| Mount server | Veeam Signature Update Server  (avupdate.veeam.com) | TCP | 443 | Default port used by Veeam Threat Hunter to download information about new malware signatures from the Veeam Signature Update Server over HTTPS. |
+
+SureBackup Components
+
+The following table describes network ports that must be opened to ensure proper communication for [SureBackup](surebackup_hiw.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+SureBackup Components
+
+| From | To | Protocol | Port | Notes |
+| Communication with Proxy Appliances | | | | |
 | Backup server | Proxy appliance | TCP | 443 | Port used for communication with the proxy appliance in the virtual lab. |
-| Applications on VMs in the virtual lab | — | — | Application-specific ports to perform port probing test. For example, to verify a DC, Veeam Backup & Replication probes port 389 for a response. |
+| Communication with VMs | | | | |
+| Backup server | Applications on VMs in the virtual lab | — | — | Application-specific ports to perform port probing test. For example, to verify a DC, Veeam Backup & Replication probes port 389 for a response. |
 | Internet-facing proxy server | VMs in the virtual lab | TCP | 8080 | Port used to let VMs in the virtual lab access the Internet. |
-| Mount server running vPower NFS Service | Backup repository or  gateway server working with backup repository | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during SureBackup  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| ESXi server | TCP | 443 | Default port used for connections to ESXi host. |
-| Backup repository or  gateway server working with backup repository | Mount server running vPower NFS Service | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during SureBackup.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
-| Backup repository or  gateway server working with backup repository | Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during SureBackup.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
+| Communication with Hypervisors | | | | |
+| Mount server running vPower NFS Service | ESXi server | TCP | 443 | Default port used for connections to ESXi host. |
+| Backup repository  Gateway server working with backup repository | Hyper-V server | TCP | 6162, 2500 to 3300 | Default port used by Veeam Transport Service (Veeam Data Mover Service if Veeam Backup & Replication is installed on the Microsoft Windows machine) during SureBackup.  The port range 2500-3300 is used for failover if port 6162 is unavailable. |
 
-SureReplica Recovery Verification
+SureReplica Recovery Verification Components
 
-The following table describes network ports that must be opened to ensure proper communication between SureReplica components.
+The following table describes network ports that must be opened to ensure proper communication for [SureReplica](surereplica_hiw.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-SureReplica Recovery Verification
+SureReplica Recovery Verification Components
 
 | From | To | Protocol | Port | Notes |
+| Communication with Proxy Appliances | | | | |
 | Backup server | Proxy appliance | TCP | 443 | Port used for communication with the proxy appliance in the virtual lab. |
-| Applications on VMs in the virtual lab | — | — | Application-specific ports to perform port probing test. For example, to verify a DC, Veeam Backup & Replication probes port 389 for a response. |
+| Communication with VMs | | | | |
+| Backup server | Applications on VMs in the virtual lab | — | — | Application-specific ports to perform port probing test. For example, to verify a DC, Veeam Backup & Replication probes port 389 for a response. |
 | Internet-facing proxy server | VMs in the virtual lab | TCP | 8080 | Port used to let VMs in the virtual lab access the Internet. |
 
-Microsoft Active Directory Domain Controller Connections During Application Item Restore
+Application Item Restore
 
-The following table describes network ports that must be opened to ensure proper communication of the backup server with the Microsoft Active Directory VM during application-item restore.
+The following tables describe network ports that must be opened to ensure proper communication for components involved in the [application-item restore](restore_veeam_explorers.md):
 
-Microsoft Active Directory Domain Controller Connections During Application Item Restore
+* [VMs with Microsoft Active Directory Domain Controller](#ad)
+* [VMs with Microsoft Exchange Server](#ex)
+* [VMs with Microsoft SQL Server](#sql)
+
+If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+Microsoft Active Directory Domain Controller
+
+The following table describes network ports that must be opened for the Microsoft Active Directory VM involved in application-item restore.
+
+Microsoft Active Directory Domain Controller
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Microsoft  Active Directory VM guest OS | TCP | 135 | Port used for communication between the domain controller and backup server. |
 | TCP, UDP | 389 | Port used for LDAP connections. |
 | TCP | 636, 3268, 3269 | Ports used for LDAP connections. |
 
-Microsoft Exchange Server Connections During Application Item Restore
+Microsoft Exchange Server
 
-The following table describes network ports that must be opened to ensure proper communication of the Veeam backup server with the Microsoft Exchange Server system during application-item restore.
+The following table describes network ports that must be opened for the Microsoft Exchange Server involved in application-item restore.
 
-Microsoft Exchange Server Connections During Application Item Restore
+Microsoft Exchange Server
 
 | From | To | Protocol | Port | Notes |
 | Backup server | Microsoft Exchange 2003/2007 CAS Server | TCP | 80, 443 | Ports used for WebDAV connections. |
-| Microsoft Exchange 2010/2013/2016/2019 CAS Server | TCP | 443 | Port used for Microsoft Exchange Web Services Connections. |
+| Backup server | Microsoft Exchange 2010/2013/2016/2019 CAS Server | TCP | 443 | Port used for Microsoft Exchange Web Services Connections. |
 
-Microsoft SQL Server Connections During Application Item Restore
+Microsoft SQL Server
 
-The following table describes network ports that must be opened to ensure proper communication of the backup server with the VM guest OS system during application-item restore.
+The following table describes network ports that must be opened for the Microsoft SQL Server involved in application-item restore.
 
-Microsoft SQL Server Connections During Application Item Restore
+Microsoft SQL Server
 
 | From | To | Protocol | Port | Notes |
-| Backup server | Microsoft  SQL VM guest OS | TCP | 1433, 1434 and other | Ports used for communication with the Microsoft SQL Server installed inside the VM.  Port numbers depends on configuration of your Microsoft SQL server. For more information, see [this Microsoft article](https://msdn.microsoft.com/en-us/library/cc646023.aspx#BKMK_ssde). |
+| Backup server | Microsoft SQL VM guest OS | TCP | 1433, 1434 and other | Ports used for communication with the Microsoft SQL Server installed inside the VM.  Port numbers depends on configuration of your Microsoft SQL server. For more information, see [this Microsoft article](https://msdn.microsoft.com/en-us/library/cc646023.aspx#BKMK_ssde). |
 | UDP | 1434 | Port used by the Microsoft SQL Server Browser service.  For more information, see [this Microsoft article](https://learn.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-browser-service). |
 
-Restore to Amazon EC2
+Restore to Amazon EC2 and Restore to Google Cloud Components
 
-Restore to Amazon EC2
+The following table describes network ports that must be opened to ensure proper communication for [restore to Amazon EC2](restore_amazon.md) and [restore to Google Compute Engine](restore_google.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
 
-| From | To | Protocol | Port | Notes |
-| Backup server or backup repository | Helper appliance | TCP | 22 | Port used as a communication channel to the helper appliance. |
-| TCP | 443 | Default redirector port. You can change the port in helper appliance settings. For details, see the Specify Helper Appliance section in [Restore to Amazon EC2](restore_amazon_proxy.md). |
-
-Restore to Google Cloud
-
-Restore to Google Cloud
+Restore to Amazon EC2 and Restore to Google Cloud Components
 
 | From | To | Protocol | Port | Notes |
-| Backup server or backup repository | Helper appliance | TCP | 22 | Port used as a communication channel to the helper appliance. |
-| TCP | 443 | Default redirector port. You can change the port in helper appliance settings. For details, see the Specify Helper Appliance section in [Restore to Google Cloud](restore_google_proxy_appliance.md). |
+| Backup server or  Backup repository | Helper appliance | TCP | 22 | Port used as a communication channel to the helper appliance. |
+| TCP | 443 | Default redirector port. You can change the port in helper appliance settings. For details, see the Specify Helper Appliance section in [Restore to Amazon EC2](restore_amazon_proxy.md) and [Restore to Google Cloud](restore_google_proxy_appliance.md). |
 
-Restore to Microsoft Azure
+Restore to Microsoft Azure Components
 
-Restore to Microsoft Azure
+The following table describes network ports that must be opened to ensure proper communication for [Restore to Microsoft Azure](restore_azure_hiw.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+Restore to Microsoft Azure Components
 
 | From | To | Protocol | Port | Notes |
+| Communication with Microsoft | | | | |
 | Backup server | Microsoft Azure Resource Manager service  (https://management.azure.com) | TCP | 443 | Port used for Azure resources management and deployment. |
-| Microsoft Entra ID  (https://login.microsoftonline.com) | TCP | 443 | Port used for Entra ID authentication. |
-| Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
-| Microsoft Azure storage accounts (blob storage)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used for restored Windows-based VM conversion. Restored disks are temporarily mounted to the backup server.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Azure Windows VM agent distribution location  (go.microsoft.com, aka.ms, github.com, objects.githubusercontent.com) | TCP | 443 | Port used to install the Azure Windows VM agent on the restored VM.  Consider that the URLs used are subject to change. For more information, see [this Microsoft article](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#install-the-azure-windows-vm-agent). |
-| Helper appliance | TCP | 22 | Port used by default as a communication channel to the helper appliance when restoring Linux workloads.  This port can be changed during helper appliance deployment. For details, see [Managing Helper Appliances](restore_azure_linux.md). |
+| Backup server | Microsoft Entra ID  (https://login.microsoftonline.com) | TCP | 443 | Port used for Entra ID authentication. |
+| Backup server | Microsoft Azure storage accounts (blob storage)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used for restored Windows-based VM conversion. Restored disks are temporarily mounted to the backup server.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
+| Backup server | Azure Windows VM agent distribution location  (go.microsoft.com, aka.ms, github.com, objects.githubusercontent.com) | TCP | 443 | Port used to install the Azure Windows VM agent on the restored VM.  Consider that the URLs used are subject to change. For more information, see [this Microsoft article](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#install-the-azure-windows-vm-agent). |
+| Backup server | Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
+| Communication with Helper Appliances | | | | |
+| Backup server | Helper appliance | TCP | 22 | Port used by default as a communication channel to the helper appliance when restoring Linux workloads.  This port can be changed during helper appliance deployment. For details, see [Managing Helper Appliances](restore_azure_linux.md). |
+| Communication with Proxy Appliances | | | | |
 | Backup server or backup repository | Azure restore proxy appliance | TCP | 443 | Default management and data transport port required for communication with the Azure restore proxy appliance. The port must be accessible from the backup server and backup repository storing VM backups.  This port can be changed in the settings of the Azure Restore proxy appliance. For details, see [Specify Credentials and Transport Port](restore_azure_proxy_credentials.md). |
 
-Instant Recovery to Microsoft Azure
+Instant Recovery to Microsoft Azure Components
 
-Instant Recovery to Microsoft Azure
+The following table describes network ports that must be opened to ensure proper communication for [Instant Recovery to Microsoft Azure](instant_recovery_to_azure.md). If any basic backup infrastructure components will also be used, you also need to open ports for these components. For example, [Backup Server](#backup). You may also need to open ports for other features described in this section. For example, [Guest Processing](#guest_processing_components).
+
+Instant Recovery to Microsoft Azure Components
 
 | From | To | Protocol | Port | Notes |
+| Communication with Microsoft | | | | |
 | Backup server | Microsoft Azure Resource Manager service  (https://management.azure.com) | TCP | 443 | Port used for Azure Resources management and deployment.  Service Tag: AzureResourceManager |
-| Microsoft Azure storage account (Veeam packages upload)  (<storage-account>.queue.core.windows.net, <storage-account>.queue.storage.azure.net) | TCP | 443 | Port used to deliver Veeam components from the backup server to the temporary Azure VM used to create templates of Instant Recovery to Azure helper appliances.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
-| Microsoft Azure storage account (message queues)  (<storage-account>.queue.core.windows.net, <storage-account>.queue.storage.azure.net) | TCP | 443 | Port used for communication with Instant Recovery to Azure helper appliances via Azure Message queues.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal. |
-| Microsoft Entra ID  (https://login.microsoftonline.com) | TCP | 443 | Port used for Entra ID authentication to access storage accounts and message queues.  Service Tag: AzureActiveDirectory |
-| Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server can reach these verification endpoints. |
-| Instant Recovery for Azure helper appliance | Microsoft Azure storage account (message queues)  (<storage-account>.queue.core.windows.net, <storage-account>.queue.storage.azure.net) | TCP | 443 | Port used for communication with the backup server through Azure Message queues.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
-| Microsoft Azure storage account (backup repository) / Veeam Data Cloud Vault (backup repository)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to access backups.  Consider that the <storage-account> part of the address must be replaced with the ID of your storage vault. You can find the storage vault ID in the Storage Vaults > Vault ID section in Veeam Data Cloud Vault. For more information, see the [Managing Storage Vaults](https://helpcenter.veeam.com/docs/vdc/userguide/vault_storage_vaults_edit.html#viewing-storage-vault-details) section in the Veeam Data Cloud User Guide.  Service Tag: Storage |
-| Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the helper appliance can reach these verification endpoints. |
-| Azure Windows VM Agent Distribution location  (go.microsoft.com, aka.ms, github.com, objects.githubusercontent.com) | TCP | 443 | Port used to install the Azure Windows VM agent on the restored Windows VM.  Consider that these URLs are subject to change. For more information, see [this Microsoft article](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#install-the-azure-windows-vm-agent). |
-| Microsoft Entra ID  (https://login.microsoftonline.com) | TCP | 443 | Port used for Entra ID authentication to access storage accounts and message queues. |
-| Azure Instance Metadata Service endpoint  (http://169.254.169.254) | TCP | 80 | Port used for Entra ID authentication to access storage accounts and message queues and other purposes:  Service Tag: AzureActiveDirectory |
+| Backup server | Microsoft Azure storage account (Veeam packages upload)  (<storage-account>.queue.core.windows.net, <storage-account>.queue.storage.azure.net) | TCP | 443 | Port used to deliver Veeam components from the backup server to the temporary Azure VM used to create templates of Instant Recovery to Azure helper appliances.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
 | Temporary Azure VMs used to create templates of Instant Recovery to Azure helper appliances | Microsoft Azure storage account (Veeam packages upload)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to deliver Veeam components from the backup server to the temporary VM,  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
-| Microsoft Azure storage account (message queues)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used for communication with the backup server through Azure Message queues,  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
-| Ubuntu Azure repository  (http://azure.archive.ubuntu.com/ubuntu/) | TCP | 80 | Port used to install prerequisite packages. |
-| Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the temporary VMs can reach these verification endpoints. |
+| Backup server,  Instant Recovery for Azure helper appliance | Microsoft Azure storage account (message queues)  (<storage-account>.queue.core.windows.net, <storage-account>.queue.storage.azure.net) | TCP | 443 | Port used for communication using Azure Message queues.  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
+| Temporary Azure VMs used to create templates of Instant Recovery to Azure helper appliances | Microsoft Azure storage account (message queues)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used for communication with the backup server through Azure Message queues,  Consider that the <storage-account> part of the address must be replaced with your actual storage account URL that can be found in the Azure management portal.  Service Tag: Storage |
+| Instant Recovery for Azure helper appliance | Microsoft Azure storage account (backup repository) / Veeam Data Cloud Vault (backup repository)  (<storage-account>.blob.core.windows.net, <storage-account>.blob.storage.azure.net) | TCP | 443 | Port used to access backups.  Consider that the <storage-account> part of the address must be replaced with the ID of your storage vault. You can find the storage vault ID in the Storage Vaults > Vault ID section in Veeam Data Cloud Vault. For more information, see the [Managing Storage Vaults](https://helpcenter.veeam.com/docs/vdc/userguide/vault_storage_vaults_edit.html#viewing-storage-vault-details) section in the Veeam Data Cloud User Guide.  Service Tag: Storage |
+| Backup server,  Instant Recovery for Azure helper appliance | Microsoft Entra ID  (https://login.microsoftonline.com) | TCP | 443 | Port used for Entra ID authentication to access storage accounts and message queues.  Service Tag: AzureActiveDirectory |
+| Backup server,  Instant Recovery for Azure helper appliance,  Temporary Azure VMs used to create templates of Instant Recovery to Azure helper appliances | Certificate verification endpoints | TCP | 80 | Port used to verify the certificate status through the certificate verification endpoints (CRL URLs and OCSP servers).  These endpoints are subject to change. You can find the actual list of addresses in [this Microsoft article](https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-CA-details?tabs=root-and-subordinate-cas-list#certificate-downloads-and-revocation-lists) or in the certificate details in the following fields:   * CRL Distribution Points * Authority Information Access   Make sure that the backup server, helper appliance and temporary VMs can reach these verification endpoints. |
+| Instant Recovery for Azure helper appliance | Azure Windows VM Agent Distribution location  (go.microsoft.com, aka.ms, github.com, objects.githubusercontent.com) | TCP | 443 | Port used to install the Azure Windows VM agent on the restored Windows VM.  Consider that these URLs are subject to change. For more information, see [this Microsoft article](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows#install-the-azure-windows-vm-agent). |
+| Instant Recovery for Azure helper appliance | Azure Instance Metadata Service endpoint  (http://169.254.169.254) | TCP | 80 | Port used for Entra ID authentication to access storage accounts and message queues and other purposes:  Service Tag: AzureActiveDirectory |
+| Temporary Azure VMs used to create templates of Instant Recovery to Azure helper appliances | Ubuntu Azure repository  (http://azure.archive.ubuntu.com/ubuntu/) | TCP | 80 | Port used to install prerequisite packages. |
+| Communication with Helper Appliances | | | | |
 | Restored VM | Instant Recovery to Azure helper appliance | TCP | 3260-3262 | Ports used to boot the restored VM from backed up disks with iSCSI protocol. |
 | TCP | 9555 | Port used to get boot firmware configuration from the Platform Converter Service running on the appliance. |
 

--- a/docs/virtual_lab.md
+++ b/docs/virtual_lab.md
@@ -3,14 +3,14 @@ title: "Virtual Lab"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/virtual_lab.html"
-last_updated: "4/29/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Virtual Lab
 
 
-The virtual lab is an isolated virtual environment in which Veeam Backup & Replication verifies VMs. In the virtual lab, Veeam Backup & Replication starts VMs from the application group and the verified VM. The virtual lab is used not only for the SureBackup verification procedure, but also for [U-AIR](https://www.veeam.com/veeam_backup_12_uair_wizard_user_guide_pg.pdf), On-Demand Sandbox and staged restore.
+The virtual lab is an isolated virtual environment in which Veeam Backup & Replication verifies VMs. In the virtual lab, Veeam Backup & Replication starts VMs from the application group and the verified VM. The virtual lab is used not only for the SureBackup verification procedure, but also for the On-Demand Sandbox and the staged restore.
 
 The virtual lab itself does not require that you provision extra resources for it. However, VMs running in the virtual lab consume CPU and memory resources of the ESXi host where the virtual lab is deployed. All VM changes that take place during recovery verification are written to redo log files. By default, Veeam Backup & Replication stores redo logs on the datastore selected in the virtual lab settings and removes redo logs after the recovery process is complete.
 

--- a/docs/virtual_lab_hv.md
+++ b/docs/virtual_lab_hv.md
@@ -3,14 +3,14 @@ title: "Virtual Lab"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/virtual_lab_hv.html"
-last_updated: "5/5/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/31/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Virtual Lab
 
 
-The virtual lab is an isolated virtual environment in which Veeam Backup & Replication verifies VMs. In the virtual lab, Veeam Backup & Replication starts VMs from the application group and the verified VM. The virtual lab is used not only for the SureBackup verification procedure, but also for [U-AIR](https://www.veeam.com/veeam_backup_12_uair_wizard_user_guide_pg.pdf), On-Demand Sandbox and staged restore.
+The virtual lab is an isolated virtual environment in which Veeam Backup & Replication verifies VMs. In the virtual lab, Veeam Backup & Replication starts VMs from the application group and the verified VM. The virtual lab is used not only for the SureBackup verification procedure, but also for the On-Demand Sandbox and the staged restore.
 
 The virtual lab itself does not require that you provision extra resources for it. However, VMs running in the virtual lab consume CPU and memory resources of the Hyper-V host where the virtual lab is deployed. All VM changes that take place during recovery verification are written to the differencing disk (AVHD/AVHDX file) which Veeam Backup & Replication creates for the recovered VM. When the recovery verification process is complete, the changes are discarded.
 

--- a/docs/vmware_proxy_server.md
+++ b/docs/vmware_proxy_server.md
@@ -3,8 +3,8 @@ title: "Step 2. Choose Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmware_proxy_server.html"
-last_updated: "12/3/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/24/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 2. Choose Server
@@ -37,7 +37,7 @@ You can select the data transport mode manually. Click Choose on the right of th
 |  |
 | --- |
 | Note |
-| In some cases, the backup proxy may not be able to use some transport modes due to known limitations. For more information, see [Transport Modes](transport_modes.md). If you assign the backup proxy role to a hardened repository, only the Network mode will be available. Other transport modes will be grayed out. |
+| The support of the transport modes depends on the backup infrastructure component that performs the backup proxy role. For more information, see [Transport Modes](transport_modes.md). |
 
 ![Step 2. Choose Server](images/add_vmware_proxy_server_mode.webp)
 

--- a/docs/vmware_proxy_server_web.md
+++ b/docs/vmware_proxy_server_web.md
@@ -3,8 +3,8 @@ title: "Step 2. Choose Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmware_proxy_server_web.html"
-last_updated: "12/3/2025"
-product_version: "13.0.1.1071"
+last_updated: "3/24/2026"
+product_version: "13.0.1.2067"
 ---
 
 # Step 2. Choose Server
@@ -34,7 +34,7 @@ You can select the data transport mode manually. Click Choose on the right of th
 |  |
 | --- |
 | Note |
-| In some cases, the backup proxy may not be able to use some transport modes due to known limitations. For more information, see [Transport Modes](transport_modes.md). If you assign the backup proxy role to a hardened repository, only the Network mode will be available. Other transport modes will be grayed out. |
+| The support of the transport modes depends on the backup infrastructure component that performs the backup proxy role. For more information, see [Transport Modes](transport_modes.md). |
 
 1. In the Connected datastores field, specify datastores to which the backup proxy has a direct SAN or NFS connection. By default, Veeam Backup & Replication automatically detects all datastores that the backup proxy can access.
 


### PR DESCRIPTION
## Documentation Update - VBR

Scraped from [Veeam Help Center](https://helpcenter.veeam.com) on 2026-03-31.

### Summary

| Type | New | Updated (Content) | Updated (Metadata) | Deleted |
|------|-----|-------------------|-------------------|---------|
| Markdown | 1 | 21 | 200 | 0 |
| Images | 0 | 0 | - | 0 |
### New Pages (1)

#### Userguide (1)

- `docs/sia_transport.md` - Storage Integration Access


### Content Updates (21)

#### Cloud (1)

| File | Changes | Summary |
|------|---------|---------|
| `docs/cloud/cloud_connect_sp_vbr.md` | +3/-3 | Updated limitations for SP Veeam Backup Server. |

#### Userguide (20)

| File | Changes | Summary |
|------|---------|---------|
| `docs/backup_proxy_requirements.md` | +3/-3 | Updated transport modes information for Linux-based backup proxies. |
| `docs/direct_san_access.md` | +8/-6 | Added requirements for Veeam Infrastructure Appliance with iSCSI and NVMe/TCP. |
| `docs/direct_storage_access.md` | +3/-2 | No changes. |
| `docs/file_share_backup_job_advanced_maintenance.md` | +4/-4 | Updated health check settings for file share backup jobs. |
| `docs/file_share_backup_job_files_and_folders.md` | +3/-3 | Updated exclude masks for file share backup jobs. |
| `docs/hardened_repository_limitations.md` | +2/-4 | Removed note about Nutanix Mine infrastructure. |
| `docs/linux_infrastructure_appliance_byb.md` | +2/-5 | Updated transport modes for Veeam Infrastructure Appliance. |
| `docs/multios_restore_before_you_begin.md` | +2/-1 | Added dynamic port range requirement for Linux helper hosts. |
| `docs/os_backup_job_advanced_maintenance.md` | +3/-3 | Updated health check settings for object storage backup jobs. |
| `docs/pve_used_ports.md` | +102/-49 | Updated network ports for guest processing components. |
| `docs/recovery_verification_surereplica.md` | +2/-3 | No changes. |
| `docs/surebackup_job_appgroup_hv.md` | +3/-3 | Removed U-AIR reference. |
| `docs/surebackup_job_appgroup_vm.md` | +3/-3 | Removed U-AIR reference. |
| `docs/surereplica_hiw.md` | +3/-5 | Removed U-AIR and On-Demand Sandbox references. |
| `docs/transport_modes.md` | +9/-7 | Updated transport mode limitations for Veeam Infrastructure Appliance and hardened repositories. |
| `docs/used_ports.md` | +691/-604 | Updated information on ports required for Veeam Backup & Replication, including details on core backup infrastructure components and features. |
| `docs/virtual_lab.md` | +3/-3 | Updated the virtual lab documentation to reflect changes in Veeam Backup & Replication 13.0.1.2067. |
| `docs/virtual_lab_hv.md` | +3/-3 | Updated the virtual lab documentation for Hyper-V to reflect changes in Veeam Backup & Replication 13.0.1.2067. |
| `docs/vmware_proxy_server.md` | +3/-3 | Updated the backup proxy server documentation to reflect changes in transport mode support. |
| `docs/vmware_proxy_server_web.md` | +3/-3 | Updated the backup proxy server documentation for web-based configuration to reflect changes in transport mode support. |


### Metadata-Only Updates (200)

<details><summary>200 files with only frontmatter changes (version, date)</summary>

- `docs/agent_export_backup.md`
- `docs/deployment_linux.md`
- `docs/deployment_linux_automated_deployment.md`
- `docs/deployment_linux_byb.md`
- `docs/deployment_linux_iso_install.md`
- `docs/deployment_linux_iso_install_host_administrator.md`
- `docs/deployment_linux_iso_install_hostname.md`
- `docs/deployment_linux_iso_install_license.md`
- `docs/deployment_linux_iso_install_mount.md`
- `docs/deployment_linux_iso_install_network.md`
- `docs/deployment_linux_iso_install_security_officer.md`
- `docs/deployment_linux_iso_install_select_product.md`
- `docs/deployment_linux_iso_install_summary.md`
- `docs/deployment_linux_iso_install_time.md`
- `docs/deployment_linux_iso_install_type.md`
- `docs/deployment_linux_iso_reinstall.md`
- `docs/deployment_linux_ova.md`
- `docs/deployment_linux_silent_deploy_configure.md`
- `docs/deployment_linux_silent_deploy_install.md`
- `docs/entra_id_tenant_restore_items.md`
- ... and 180 more files\n
</details>

---
*Automatically generated by [veeam-docs-scraper](https://github.com/comnam90/veeam-docs-scraper)*
