### PR TITLE
docs(vbr): documentation update 2026-06-09

### DIFF
--- a/docs/add_gfs_media_pool_name.md
+++ b/docs/add_gfs_media_pool_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Media Pool Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/add_gfs_media_pool_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/add_gfs_media_pool_set.md
+++ b/docs/add_gfs_media_pool_set.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Media Set Options"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/add_gfs_media_pool_set.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/add_media_pool_name.md
+++ b/docs/add_media_pool_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Media Pool Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/add_media_pool_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/add_media_pool_review.md
+++ b/docs/add_media_pool_review.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/add_media_pool_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/add_media_pool_set.md
+++ b/docs/add_media_pool_set.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Media Set Options"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/add_media_pool_set.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/agent_job_manage_job.md
+++ b/docs/agent_job_manage_job.md
@@ -3,7 +3,7 @@ title: "Managing Veeam Agent Backup Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_manage_job.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/agent_job_manage_policy.md
+++ b/docs/agent_job_manage_policy.md
@@ -3,7 +3,7 @@ title: "Managing Veeam Agent Backup Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_job_manage_policy.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/agent_policy_target_set_unix.md
+++ b/docs/agent_policy_target_set_unix.md
@@ -3,7 +3,7 @@ title: "Step 8. Specify Backup Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/agent_policy_target_set_unix.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/ahv_instant_recovery.md
+++ b/docs/ahv_instant_recovery.md
@@ -3,7 +3,7 @@ title: "Instant Recovery"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ahv_instant_recovery.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/ahv_ir_target_container_ahv.md
+++ b/docs/ahv_ir_target_container_ahv.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Storage Container"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ahv_ir_target_container_ahv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/ahv_ir_workloads_ahv.md
+++ b/docs/ahv_ir_workloads_ahv.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ahv_ir_workloads_ahv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/appgroup_launch_hv.md
+++ b/docs/appgroup_launch_hv.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Application Group Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/appgroup_launch_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/appgroup_name_hv.md
+++ b/docs/appgroup_name_hv.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Application Group Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/appgroup_name_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/appgroup_review_hv.md
+++ b/docs/appgroup_review_hv.md
@@ -3,7 +3,7 @@ title: "Step 5. Review the Application Group Settings and Finish Working with Wi
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/appgroup_review_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/assess_results.md
+++ b/docs/assess_results.md
@@ -3,7 +3,7 @@ title: "Step 5. Assess Results"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/assess_results.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_notifications_hana.md
+++ b/docs/backup_copy_advanced_notifications_hana.md
@@ -3,7 +3,7 @@ title: "Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_notifications_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_notifications_rman.md
+++ b/docs/backup_copy_advanced_notifications_rman.md
@@ -3,7 +3,7 @@ title: "Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_notifications_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_notifications_sap_oracle.md
+++ b/docs/backup_copy_advanced_notifications_sap_oracle.md
@@ -3,7 +3,7 @@ title: "Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_notifications_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_rpo_monitor_hana.md
+++ b/docs/backup_copy_advanced_rpo_monitor_hana.md
@@ -3,7 +3,7 @@ title: "RPO Warning Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_rpo_monitor_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_rpo_monitor_rman.md
+++ b/docs/backup_copy_advanced_rpo_monitor_rman.md
@@ -3,7 +3,7 @@ title: "RPO Warning Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_rpo_monitor_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_rpo_monitor_sap_oracle.md
+++ b/docs/backup_copy_advanced_rpo_monitor_sap_oracle.md
@@ -3,7 +3,7 @@ title: "RPO Warning Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_rpo_monitor_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_storage_hana.md
+++ b/docs/backup_copy_advanced_storage_hana.md
@@ -3,7 +3,7 @@ title: "Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_storage_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_advanced_storage_rman.md
+++ b/docs/backup_copy_advanced_storage_rman.md
@@ -3,7 +3,7 @@ title: "Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_advanced_storage_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_copy_backups.md
+++ b/docs/backup_copy_copy_backups.md
@@ -3,7 +3,7 @@ title: "Copying Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_copy_backups.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_hpe_storeonce_settings.md
+++ b/docs/backup_copy_hpe_storeonce_settings.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Advanced Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_hpe_storeonce_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_main_hana.md
+++ b/docs/backup_copy_main_hana.md
@@ -3,7 +3,7 @@ title: "Backup Copy for SAP HANA Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_main_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_main_rman.md
+++ b/docs/backup_copy_main_rman.md
@@ -3,7 +3,7 @@ title: "Backup Copy for Oracle RMAN Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_main_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_prerequisites_hana.md
+++ b/docs/backup_copy_prerequisites_hana.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_prerequisites_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_prerequisites_rman.md
+++ b/docs/backup_copy_prerequisites_rman.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_prerequisites_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_prerequisites_sap_oracle.md
+++ b/docs/backup_copy_prerequisites_sap_oracle.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_prerequisites_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_retention.md
+++ b/docs/backup_copy_retention.md
@@ -3,7 +3,7 @@ title: "Retention Policy for Backup Copy Jobs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_retention.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_schedule_hana.md
+++ b/docs/backup_copy_schedule_hana.md
@@ -3,7 +3,7 @@ title: "Step 6. Define Backup Copy Schedule"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_schedule_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_schedule_rman.md
+++ b/docs/backup_copy_schedule_rman.md
@@ -3,7 +3,7 @@ title: "Step 6. Define Backup Copy Schedule"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_schedule_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_schedule_sap_oracle.md
+++ b/docs/backup_copy_schedule_sap_oracle.md
@@ -3,7 +3,7 @@ title: "Step 6. Define Backup Copy Schedule"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_schedule_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_target_rman.md
+++ b/docs/backup_copy_target_rman.md
@@ -3,7 +3,7 @@ title: "Step 4. Define Backup Copy Target"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_target_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_copy_target_sap_oracle.md
+++ b/docs/backup_copy_target_sap_oracle.md
@@ -3,7 +3,7 @@ title: "Step 4. Define Backup Copy Target"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_copy_target_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_job_limitations.md
+++ b/docs/backup_job_limitations.md
@@ -3,8 +3,8 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_limitations.html"
-last_updated: "2/6/2026"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Considerations and Limitations
@@ -25,7 +25,8 @@ Backup Infrastructure
 
 Backup Source
 
-Veeam Backup & Replication does not support protection of workloads with 4K native disks (disks with 4096 bytes logical sector size).
+* Using replicas as a source for backup jobs is not recommended. Due to VMware vSphere Changed Block Tracking (CBT) behavior, incremental backups of replica VMs that have not been powered on may be inefficient.
+* Veeam Backup & Replication does not support the protection of workloads with 4K native disks (disks with 4096 bytes logical sector size).
 
 Backup Job Configuration
 

--- a/docs/backup_job_storage_hv.md
+++ b/docs/backup_job_storage_hv.md
@@ -3,8 +3,8 @@ title: "Step 6. Specify Backup Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_storage_hv.html"
-last_updated: "9/17/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/8/2026"
+product_version: "13.0.2.29"
 ---
 
 # Step 6. Specify Backup Storage Settings
@@ -31,7 +31,7 @@ To perform off-host backup, Veeam Backup & Replication analyzes the current load
 | Note |
 | Consider the following:   * If you change the repository after the job has already run, Veeam Backup & Replication suggests you move the existing backups to the new repository. If you want to move the backups, check the limitations and considerations in [Backup Move](backup_moving_hv.md). * If you select an object storage repository or a scale-out backup repository which performance tier consists of object storage repositories, Veeam Backup & Replication will not provide the amount of free space in this repository since its capacity is constantly expanding. |
 
-1. You can map the job to a specific backup stored in the backup repository. Backup job mapping can be helpful if you have moved backup files to a new backup repository and want to point the job to existing backups in this new backup repository. You can also use backup job mapping if the configuration database gets corrupted and you need to reconfigure backup jobs.
+1. You can map the job to a specific backup available in the backup repository. Backup job mapping can be helpful if you have moved backup files to a new backup repository and want to point the job to existing backups in this new backup repository. You can also use backup job mapping if the configuration database gets corrupted and you need to reconfigure backup jobs.
 
 To map the job to a backup, click the Map backup link and select the backup in the backup repository. Backups can be easily identified by job names. To find the backup, you can also use the search field at the bottom of the window.
 

--- a/docs/backup_job_storage_vm.md
+++ b/docs/backup_job_storage_vm.md
@@ -3,8 +3,8 @@ title: "Step 6. Specify Backup Storage Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_storage_vm.html"
-last_updated: "9/17/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/8/2026"
+product_version: "13.0.2.29"
 ---
 
 # Step 6. Specify Backup Storage Settings
@@ -29,7 +29,7 @@ If you plan to use the Backup from Storage Snapshots technology, see section [Re
 | Note |
 | Consider the following:   * If you change the repository after the job has already run, Veeam Backup & Replication suggests that you move the existing backups to the new repository. If you want to move the backups, see limitations and considerations in [Backup Move](backup_moving.md). * If you select an object storage repository or a scale-out backup repository which performance tier consists of object storage repositories, Veeam Backup & Replication will not provide the amount of free space in this repository since its capacity is constantly expanding. |
 
-1. You can map the job to a specific backup stored in the backup repository. Backup job mapping can be helpful if you have moved backup files to a new backup repository and want to point the job to existing backups in this new backup repository. You can also use backup job mapping if the configuration database gets corrupted and you need to reconfigure backup jobs.
+1. You can map the job to a specific backup available in the backup repository. Backup job mapping can be helpful if you have moved backup files to a new backup repository and want to point the job to existing backups in this new backup repository. You can also use backup job mapping if the configuration database gets corrupted and you need to reconfigure backup jobs.
 
 To map the job to a backup, click the Map backup link and select the backup in the backup repository. Backups can be easily identified by job names. To find the backup, you can also use the search field at the bottom of the window.
 

--- a/docs/backup_job_vss_postgresql_vm.md
+++ b/docs/backup_job_vss_postgresql_vm.md
@@ -3,7 +3,7 @@ title: "PostgreSQL WAL Files Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_job_vss_postgresql_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_modes.md
+++ b/docs/backup_modes.md
@@ -3,7 +3,7 @@ title: "Backup Modes"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_modes.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_to_tape_advanced.md
+++ b/docs/backup_to_tape_advanced.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify Advanced Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_advanced.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_to_tape_incremental_pool.md
+++ b/docs/backup_to_tape_incremental_pool.md
@@ -3,7 +3,7 @@ title: "Step 5. Choose Media Pool for Incremental Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_incremental_pool.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_to_tape_name.md
+++ b/docs/backup_to_tape_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Job Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_to_tape_review.md
+++ b/docs/backup_to_tape_review.md
@@ -3,7 +3,7 @@ title: "Step 9. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_to_tape_schedule.md
+++ b/docs/backup_to_tape_schedule.md
@@ -3,7 +3,7 @@ title: "Step 8. Define Job Schedule"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_to_tape_schedule.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/backup_validator.md
+++ b/docs/backup_validator.md
@@ -3,7 +3,7 @@ title: "Veeam Backup Validator"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/backup_validator.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/byb_failback_vcd.md
+++ b/docs/byb_failback_vcd.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/byb_failback_vcd.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_disable.md
+++ b/docs/cdp_disable.md
@@ -3,7 +3,7 @@ title: "Disabling and Deleting Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_disable.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_edit.md
+++ b/docs/cdp_edit.md
@@ -3,7 +3,7 @@ title: "Editing Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_edit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_policy_guest_scripts.md
+++ b/docs/cdp_policy_guest_scripts.md
@@ -3,7 +3,7 @@ title: "Script Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_policy_guest_scripts.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_policy_notification.md
+++ b/docs/cdp_policy_notification.md
@@ -3,7 +3,7 @@ title: "Step 11. Specify Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_policy_notification.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_policy_sql_trans_logs.md
+++ b/docs/cdp_policy_sql_trans_logs.md
@@ -3,7 +3,7 @@ title: "Microsoft SQL Server Transaction Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_policy_sql_trans_logs.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_policy_workloads.md
+++ b/docs/cdp_policy_workloads.md
@@ -3,7 +3,7 @@ title: "Step 3. Select VMs to Replicate"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_policy_workloads.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_proxy_install_components.md
+++ b/docs/cdp_proxy_install_components.md
@@ -3,7 +3,7 @@ title: "Step 5. Review Settings and Install Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_proxy_install_components.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cdp_view_properties.md
+++ b/docs/cdp_view_properties.md
@@ -3,7 +3,7 @@ title: "Viewing Replica Properties"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/cdp_view_properties.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/changing_switching_time.md
+++ b/docs/changing_switching_time.md
@@ -3,7 +3,7 @@ title: "Changing Switching Time"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/changing_switching_time.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cc_backup_server_manage.md
+++ b/docs/cloud/cc_backup_server_manage.md
@@ -3,7 +3,7 @@ title: "Managing SP Backup Server"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cc_backup_server_manage.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cc_backup_to_tape.md
+++ b/docs/cloud/cc_backup_to_tape.md
@@ -3,7 +3,7 @@ title: "Working with Tapes"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cc_backup_to_tape.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cc_considerations.md
+++ b/docs/cloud/cc_considerations.md
@@ -3,7 +3,7 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cc_considerations.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cc_remote_console_byb.md
+++ b/docs/cloud/cc_remote_console_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cc_remote_console_byb.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_assess_results.md
+++ b/docs/cloud/cloud_connect_assess_results.md
@@ -3,7 +3,7 @@ title: "Step 5. Assess Results"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_assess_results.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_gateway_review.md
+++ b/docs/cloud/cloud_connect_gateway_review.md
@@ -3,7 +3,7 @@ title: "Step 4. Review Cloud Gateway Settings"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_gateway_review.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_limitations.md
+++ b/docs/cloud/cloud_connect_limitations.md
@@ -3,8 +3,8 @@ title: "Veeam Cloud Connect Backup"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_limitations.html"
-last_updated: "11/28/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/9/2026"
+product_version: "13.0.2.29"
 ---
 
 # Veeam Cloud Connect Backup
@@ -22,7 +22,7 @@ Note that cloud repositories backed by object storage systems are not supported 
 
 * Instant VM Recovery, multi-OS file-level restore, restore to Proxmox VE, restore to oVirt KVM, restore to Microsoft Azure and Amazon EC2 from backups in the cloud repository are not supported on the tenant side.
 
-If Nutanix AHV Plug-in is installed and a Nutanix AHV cluster is added in Veeam Backup & Replication, the tenant can perform instant recovery to Nutanix AHV form backups that reside in the cloud repository. For more information, see the [Instant Recovery](https://helpcenter.veeam.com/docs/vbahv/userguide/instant_recovery.html?ver=9) section in the Veeam Backup for Nutanix AHV User Guide.
+If Nutanix AHV Plug-in is installed and a Nutanix AHV cluster is added in Veeam Backup & Replication, the tenant can perform instant recovery to Nutanix AHV from backups that reside in the cloud repository. For more information, see the [Instant Recovery](https://helpcenter.veeam.com/docs/vbahv/userguide/instant_recovery.html?ver=9) section in the Veeam Backup for Nutanix AHV User Guide.
 
 Some restore operations are available on the SP side only, including Instant Recovery from VM backups and Veeam Agent backups, restore to Microsoft Azure and restore to Amazon EC2. To learn more, see [Restoring Data from Tenant Backups](cc_data_restore.md).
 

--- a/docs/cloud/cloud_connect_manage_tenant_appliance.md
+++ b/docs/cloud/cloud_connect_manage_tenant_appliance.md
@@ -3,7 +3,7 @@ title: "Managing Network Extension Appliance"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_manage_tenant_appliance.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_manage_user_replicas.md
+++ b/docs/cloud/cloud_connect_manage_user_replicas.md
@@ -3,7 +3,7 @@ title: "Managing Tenant VM Replicas"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_manage_user_replicas.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_network_redirectors.md
+++ b/docs/cloud/cloud_connect_network_redirectors.md
@@ -3,7 +3,7 @@ title: "Network Redirectors"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_network_redirectors.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_sp_apply.md
+++ b/docs/cloud/cloud_connect_sp_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Assess Results"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_sp_apply.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_sp_enumerate.md
+++ b/docs/cloud/cloud_connect_sp_enumerate.md
@@ -3,7 +3,7 @@ title: "Step 4. Enumerate Cloud Repository Resources"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_sp_enumerate.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_sp_finish.md
+++ b/docs/cloud/cloud_connect_sp_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_sp_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_ssl.md
+++ b/docs/cloud/cloud_connect_ssl.md
@@ -3,7 +3,7 @@ title: "TLS Certificates"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_ssl.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_ssl_next.md
+++ b/docs/cloud/cloud_connect_ssl_next.md
@@ -3,7 +3,7 @@ title: "What You Do Next"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_ssl_next.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_ssl_verify.md
+++ b/docs/cloud/cloud_connect_ssl_verify.md
@@ -3,7 +3,7 @@ title: "TLS Certificate Thumbprint Verification"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_ssl_verify.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_user_assess_results.md
+++ b/docs/cloud/cloud_connect_user_assess_results.md
@@ -3,7 +3,7 @@ title: "Step 7. Assess Results"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_user_assess_results.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_user_before.md
+++ b/docs/cloud/cloud_connect_user_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_user_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_user_compute_resources.md
+++ b/docs/cloud/cloud_connect_user_compute_resources.md
@@ -3,7 +3,7 @@ title: "Step 5. Allocate Replication Resources"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_user_compute_resources.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_user_configure.md
+++ b/docs/cloud/cloud_connect_user_configure.md
@@ -3,7 +3,7 @@ title: "Setting Up Tenant Veeam Cloud Connect Infrastructure"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_user_configure.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_connect_user_finish.md
+++ b/docs/cloud/cloud_connect_user_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_connect_user_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_failover_plan_byb.md
+++ b/docs/cloud/cloud_failover_plan_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_failover_plan_byb.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_failover_plan_gateways.md
+++ b/docs/cloud/cloud_failover_plan_gateways.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Default Gateways"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_failover_plan_gateways.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_failover_plan_vms.md
+++ b/docs/cloud/cloud_failover_plan_vms.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Virtual Machines"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_failover_plan_vms.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_gateway_pool_after.md
+++ b/docs/cloud/cloud_gateway_pool_after.md
@@ -3,7 +3,7 @@ title: "What You Do Next"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_gateway_pool_after.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_gateway_pool_before.md
+++ b/docs/cloud/cloud_gateway_pool_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_gateway_pool_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_gateway_pool_finish.md
+++ b/docs/cloud/cloud_gateway_pool_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_gateway_pool_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_gateway_pool_name.md
+++ b/docs/cloud/cloud_gateway_pool_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Cloud Gateway Pool Name and Description"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_gateway_pool_name.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_vcd_tenant_apply.md
+++ b/docs/cloud/cloud_vcd_tenant_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Assess Results"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_vcd_tenant_apply.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_vcd_tenant_before.md
+++ b/docs/cloud/cloud_vcd_tenant_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_vcd_tenant_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/cloud_vcd_tenant_finish.md
+++ b/docs/cloud/cloud_vcd_tenant_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/cloud_vcd_tenant_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plan_assess_results.md
+++ b/docs/cloud/hardware_plan_assess_results.md
@@ -3,7 +3,7 @@ title: "Step 6. Assess Results"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plan_assess_results.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plan_before_you_begin.md
+++ b/docs/cloud/hardware_plan_before_you_begin.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plan_before_you_begin.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plan_name.md
+++ b/docs/cloud/hardware_plan_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Hardware Plan Name and Description"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plan_name.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plan_network.md
+++ b/docs/cloud/hardware_plan_network.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Network Settings"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plan_network.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plan_summary.md
+++ b/docs/cloud/hardware_plan_summary.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plan_summary.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/hardware_plans_add.md
+++ b/docs/cloud/hardware_plans_add.md
@@ -3,7 +3,7 @@ title: "Adding Hardware Plans"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/hardware_plans_add.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/managing_backups.md
+++ b/docs/cloud/managing_backups.md
@@ -3,7 +3,7 @@ title: "Managing Backups"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/managing_backups.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/managing_hardware_plans.md
+++ b/docs/cloud/managing_hardware_plans.md
@@ -3,7 +3,7 @@ title: "Managing Hardware Plans"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/managing_hardware_plans.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/performing_full_site_failover.md
+++ b/docs/cloud/performing_full_site_failover.md
@@ -3,7 +3,7 @@ title: "Performing Full Site Failover"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/performing_full_site_failover.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/reporting.md
+++ b/docs/cloud/reporting.md
@@ -3,7 +3,7 @@ title: "Reporting"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/reporting.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/sp_license_usage_adjust.md
+++ b/docs/cloud/sp_license_usage_adjust.md
@@ -3,7 +3,7 @@ title: "Adjusting License Usage Report"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/sp_license_usage_adjust.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_create_before.md
+++ b/docs/cloud/subtenant_create_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_create_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_create_finish.md
+++ b/docs/cloud/subtenant_create_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_create_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_create_sp_finish.md
+++ b/docs/cloud/subtenant_create_sp_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_create_sp_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_before.md
+++ b/docs/cloud/subtenant_vcd_create_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_finish.md
+++ b/docs/cloud/subtenant_vcd_create_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_settings.md
+++ b/docs/cloud/subtenant_vcd_create_settings.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Cloud Director User"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_settings.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_sp_before.md
+++ b/docs/cloud/subtenant_vcd_create_sp_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_sp_before.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_sp_finish.md
+++ b/docs/cloud/subtenant_vcd_create_sp_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finish Working with Wizard"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_sp_finish.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/subtenant_vcd_create_sp_settings.md
+++ b/docs/cloud/subtenant_vcd_create_sp_settings.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Cloud Director User"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/subtenant_vcd_create_sp_settings.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/vcloud_failover_plan_byb.md
+++ b/docs/cloud/vcloud_failover_plan_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/vcloud_failover_plan_byb.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/cloud/vcloud_failover_plan_vms.md
+++ b/docs/cloud/vcloud_failover_plan_vms.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Virtual Machines"
 product: "vbr"
 doc_type: "cloud"
 source_url: "https://helpcenter.veeam.com/docs/vbr/cloud/vcloud_failover_plan_vms.html"
-last_updated: "6/3/2026"
+last_updated: "6/9/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/compare_to_onprem.md
+++ b/docs/compare_to_onprem.md
@@ -3,7 +3,7 @@ title: "Compare to On-Premises Microsoft Servers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/compare_to_onprem.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/compatible_apply.md
+++ b/docs/compatible_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/compatible_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/compatible_review.md
+++ b/docs/compatible_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/compatible_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/configuration_tool_using.md
+++ b/docs/configuration_tool_using.md
@@ -3,7 +3,7 @@ title: "Using Veeam Backup Configuration Tool"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/configuration_tool_using.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/create_policy_create_oracle_rman.md
+++ b/docs/create_policy_create_oracle_rman.md
@@ -3,7 +3,7 @@ title: "Creating Oracle RMAN Backup Policy"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/create_policy_create_oracle_rman.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/create_policy_create_sap_hana.md
+++ b/docs/create_policy_create_sap_hana.md
@@ -3,7 +3,7 @@ title: "Creating SAP HANA Backup Policy"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/create_policy_create_sap_hana.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/create_policy_create_sap_oracle.md
+++ b/docs/create_policy_create_sap_oracle.md
@@ -3,7 +3,7 @@ title: "Creating SAP on Oracle Backup Policy"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/create_policy_create_sap_oracle.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/deployment_linux_byb.md
+++ b/docs/deployment_linux_byb.md
@@ -3,8 +3,8 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_linux_byb.html"
-last_updated: "4/21/2026"
-product_version: "13.0.1.2067"
+last_updated: "6/4/2026"
+product_version: "13.0.2.29"
 ---
 
 # Considerations and Limitations

--- a/docs/deployment_scenarios.md
+++ b/docs/deployment_scenarios.md
@@ -3,7 +3,7 @@ title: "Deployment Scenarios"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/deployment_scenarios.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/disk_restore_before_you_begin.md
+++ b/docs/disk_restore_before_you_begin.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/disk_restore_before_you_begin.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/disk_restore_review_vm.md
+++ b/docs/disk_restore_review_vm.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/disk_restore_review_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/dsa_repository_apply.md
+++ b/docs/dsa_repository_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Backup Repository Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/dsa_repository_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/dsa_repository_launch.md
+++ b/docs/dsa_repository_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Backup Repository Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/dsa_repository_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/dsa_repository_name.md
+++ b/docs/dsa_repository_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Backup Repository Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/dsa_repository_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/dsa_repository_review.md
+++ b/docs/dsa_repository_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Properties and Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/dsa_repository_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/edit_server.md
+++ b/docs/edit_server.md
@@ -3,7 +3,7 @@ title: "Editing Server Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/edit_server.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/editing_jobs.md
+++ b/docs/editing_jobs.md
@@ -3,14 +3,19 @@ title: "Editing Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/editing_jobs.html"
-last_updated: "8/15/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Editing Job Settings
 
 
 After you add a backup job, you can edit its settings at any time. For example, you may want to change the scheduling settings or add VMs to the job.
+
+|  |
+| --- |
+| Note |
+| If you change the backup scope of an existing job, for example, switch from individual VMs to a cluster, datastore or tag, Veeam Backup & Replication preserves and continues the existing backup chain for VMs that have already been processed. Objects that are newly added to the job are treated as new and require a full backup during the next job session. Changes that you apply when the job is running take effect during the next job session. |
 
 Editing General Settings
 

--- a/docs/editing_jobs_hv.md
+++ b/docs/editing_jobs_hv.md
@@ -3,14 +3,19 @@ title: "Editing Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/editing_jobs_hv.html"
-last_updated: "2/18/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Editing Job Settings
 
 
 After you add a backup job, you can edit its settings at any time. For example, you may want to change the scheduling settings or add VMs to the job.
+
+|  |
+| --- |
+| Note |
+| If you change the backup scope of an existing job, for example, switch from individual VMs to a cluster, datastore or tag, Veeam Backup & Replication preserves and continues the existing backup chain for VMs that have already been processed. Objects that are newly added to the job are treated as new and require a full backup during the next job session. Changes that you apply when the job is running take effect during the next job session. |
 
 Editing General Settings
 

--- a/docs/editing_jobs_hv_web.md
+++ b/docs/editing_jobs_hv_web.md
@@ -3,14 +3,19 @@ title: "Editing Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/editing_jobs_hv_web.html"
-last_updated: "9/23/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Editing Job Settings
 
 
 After you add a backup job, you can edit its settings at any time. For example, you may want to change the scheduling settings or add VMs to the job.
+
+|  |
+| --- |
+| Note |
+| If you change the backup scope of an existing job, for example, switch from individual VMs to a cluster, datastore or tag, Veeam Backup & Replication preserves and continues the existing backup chain for VMs that have already been processed. Objects that are newly added to the job are treated as new and require a full backup during the next job session. Changes that you apply when the job is running take effect during the next job session. |
 
 Editing General Settings
 

--- a/docs/editing_jobs_web.md
+++ b/docs/editing_jobs_web.md
@@ -3,14 +3,19 @@ title: "Editing Job Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/editing_jobs_web.html"
-last_updated: "9/23/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Editing Job Settings
 
 
 After you add a backup job, you can edit its settings at any time. For example, you may want to change the scheduling settings or add VMs to the job.
+
+|  |
+| --- |
+| Note |
+| If you change the backup scope of an existing job, for example, switch from individual VMs to a cluster, datastore or tag, Veeam Backup & Replication preserves and continues the existing backup chain for VMs that have already been processed. Objects that are newly added to the job are treated as new and require a full backup during the next job session. Changes that you apply when the job is running take effect during the next job session. |
 
 Editing General Settings
 

--- a/docs/external_azure_name.md
+++ b/docs/external_azure_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify External Repository Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/external_azure_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/external_before_begin.md
+++ b/docs/external_before_begin.md
@@ -3,7 +3,7 @@ title: "How External Repository Works"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/external_before_begin.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/external_repositories_add.md
+++ b/docs/external_repositories_add.md
@@ -3,7 +3,7 @@ title: "Adding External Repositories"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/external_repositories_add.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/extract_utility_console.md
+++ b/docs/extract_utility_console.md
@@ -3,7 +3,7 @@ title: "Using Extract Utility from Command Line"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/extract_utility_console.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/extract_utility_console_help.md
+++ b/docs/extract_utility_console_help.md
@@ -3,7 +3,7 @@ title: "Displaying Help Information for Utility Usage"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/extract_utility_console_help.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/extract_utility_console_interactive.md
+++ b/docs/extract_utility_console_interactive.md
@@ -3,7 +3,7 @@ title: "Running Extract Utility in Interactive Mode"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/extract_utility_console_interactive.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/extract_utility_encrypted.md
+++ b/docs/extract_utility_encrypted.md
@@ -3,7 +3,7 @@ title: "Getting Encryption Status of Backup File"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/extract_utility_encrypted.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/failback_datastore_hv.md
+++ b/docs/failback_datastore_hv.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Target Datastore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/failback_datastore_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/failback_host_hv.md
+++ b/docs/failback_host_hv.md
@@ -3,7 +3,7 @@ title: "Step 4. Select Target Host"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/failback_host_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/failback_name_hv.md
+++ b/docs/failback_name_hv.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify VM Name and VM UUID Handling"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/failback_name_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/failback_vsan.md
+++ b/docs/failback_vsan.md
@@ -3,7 +3,7 @@ title: "Failback on VSAN"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/failback_vsan.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/failover_retry_vcd.md
+++ b/docs/failover_retry_vcd.md
@@ -3,7 +3,7 @@ title: "Performing Failover Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/failover_retry_vcd.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/file_copy_byb.md
+++ b/docs/file_copy_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_copy_byb.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/file_share_backup_job_summary.md
+++ b/docs/file_share_backup_job_summary.md
@@ -3,7 +3,7 @@ title: "Step 9. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_share_backup_job_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/file_share_backup_new_file_proxy_summary.md
+++ b/docs/file_share_backup_new_file_proxy_summary.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_share_backup_new_file_proxy_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/file_share_recovery_roll_back_to_point_in_time.md
+++ b/docs/file_share_recovery_roll_back_to_point_in_time.md
@@ -3,7 +3,7 @@ title: "Rolling Back to a Point in Time"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/file_share_recovery_roll_back_to_point_in_time.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/files_to_tape_name.md
+++ b/docs/files_to_tape_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Job Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/files_to_tape_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/finish_working_with_vault_wizard.md
+++ b/docs/finish_working_with_vault_wizard.md
@@ -3,7 +3,7 @@ title: "Step 3. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/finish_working_with_vault_wizard.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/finish_working_with_wizard.md
+++ b/docs/finish_working_with_wizard.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/finish_working_with_wizard.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/gfs_media_pools.md
+++ b/docs/gfs_media_pools.md
@@ -3,7 +3,7 @@ title: "GFS Media Pools"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/gfs_media_pools.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/hv_proxy_summary.md
+++ b/docs/hv_proxy_summary.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/hv_proxy_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/ibm_storage_apply.md
+++ b/docs/ibm_storage_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ibm_storage_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/ibm_storage_review.md
+++ b/docs/ibm_storage_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/ibm_storage_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/image_create_progress.md
+++ b/docs/image_create_progress.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/image_create_progress.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/install_vbr_account.md
+++ b/docs/install_vbr_account.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify Service Account Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/install_vbr_account.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_disk_recovery_map.md
+++ b/docs/instant_disk_recovery_map.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Virtual Disks to Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_disk_recovery_map.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_disk_recovery_reason.md
+++ b/docs/instant_disk_recovery_reason.md
@@ -3,7 +3,7 @@ title: "Step 7. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_disk_recovery_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_disk_recovery_restore_point.md
+++ b/docs/instant_disk_recovery_restore_point.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_disk_recovery_restore_point.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_disk_recovery_summary.md
+++ b/docs/instant_disk_recovery_summary.md
@@ -3,7 +3,7 @@ title: "Step 8. Verify Recovery Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_disk_recovery_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_disk_recovery_vm.md
+++ b/docs/instant_disk_recovery_vm.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Source VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_disk_recovery_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_disks.md
+++ b/docs/instant_fcd_recovery_disks.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Virtual Disks to Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_disks.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_reason.md
+++ b/docs/instant_fcd_recovery_reason.md
@@ -3,7 +3,7 @@ title: "Step 8. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_restore_point.md
+++ b/docs/instant_fcd_recovery_restore_point.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_restore_point.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_summary.md
+++ b/docs/instant_fcd_recovery_summary.md
@@ -3,7 +3,7 @@ title: "Step 9. Verify Instant FCD Recovery Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_target_host.md
+++ b/docs/instant_fcd_recovery_target_host.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify Target Cluster"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_target_host.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_vm.md
+++ b/docs/instant_fcd_recovery_vm.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Source VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_fcd_recovery_write_cache.md
+++ b/docs/instant_fcd_recovery_write_cache.md
@@ -3,7 +3,7 @@ title: "Step 7. Select Destination for FCD Updates"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_fcd_recovery_write_cache.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/instant_nas_recovery_summary.md
+++ b/docs/instant_nas_recovery_summary.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/instant_nas_recovery_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/launching_new_export_wizard.md
+++ b/docs/launching_new_export_wizard.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Export Backup Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/launching_new_export_wizard.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/linux_repository_apply.md
+++ b/docs/linux_repository_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Backup Repository Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_repository_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/linux_repository_finish.md
+++ b/docs/linux_repository_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_repository_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/linux_repository_name.md
+++ b/docs/linux_repository_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Backup Repository Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_repository_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/linux_repository_review.md
+++ b/docs/linux_repository_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Properties and Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_repository_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/linux_server_summary.md
+++ b/docs/linux_server_summary.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/linux_server_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/managing_vcd_replicas.md
+++ b/docs/managing_vcd_replicas.md
@@ -3,7 +3,7 @@ title: "Managing Cloud Director Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/managing_vcd_replicas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/migrate_share_to_production_summary.md
+++ b/docs/migrate_share_to_production_summary.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/migrate_share_to_production_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/migration_architecture.md
+++ b/docs/migration_architecture.md
@@ -3,7 +3,7 @@ title: "Quick Migration Architecture"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/migration_architecture.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -3,7 +3,7 @@ title: "Naming Conventions"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/naming_conventions.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/nfs_repository_apply.md
+++ b/docs/nfs_repository_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Backup Repository Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/nfs_repository_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/nfs_repository_finish.md
+++ b/docs/nfs_repository_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/nfs_repository_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/nfs_repository_name.md
+++ b/docs/nfs_repository_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Backup Repository Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/nfs_repository_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/nfs_repository_review.md
+++ b/docs/nfs_repository_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Properties and Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/nfs_repository_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/offhost_backup_proxy_edit.md
+++ b/docs/offhost_backup_proxy_edit.md
@@ -3,7 +3,7 @@ title: "Editing Backup Proxy Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/offhost_backup_proxy_edit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/offhost_proxy_advanced.md
+++ b/docs/offhost_proxy_advanced.md
@@ -3,7 +3,7 @@ title: "Configuring Advanced Options for Off-Host Backup Proxies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/offhost_proxy_advanced.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -3,8 +3,8 @@ title: "About Veeam Backup & Replication"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/overview.html"
-last_updated: "5/11/2026"
-product_version: "13.0.1.2067"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # About Veeam Backup & Replication

--- a/docs/performing_instant_file_share_recovery.md
+++ b/docs/performing_instant_file_share_recovery.md
@@ -3,7 +3,7 @@ title: "Performing Instant File Share Recovery"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/performing_instant_file_share_recovery.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/policy_sap_hana_before.md
+++ b/docs/policy_sap_hana_before.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/policy_sap_hana_before.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/protected_computers_move.md
+++ b/docs/protected_computers_move.md
@@ -3,7 +3,7 @@ title: "Moving Unmanaged Computer to Protection Group"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/protected_computers_move.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/protection_group_hiw.md
+++ b/docs/protection_group_hiw.md
@@ -3,7 +3,7 @@ title: "Protection Groups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/protection_group_hiw.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/quick_migration_before_you_begin.md
+++ b/docs/quick_migration_before_you_begin.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/quick_migration_before_you_begin.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/quick_migration_destination.md
+++ b/docs/quick_migration_destination.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify VM Destination"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/quick_migration_destination.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/quick_migration_vms.md
+++ b/docs/quick_migration_vms.md
@@ -3,7 +3,7 @@ title: "Step 2. Select VMs to Relocate"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/quick_migration_vms.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/recovery_verification.md
+++ b/docs/recovery_verification.md
@@ -3,7 +3,7 @@ title: "Mixed Scenarios"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/recovery_verification.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/removing_vesp_database.md
+++ b/docs/removing_vesp_database.md
@@ -3,7 +3,7 @@ title: "Removing Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/removing_vesp_database.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/removing_vex_database.md
+++ b/docs/removing_vex_database.md
@@ -3,7 +3,7 @@ title: "Removing Stores"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/removing_vex_database.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_order_hv.md
+++ b/docs/replica_order_hv.md
@@ -3,7 +3,7 @@ title: "Step 6. Specify VM Replication Order"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_order_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_review_hv.md
+++ b/docs/replica_review_hv.md
@@ -3,7 +3,7 @@ title: "Step 16. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_review_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_review_vm.md
+++ b/docs/replica_review_vm.md
@@ -3,7 +3,7 @@ title: "Step 16. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_review_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_vss_exclusion_vm.md
+++ b/docs/replica_vss_exclusion_vm.md
@@ -3,7 +3,7 @@ title: "VM Guest OS File Exclusion Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_vss_exclusion_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_vss_postgresql_vm.md
+++ b/docs/replica_vss_postgresql_vm.md
@@ -3,7 +3,7 @@ title: "PostgreSQL Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_vss_postgresql_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/replica_vss_transaction_sql_hv.md
+++ b/docs/replica_vss_transaction_sql_hv.md
@@ -3,7 +3,7 @@ title: "Microsoft SQL Server Transaction Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/replica_vss_transaction_sql_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/repository_apply.md
+++ b/docs/repository_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Backup Repository Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repository_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/repository_finish.md
+++ b/docs/repository_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repository_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/repository_name.md
+++ b/docs/repository_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Backup Repository Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repository_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/repository_review.md
+++ b/docs/repository_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Properties and Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/repository_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/restore_archive_tier.md
+++ b/docs/restore_archive_tier.md
@@ -3,7 +3,7 @@ title: "Restore from Archive Tier"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_archive_tier.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/restore_azure_acc_name.md
+++ b/docs/restore_azure_acc_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Account Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_azure_acc_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/restore_backup_from_tape_review.md
+++ b/docs/restore_backup_from_tape_review.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_backup_from_tape_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/restore_olvm_rhv.md
+++ b/docs/restore_olvm_rhv.md
@@ -3,8 +3,8 @@ title: "Restore to OLVM and RHV"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_olvm_rhv.html"
-last_updated: "11/13/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Restore to OLVM and RHV
@@ -17,11 +17,11 @@ Veeam Backup & Replication allows you to recover different workloads as OLVM and
 |  |
 | --- |
 | Important |
-| To restore to OLVM and RHV, you must install oVirt KVM Plug-In for Veeam Backup & Replication on the backup server. To learn more, see the [Installation](https://helpcenter.veeam.com/docs/vbrhv/userguide/install_plugin.html?ver=7) section in the Veeam Backup for Oracle Linux Virtualization Manager and Red Hat Virtualization User Guide. |
+| To restore to OLVM and RHV, you must install Veeam Plug-In for oVirt KVM on the backup server. To learn more, see the [Installation](https://helpcenter.veeam.com/docs/vbrhv/userguide/install_plugin.html?ver=7) section in the Veeam Backup for Oracle Linux Virtualization Manager and Red Hat Virtualization User Guide. |
 
 Supported Backup Types
 
-To restore workloads to Proxmox VE, you can use the following backups:
+To restore workloads to OLVM or RHV, you can use the following backups:
 
 * Backups of VMware vSphere virtual machines created by Veeam Backup & Replication
 * Backups of VMware Cloud Director virtual machines created by Veeam Backup & Replication
@@ -34,14 +34,14 @@ To restore workloads to Proxmox VE, you can use the following backups:
 * Backups of Microsoft Azure virtual machines created by [Veeam Backup for Microsoft Azure](https://helpcenter.veeam.com/docs/vbazure/guide/overview.html?ver=8.1)
 * Backups of Google Compute Engine VM instances created by [Veeam Backup for Google Cloud](https://helpcenter.veeam.com/docs/vbgc/guide/welcome.html?ver=7)
 
-* Backups of oVirt VMs created by [Veeam Backup for OLVM and RHV](https://helpcenter.veeam.com/docs/vbrhv/userguide/overview.html?ver=7)
+* Backups of oVirt VMs created by [Veeam Plug-In for oVirt KVM](https://helpcenter.veeam.com/docs/vbrhv/userguide/overview.html?ver=7)
 * Backups of Proxmox VE VMs created by [Veeam Plug-In for Proxmox VE](https://helpcenter.veeam.com/docs/vbproxmoxve/userguide/overview.html?ver=3)
 
 * Backups of Scale Computing HyperCore VMs created by [Veeam Plug-In for Scale Computing HyperCore](https://helpcenter.veeam.com/docs/vpsch/userguide/overview.html?ver=2).
 
 Performing Restore to OLVM and RHV
 
-The restore procedure of entire workloads to oVirt KVM practically does not differ from the procedure described in the [Performing VM Restore](https://helpcenter.veeam.com/docs/vbrhv/userguide/restore_to_rhv.html?ver=7) section in the Veeam Backup for OLVM and RHV User Guide.
+The restore procedure of entire workloads to oVirt KVM practically does not differ from the procedure described in the [Performing VM Restore](https://helpcenter.veeam.com/docs/vbrhv/userguide/restore_to_rhv.html?ver=7) section in the Veeam Plug-In for oVirt KVM User Guide.
 
 [![Restore to OLVM and RHV](images/restore_kvm_vm.webp)](images/restore_kvm_vm.webp)
 

--- a/docs/restore_retrieved_data.md
+++ b/docs/restore_retrieved_data.md
@@ -3,7 +3,7 @@ title: "Restoring Retrieved Data"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restore_retrieved_data.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/restoring_document_libraries_and_lists_another_location.md
+++ b/docs/restoring_document_libraries_and_lists_another_location.md
@@ -3,7 +3,7 @@ title: "Restoring Document Libraries and Lists to Another Location"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/restoring_document_libraries_and_lists_another_location.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/review_components.md
+++ b/docs/review_components.md
@@ -3,7 +3,7 @@ title: "Step 4. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/review_components.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/roll_back_to_point_in_time_summary.md
+++ b/docs/roll_back_to_point_in_time_summary.md
@@ -3,7 +3,7 @@ title: "Step 3. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/roll_back_to_point_in_time_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/securing_backup_infrastructure.md
+++ b/docs/securing_backup_infrastructure.md
@@ -3,8 +3,8 @@ title: "Securing Backup Infrastructure"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/securing_backup_infrastructure.html"
-last_updated: "3/19/2026"
-product_version: "13.0.1.2067"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Securing Backup Infrastructure
@@ -36,6 +36,8 @@ For a Linux-based Veeam Backup & Replication server, allow only HTTPS connection
 | --- |
 | Note |
 | The account used for RDP access must not have local Administrator privileges on the jump server, and you must never use the saved credentials functionality for RDP access or any other remote console connections. To restrict users from saving RDP credentials, you can use Group Policies. For more information, see [this article](https://docs.microsoft.com/en-us/answers/questions/383902/how-to-prevent-windows-from-saving-rdp-connection.html). |
+
+* Restrict access to storage devices connected to the backup server. Inbound connections to storage devices must only be possible by authorized users connecting from trusted hosts.
 
 * Encrypt backup traffic. By default, Veeam Backup & Replication encrypts network traffic transferred between public networks. To ensure secure communication of sensitive data within the boundaries of the same network, encrypt backup traffic also in private networks. For more information, see [Enabling Traffic Encryption](enable_network_encryption.md).
 
@@ -70,7 +72,7 @@ To secure data stored in backups and replicas, consider the following recommenda
 * Encrypt data in backups. Use Veeam Backup & Replication built-in encryption to protect data in backups. For more information, see [Data Encryption](data_encryption.md).
 * Encrypt SMB traffic. If you use SMB shares in your backup infrastructure, [enable SMB signing](https://techcommunity.microsoft.com/t5/storage-at-microsoft/configure-smb-signing-with-confidence/ba-p/2418102) to prevent NTLMv2 relay attacks. Also, [enable SMB encryption](https://docs.microsoft.com/en-us/windows-server/storage/file-server/smb-security).
 * Enable immutability for backups. To protect backup files from being modified or deleted, you can make them immutable. For more information, see [Immutability for Backup Files](immutability.md).
-* Use offline media to keep backup files in addition to virtual storage. For more information, see [Backup Repositories with Rotated Drives](backup_repository_rotated.md) and [Tape Device Support](tape_device_support.md).
+* Use offline media to keep backup files in addition to virtual storage. For more information, see [Backup Repositories with Rotated Drives](backup_repository_rotated.md) and [Tape Device Support](tape_device_support.md)
 * Ensure security of mount servers. Machines performing roles of mount servers have access to the backup repositories and ESXi hosts which make them a potential source of vulnerability. Check that all required [security recommendations](general_security_considerations.md) are applied to these backup infrastructure components.
 
 Veeam Backup Enterprise Manager

--- a/docs/select_mailboxes_to_restore_mfa.md
+++ b/docs/select_mailboxes_to_restore_mfa.md
@@ -3,7 +3,7 @@ title: "Step 4. Select Mailboxes to Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/select_mailboxes_to_restore_mfa.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_apply.md
+++ b/docs/smb_apply.md
@@ -3,7 +3,7 @@ title: "Step 5. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_before_you_begin.md
+++ b/docs/smb_before_you_begin.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_before_you_begin.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_repository_apply.md
+++ b/docs/smb_repository_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Backup Repository Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_repository_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_repository_finish.md
+++ b/docs/smb_repository_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_repository_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_repository_name.md
+++ b/docs/smb_repository_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Backup Repository Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_repository_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_repository_review.md
+++ b/docs/smb_repository_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Properties and Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_repository_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_summary.md
+++ b/docs/smb_summary.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/smb_type.md
+++ b/docs/smb_type.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Server Type"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/smb_type.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/snmp_service_properties.md
+++ b/docs/snmp_service_properties.md
@@ -3,7 +3,7 @@ title: "Configuring SNMP Service Properties"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/snmp_service_properties.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/sobr_add_name.md
+++ b/docs/sobr_add_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Scale-Out Backup Repository Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sobr_add_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/sobr_add_summary.md
+++ b/docs/sobr_add_summary.md
@@ -3,7 +3,7 @@ title: "Step 7. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sobr_add_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/sobr_launch.md
+++ b/docs/sobr_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New Scale-Out Backup Repository Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sobr_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/sobr_remove.md
+++ b/docs/sobr_remove.md
@@ -3,7 +3,7 @@ title: "Removing Scale-Out Backup Repositories"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/sobr_remove.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_domain_and_credentials_compare.md
+++ b/docs/specify_domain_and_credentials_compare.md
@@ -3,7 +3,7 @@ title: "Step 1. Specify Domain and Credentials"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_domain_and_credentials_compare.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_export_reason.md
+++ b/docs/specify_export_reason.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Export Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_export_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_export_reason_hv.md
+++ b/docs/specify_export_reason_hv.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Export Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_export_reason_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_media_vault_name.md
+++ b/docs/specify_media_vault_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Media Vault Name"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_media_vault_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_target_site.md
+++ b/docs/specify_target_site.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target Site Alias"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_target_site.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_target_site_doc_onprem.md
+++ b/docs/specify_target_site_doc_onprem.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Target Site Web Address and Credentials"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_target_site_doc_onprem.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_target_site_lib_onprem.md
+++ b/docs/specify_target_site_lib_onprem.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Target Site Web Address and Credentials"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_target_site_lib_onprem.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_target_site_list_m365.md
+++ b/docs/specify_target_site_list_m365.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Target Site and List"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_target_site_list_m365.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_target_site_m365.md
+++ b/docs/specify_target_site_m365.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Target Site Web Address"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_target_site_m365.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/specify_user_account_single.md
+++ b/docs/specify_user_account_single.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify User Account"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/specify_user_account_single.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/storage_restore_netapp_cloning.md
+++ b/docs/storage_restore_netapp_cloning.md
@@ -3,7 +3,7 @@ title: "Traditional LUN Cloning"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/storage_restore_netapp_cloning.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/storage_restore_netapp_flexclone.md
+++ b/docs/storage_restore_netapp_flexclone.md
@@ -3,7 +3,7 @@ title: "FlexClone"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/storage_restore_netapp_flexclone.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/surebackup_job_joblink_hv.md
+++ b/docs/surebackup_job_joblink_hv.md
@@ -3,8 +3,8 @@ title: "Step 5. Link Backup Job"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_job_joblink_hv.html"
-last_updated: "1/22/2026"
-product_version: "13.0.1.1071"
+last_updated: "6/8/2026"
+product_version: "13.0.2.29"
 ---
 
 # Step 5. Link Backup Job
@@ -48,7 +48,7 @@ To remove an object from the list, select it and click Remove.
 |  |
 | --- |
 | Note |
-| Removed or deleted machines can be excluded from the SureBackup job using the From backups option. |
+| Removed or deleted machines cannot be excluded from a SureBackup job. |
 
 ![Step 5. Link Backup Job](images/surebackup_job_link_121.webp)
 

--- a/docs/surebackup_job_joblink_vm.md
+++ b/docs/surebackup_job_joblink_vm.md
@@ -3,8 +3,8 @@ title: "Step 5. Link Backup or Replication Job"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_job_joblink_vm.html"
-last_updated: "1/22/2026"
-product_version: "13.0.1.1071"
+last_updated: "6/8/2026"
+product_version: "13.0.2.29"
 ---
 
 # Step 5. Link Backup or Replication Job
@@ -17,7 +17,7 @@ You can link a backup or replication job to the SureBackup job or skip this step
 |  |
 | --- |
 | Note |
-| You cannot link backup copy jobs to the SureBackup job. |
+| You cannot link backup copy jobs to a SureBackup job. |
 
 Linking Backup or Replication Job
 
@@ -48,7 +48,7 @@ To remove an object from the list, select it and click Remove.
 |  |
 | --- |
 | Note |
-| Removed or deleted machines can be excluded from the SureBackup job using the From backups option. |
+| Removed or deleted machines cannot be excluded from a SureBackup job. |
 
 ![Step 5. Link Backup or Replication Job](images/surebackup_job_link_121.webp)
 

--- a/docs/surebackup_job_review_hv.md
+++ b/docs/surebackup_job_review_hv.md
@@ -3,7 +3,7 @@ title: "Step 9. Review Job Summary and Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surebackup_job_review_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/surereplica_application_group.md
+++ b/docs/surereplica_application_group.md
@@ -3,7 +3,7 @@ title: "Application Group"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surereplica_application_group.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/surereplica_vlab_config.md
+++ b/docs/surereplica_vlab_config.md
@@ -3,7 +3,7 @@ title: "Virtual Lab Configuration"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/surereplica_vlab_config.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/system_requirements_limitations.md
+++ b/docs/system_requirements_limitations.md
@@ -3,7 +3,7 @@ title: "Considerations and Limitations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/system_requirements_limitations.html"
-last_updated: "6/3/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 
@@ -55,7 +55,8 @@ Consider the following requirements and limitations:
 
 * Names of port groups/segments/networks must be unique.
 
-* [For VMware vSphere] VMware NSX-T 2.3 or later is supported with N-VDS for VMware vSphere and VMware Cloud on AWS/Dell.
-* [For VMware vSphere] VMware NSX-T 3.0 or later is supported with VDS for VMware vSphere and VMware Cloud on AWS/Dell.
+* [For VMware vSphere] VMware NSX-T 2.X (starting from 2.3) is supported with N-VDS for VMware vSphere and VMware Cloud on AWS/Dell.
+* [For VMware vSphere] VMware NSX-T 3.X is supported with VDS for VMware vSphere and VMware Cloud on AWS/Dell.
+* [For VMware vSphere] VMware NSX 4.X (up to 4.2.3.2) and 9.0 are supported with VDS for VMware vSphere and VMware Cloud on AWS/Dell.
 
 

--- a/docs/tape_alert.md
+++ b/docs/tape_alert.md
@@ -3,7 +3,7 @@ title: "Tape Alerts"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tape_alert.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/tape_alerts.md
+++ b/docs/tape_alerts.md
@@ -3,7 +3,7 @@ title: "Tape Drive Alerts"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tape_alerts.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/tape_backup_sets.md
+++ b/docs/tape_backup_sets.md
@@ -3,7 +3,7 @@ title: "Backup Sets"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tape_backup_sets.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/tape_changer_alerts.md
+++ b/docs/tape_changer_alerts.md
@@ -3,7 +3,7 @@ title: "Tape Changer Alerts"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tape_changer_alerts.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/tape_copy_source.md
+++ b/docs/tape_copy_source.md
@@ -3,8 +3,8 @@ title: "Step 2. Choose Source Tapes to Copy"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tape_copy_source.html"
-last_updated: "3/14/2025"
-product_version: "13.0.1.1071"
+last_updated: "6/5/2026"
+product_version: "13.0.2.29"
 ---
 
 # Step 2. Choose Source Tapes to Copy
@@ -15,9 +15,17 @@ At the Source Tapes step of the wizard, select source tapes to copy. The tape th
 1. Click Add. Veeam Backup & Replication opens the Select Tapes window listing all media pools and tapes in them available for copying.
 2. In the Select Tapes window, navigate to the required media pool and select the tape you want to copy.
 
-Within one tape copy session, you can copy tapes of one type only: either tapes from a regular media pool, or tapes from a GFS media pool. You cannot combine them.
+|  |
+| --- |
+| Note |
+| Within one tape copy session, you can copy tapes of one type only: either tapes from a regular media pool, or tapes from a GFS media pool. You cannot combine them. |
 
-When writing backup files to tapes, there can be situations where a file does not fit on a tape. Then Veeam Backup & Replication divides it into parts and writes to several tapes, which are then considered dependent. Veeam Backup & Replication tracks this. When you are copying data from a tape that contains only one part of the backup file, Veeam Backup & Replication detects that. When you click Next, Veeam Backup & Replication informs you which tapes contain other parts of the file and prompts you to add these tapes to the list for copying complete content. You can agree to add these tapes to the job. Then Veeam Backup & Replication will copy these tapes marked as Partially cloned in the Copy option column only partially: it will copy only data required for cloning full content of the initially selected tapes in the consistent manner. Or you can refuse to add dependent tapes for copying. Then Veeam Backup & Replication will not copy files that are not complete from initially selected tapes. The Used size column shows the total size of the backups/files on each tape that will be copied. It does not include encrypted backups that are skipped when copying tapes or file parts that do not have accompanying file parts stored on dependent tapes.
+When writing backup files to tapes, there can be situations where a file does not fit on a tape. Then Veeam Backup & Replication divides it into parts and writes it to several tapes, which are then considered dependent. Veeam Backup & Replication tracks what parts of the file are on which tape. When you are copying data from a tape that contains only one part of the backup file, Veeam Backup & Replication detects that and informs you which tapes contain the remaining parts of the file. You will be prompted to add these tapes to the list to make a complete file copy:
+
+* If you agree to add these tapes to the job, the tapes will be added to the list of tapes to copy and marked as Partial Copy in the Copy option column. Veeam Backup & Replication will copy only the data required for cloning full content of the initially selected tapes in the consistent manner.
+* If you refuse to add dependent tapes for copying, Veeam Backup & Replication will not copy incomplete files from initially selected tapes. These files will be skipped.
+
+The Used size column shows the total size of the backups/files on each tape that will be copied. It does not include encrypted backups or incomplete files which are skipped from processing.
 
 To remove tapes from the copy list, select the tapes and click Remove.
 

--- a/docs/tapes_availability.md
+++ b/docs/tapes_availability.md
@@ -3,7 +3,7 @@ title: "Tapes Availability and Write-Protection"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tapes_availability.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/tenant_restore_from_tape.md
+++ b/docs/tenant_restore_from_tape.md
@@ -3,7 +3,7 @@ title: "Tenant Restore from Tape"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/tenant_restore_from_tape.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/updating_tapeserver.md
+++ b/docs/updating_tapeserver.md
@@ -3,7 +3,7 @@ title: "Updating Tape Servers"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/updating_tapeserver.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/upgrade_vbr_license_agreement.md
+++ b/docs/upgrade_vbr_license_agreement.md
@@ -3,7 +3,7 @@ title: "Step 3. Read and Accept License Agreement"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/upgrade_vbr_license_agreement.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_app_processing.md
+++ b/docs/vcd_app_processing.md
@@ -3,7 +3,7 @@ title: "Application-Aware Processing and Transaction Logs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_app_processing.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_disable.md
+++ b/docs/vcd_cdp_disable.md
@@ -3,7 +3,7 @@ title: "Disabling and Deleting Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_disable.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_edit.md
+++ b/docs/vcd_cdp_edit.md
@@ -3,7 +3,7 @@ title: "Editing Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_edit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback.md
+++ b/docs/vcd_cdp_failback.md
@@ -3,7 +3,7 @@ title: "Failback"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_commit.md
+++ b/docs/vcd_cdp_failback_commit.md
@@ -3,7 +3,7 @@ title: "Failback Commit"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_commit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_commit_retry.md
+++ b/docs/vcd_cdp_failback_commit_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Commit Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_commit_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_dest.md
+++ b/docs/vcd_cdp_failback_dest.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Failback Destination"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_dest.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_launch.md
+++ b/docs/vcd_cdp_failback_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Failback Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_network.md
+++ b/docs/vcd_cdp_failback_network.md
@@ -3,7 +3,7 @@ title: "Step 6. Configure Network Mapping"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_network.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_quick_rollback.md
+++ b/docs/vcd_cdp_failback_quick_rollback.md
@@ -3,7 +3,7 @@ title: "Quick Rollback"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_quick_rollback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_replicas.md
+++ b/docs/vcd_cdp_failback_replicas.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_replicas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_retry.md
+++ b/docs/vcd_cdp_failback_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_schedule.md
+++ b/docs/vcd_cdp_failback_schedule.md
@@ -3,7 +3,7 @@ title: "Step 8. Schedule Switch to Production vApps"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_schedule.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_storage.md
+++ b/docs/vcd_cdp_failback_storage.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Storage Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_storage.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_summary.md
+++ b/docs/vcd_cdp_failback_summary.md
@@ -3,7 +3,7 @@ title: "Step 9. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_switching_time.md
+++ b/docs/vcd_cdp_failback_switching_time.md
@@ -3,7 +3,7 @@ title: "Changing Switching Time"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_switching_time.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_undo.md
+++ b/docs/vcd_cdp_failback_undo.md
@@ -3,7 +3,7 @@ title: "Failback Undo"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_undo.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failback_undo_retry.md
+++ b/docs/vcd_cdp_failback_undo_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Undo Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failback_undo_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_launch.md
+++ b/docs/vcd_cdp_failover_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Failover Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_reason.md
+++ b/docs/vcd_cdp_failover_reason.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Failover Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_retry.md
+++ b/docs/vcd_cdp_failover_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failover Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_summary.md
+++ b/docs/vcd_cdp_failover_summary.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_summary.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_undo.md
+++ b/docs/vcd_cdp_failover_undo.md
@@ -3,7 +3,7 @@ title: "Failover Undo"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_undo.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_failover_workloads.md
+++ b/docs/vcd_cdp_failover_workloads.md
@@ -3,7 +3,7 @@ title: "Step 2. Select vApps"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_failover_workloads.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_manage_policies.md
+++ b/docs/vcd_cdp_manage_policies.md
@@ -3,7 +3,7 @@ title: "Managing Cloud Director CDP Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_manage_policies.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_perm_failover.md
+++ b/docs/vcd_cdp_perm_failover.md
@@ -3,7 +3,7 @@ title: "Permanent Failover"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_perm_failover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_perm_failover_restry.md
+++ b/docs/vcd_cdp_perm_failover_restry.md
@@ -3,7 +3,7 @@ title: "Performing Permanent Failover Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_perm_failover_restry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_exclude.md
+++ b/docs/vcd_cdp_policy_exclude.md
@@ -3,7 +3,7 @@ title: "Step 4. Exclude Objects"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_exclude.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_guest_scripts.md
+++ b/docs/vcd_cdp_policy_guest_scripts.md
@@ -3,7 +3,7 @@ title: "Script Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_guest_scripts.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_launch.md
+++ b/docs/vcd_cdp_policy_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch New VMware Cloud Director CDP Policy Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_network.md
+++ b/docs/vcd_cdp_policy_network.md
@@ -3,7 +3,7 @@ title: "Step 7. Configure Network Mapping"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_network.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_notification.md
+++ b/docs/vcd_cdp_policy_notification.md
@@ -3,7 +3,7 @@ title: "Step 10. Specify Notification Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_notification.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_oracle_trans_logs.md
+++ b/docs/vcd_cdp_policy_oracle_trans_logs.md
@@ -3,7 +3,7 @@ title: "Oracle Archived Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_oracle_trans_logs.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_order.md
+++ b/docs/vcd_cdp_policy_order.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify vApp Processing Order"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_order.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_schedule.md
+++ b/docs/vcd_cdp_policy_schedule.md
@@ -3,7 +3,7 @@ title: "Step 11. Configure Schedule"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_schedule.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_policy_sql_trans_logs.md
+++ b/docs/vcd_cdp_policy_sql_trans_logs.md
@@ -3,7 +3,7 @@ title: "Microsoft SQL Server Transaction Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_policy_sql_trans_logs.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_replica_manage.md
+++ b/docs/vcd_cdp_replica_manage.md
@@ -3,7 +3,7 @@ title: "Managing Cloud Director CDP Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_replica_manage.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_rescanning_replicas.md
+++ b/docs/vcd_cdp_rescanning_replicas.md
@@ -3,7 +3,7 @@ title: "Rescanning Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_rescanning_replicas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_cdp_undoing_fo_retry.md
+++ b/docs/vcd_cdp_undoing_fo_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failover Undo Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_cdp_undoing_fo_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_deleting.md
+++ b/docs/vcd_deleting.md
@@ -3,7 +3,7 @@ title: "Deleting from Disk"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_deleting.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback.md
+++ b/docs/vcd_failback.md
@@ -3,7 +3,7 @@ title: "Failback"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_commit.md
+++ b/docs/vcd_failback_commit.md
@@ -3,7 +3,7 @@ title: "Failback Commit"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_commit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_commit_retry.md
+++ b/docs/vcd_failback_commit_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Commit Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_commit_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_destination.md
+++ b/docs/vcd_failback_destination.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Failback Destination"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_destination.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_finish.md
+++ b/docs/vcd_failback_finish.md
@@ -3,7 +3,7 @@ title: "Step 9. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_launch.md
+++ b/docs/vcd_failback_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Failback Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_quick_rollback.md
+++ b/docs/vcd_failback_quick_rollback.md
@@ -3,7 +3,7 @@ title: "Quick Rollback"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_quick_rollback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_retry.md
+++ b/docs/vcd_failback_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_storage_policy.md
+++ b/docs/vcd_failback_storage_policy.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Storage Policies"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_storage_policy.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_undo.md
+++ b/docs/vcd_failback_undo.md
@@ -3,7 +3,7 @@ title: "Failback Undo"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_undo.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failback_undo_retry.md
+++ b/docs/vcd_failback_undo_retry.md
@@ -3,7 +3,7 @@ title: "Performing Failback Undo Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failback_undo_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_byb.md
+++ b/docs/vcd_failover_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_byb.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_finish.md
+++ b/docs/vcd_failover_finish.md
@@ -3,7 +3,7 @@ title: "Step 5. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_launch.md
+++ b/docs/vcd_failover_launch.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Failover Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_launch.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_reason.md
+++ b/docs/vcd_failover_reason.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Failover Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_undo.md
+++ b/docs/vcd_failover_undo.md
@@ -3,7 +3,7 @@ title: "Failover Undo"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_undo.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_failover_vapps_select.md
+++ b/docs/vcd_failover_vapps_select.md
@@ -3,7 +3,7 @@ title: "Step 2. Select vApps"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_failover_vapps_select.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_network_failback.md
+++ b/docs/vcd_network_failback.md
@@ -3,7 +3,7 @@ title: "Step 6. Configure Network Mapping"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_network_failback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_orgvdc_failback.md
+++ b/docs/vcd_orgvdc_failback.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Organization VDCs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_orgvdc_failback.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_perform_perm_failover_retry.md
+++ b/docs/vcd_perform_perm_failover_retry.md
@@ -3,7 +3,7 @@ title: "Performing Permanent Failover Retry"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_perform_perm_failover_retry.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_permanent_failover.md
+++ b/docs/vcd_permanent_failover.md
@@ -3,7 +3,7 @@ title: "Permanent Failover"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_permanent_failover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_replica_data_transfer.md
+++ b/docs/vcd_replica_data_transfer.md
@@ -3,7 +3,7 @@ title: "Step 10. Specify Data Transfer Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_replica_data_transfer.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_replica_guest_exclusions.md
+++ b/docs/vcd_replica_guest_exclusions.md
@@ -3,7 +3,7 @@ title: "Guest OS File Exclusion Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_replica_guest_exclusions.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_replication_oracle_logs.md
+++ b/docs/vcd_replication_oracle_logs.md
@@ -3,7 +3,7 @@ title: "Oracle Archived Log Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_replication_oracle_logs.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_replication_postgresql.md
+++ b/docs/vcd_replication_postgresql.md
@@ -3,7 +3,7 @@ title: "PostgreSQL Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_replication_postgresql.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_replication_vapps.md
+++ b/docs/vcd_replication_vapps.md
@@ -3,7 +3,7 @@ title: "Step 3. Select vApps to Replicate"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_replication_vapps.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_rescanning_replicas.md
+++ b/docs/vcd_rescanning_replicas.md
@@ -3,7 +3,7 @@ title: "Rescanning Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_rescanning_replicas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_target_vapp.md
+++ b/docs/vcd_target_vapp.md
@@ -3,7 +3,7 @@ title: "Step 7. Select Target vApp"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_target_vapp.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcd_vapps_failback_select.md
+++ b/docs/vcd_vapps_failback_select.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Replicas"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcd_vapps_failback_select.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_director_full_vm_restore_byb.md
+++ b/docs/vcloud_director_full_vm_restore_byb.md
@@ -3,7 +3,7 @@ title: "Before You Begin"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_director_full_vm_restore_byb.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_director_full_vm_restore_network.md
+++ b/docs/vcloud_director_full_vm_restore_network.md
@@ -3,7 +3,7 @@ title: "Step 6. Select Destination Network"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_director_full_vm_restore_network.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_director_full_vm_restore_profile.md
+++ b/docs/vcloud_director_full_vm_restore_profile.md
@@ -3,7 +3,7 @@ title: "Step 8. Select Storage Policy and Datastores"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_director_full_vm_restore_profile.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_director_vapp_restore_reason.md
+++ b/docs/vcloud_director_vapp_restore_reason.md
@@ -3,7 +3,7 @@ title: "Step 10. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_director_vapp_restore_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_director_vm_restore.md
+++ b/docs/vcloud_director_vm_restore.md
@@ -3,7 +3,7 @@ title: "Data Recovery for VMware Cloud Director"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_director_vm_restore.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_instant_to_vcd_destination.md
+++ b/docs/vcloud_instant_to_vcd_destination.md
@@ -3,7 +3,7 @@ title: "Step 5. Select Destination for Restored VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_instant_to_vcd_destination.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_instant_to_vcd_reason.md
+++ b/docs/vcloud_instant_to_vcd_reason.md
@@ -3,7 +3,7 @@ title: "Step 9. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_instant_to_vcd_reason.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_instant_to_vcd_vm.md
+++ b/docs/vcloud_instant_to_vcd_vm.md
@@ -3,7 +3,7 @@ title: "Step 2. Select VMs"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_instant_to_vcd_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vcloud_regular_vm_restore.md
+++ b/docs/vcloud_regular_vm_restore.md
@@ -3,7 +3,7 @@ title: "How Restore of Regular and Standalone VMs to VMware Cloud Director Works
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vcloud_regular_vm_restore.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_account_state_containers.md
+++ b/docs/vead_account_state_containers.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Account State"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_account_state_containers.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_exporting_objects.md
+++ b/docs/vead_exporting_objects.md
@@ -3,7 +3,7 @@ title: "Exporting Objects"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_exporting_objects.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_location_containers.md
+++ b/docs/vead_location_containers.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Restore Location"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_location_containers.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_one_click_restore.md
+++ b/docs/vead_one_click_restore.md
@@ -3,7 +3,7 @@ title: "Using 1-Click Restore"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_one_click_restore.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_restore_wizard.md
+++ b/docs/vead_restore_wizard.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Restore Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_restore_wizard.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_restore_wizard_2.md
+++ b/docs/vead_restore_wizard_2.md
@@ -3,7 +3,7 @@ title: "Step 1. Launch Restore Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_restore_wizard_2.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_specify_account_state_objects.md
+++ b/docs/vead_specify_account_state_objects.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Account State"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_specify_account_state_objects.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vead_standalone_databases.md
+++ b/docs/vead_standalone_databases.md
@@ -3,7 +3,7 @@ title: "Standalone Databases Management"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vead_standalone_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veeam_cloud_connect.md
+++ b/docs/veeam_cloud_connect.md
@@ -3,7 +3,7 @@ title: "Veeam Cloud Connect"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veeam_cloud_connect.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vehana_restore_multiple.md
+++ b/docs/vehana_restore_multiple.md
@@ -3,7 +3,7 @@ title: "Restoring Multiple Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vehana_restore_multiple.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veod_copy_target_folder.md
+++ b/docs/veod_copy_target_folder.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Target Folder"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veod_copy_target_folder.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veod_copy_target_user.md
+++ b/docs/veod_copy_target_user.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target User"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veod_copy_target_user.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veod_planning_and_prep.md
+++ b/docs/veod_planning_and_prep.md
@@ -3,7 +3,7 @@ title: "Planning and Preparation"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veod_planning_and_prep.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veod_removing_database.md
+++ b/docs/veod_removing_database.md
@@ -3,7 +3,7 @@ title: "Removing Organizations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veod_removing_database.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veor_ptsr_fine_tune.md
+++ b/docs/veor_ptsr_fine_tune.md
@@ -3,7 +3,7 @@ title: "Step 3. Fine-Tune Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veor_ptsr_fine_tune.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/veor_rman_export_custom_frp.md
+++ b/docs/veor_rman_export_custom_frp.md
@@ -3,7 +3,7 @@ title: "Step 3. Fine-Tune Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/veor_rman_export_custom_frp.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_multiple_latest_finalize_ir_session.md
+++ b/docs/vep_ir_multiple_latest_finalize_ir_session.md
@@ -3,7 +3,7 @@ title: "Step 3. Finalize Instant Recovery Session"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_multiple_latest_finalize_ir_session.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_multiple_latest_specify_switchover_settings.md
+++ b/docs/vep_ir_multiple_latest_specify_switchover_settings.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_multiple_latest_specify_switchover_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_multiple_pit_specify_switchover_settings.md
+++ b/docs/vep_ir_multiple_pit_specify_switchover_settings.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_multiple_pit_specify_switchover_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_multiple_tas.md
+++ b/docs/vep_ir_multiple_tas.md
@@ -3,7 +3,7 @@ title: "Instant Recovery to Another Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_multiple_tas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_multiple_tas_specify_switchover_settings.md
+++ b/docs/vep_ir_multiple_tas_specify_switchover_settings.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_multiple_tas_specify_switchover_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_single_latest_specify_switchover_settings.md
+++ b/docs/vep_ir_single_latest_specify_switchover_settings.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_single_latest_specify_switchover_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_single_pit_finalize_ir_session.md
+++ b/docs/vep_ir_single_pit_finalize_ir_session.md
@@ -3,7 +3,7 @@ title: "Step 4. Finalize Instant Recovery Session"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_single_pit_finalize_ir_session.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ir_single_pit_specify_switchover_settings.md
+++ b/docs/vep_ir_single_pit_specify_switchover_settings.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ir_single_pit_specify_switchover_settings.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_ptsr.md
+++ b/docs/vep_ptsr.md
@@ -3,7 +3,7 @@ title: "Publishing to Specified Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_ptsr.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_restore_multiple_tas.md
+++ b/docs/vep_restore_multiple_tas.md
@@ -3,7 +3,7 @@ title: "Restoring to Another Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_restore_multiple_tas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_restore_single_tas.md
+++ b/docs/vep_restore_single_tas.md
@@ -3,7 +3,7 @@ title: "Restoring to Another Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_restore_single_tas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_restoring_multiple_instances.md
+++ b/docs/vep_restoring_multiple_instances.md
@@ -3,7 +3,7 @@ title: "Restoring Multiple Instances"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_restoring_multiple_instances.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vep_restoring_single_instance.md
+++ b/docs/vep_restoring_single_instance.md
@@ -3,7 +3,7 @@ title: "Restoring Single Instance"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vep_restoring_single_instance.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_adding_vbo_databases.md
+++ b/docs/vesp_adding_vbo_databases.md
@@ -3,7 +3,7 @@ title: "Adding Veeam Backup for Microsoft 365 Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_adding_vbo_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_restore_documents_another_location.md
+++ b/docs/vesp_restore_documents_another_location.md
@@ -3,7 +3,7 @@ title: "Restoring Documents and List Items to Another Location"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_restore_documents_another_location.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_restore_item_target_doc.md
+++ b/docs/vesp_restore_item_target_doc.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target List"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_restore_item_target_doc.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_restore_lib.md
+++ b/docs/vesp_restore_lib.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target List"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_restore_lib.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_restore_lib_onprem.md
+++ b/docs/vesp_restore_lib_onprem.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Target List"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_restore_lib_onprem.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesp_restore_sites_another_location.md
+++ b/docs/vesp_restore_sites_another_location.md
@@ -3,7 +3,7 @@ title: "Restoring Sites to Another Location"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesp_restore_sites_another_location.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_bak_multiple_pit_select_databases.md
+++ b/docs/vesql_bak_multiple_pit_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_bak_multiple_pit_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_bak_multiple_tdl_select_databases.md
+++ b/docs/vesql_bak_multiple_tdl_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_bak_multiple_tdl_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_exporting_bak_point_1.md
+++ b/docs/vesql_exporting_bak_point_1.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_exporting_bak_point_1.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_instant_another_server.md
+++ b/docs/vesql_instant_another_server.md
@@ -3,7 +3,7 @@ title: "Instant Recovery to Another Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_instant_another_server.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_instant_latest_switchover.md
+++ b/docs/vesql_instant_latest_switchover.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_instant_latest_switchover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_instant_multiple_tas_select_databases.md
+++ b/docs/vesql_instant_multiple_tas_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_instant_multiple_tas_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_instant_point_finish.md
+++ b/docs/vesql_instant_point_finish.md
@@ -3,7 +3,7 @@ title: "Step 5. Finalize Instant Recovery Session"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_instant_point_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_instant_point_switchover.md
+++ b/docs/vesql_instant_point_switchover.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_instant_point_switchover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_latest.md
+++ b/docs/vesql_ir_multiple_latest.md
@@ -3,7 +3,7 @@ title: "Instant Recovery of Latest State"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_latest.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_latest_finish.md
+++ b/docs/vesql_ir_multiple_latest_finish.md
@@ -3,7 +3,7 @@ title: "Step 4. Finalize Instant Recovery Session"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_latest_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_latest_select_databases.md
+++ b/docs/vesql_ir_multiple_latest_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_latest_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_latest_switchover.md
+++ b/docs/vesql_ir_multiple_latest_switchover.md
@@ -3,7 +3,7 @@ title: "Step 3. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_latest_switchover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_pit_select_databases.md
+++ b/docs/vesql_ir_multiple_pit_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_pit_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_pit_switchover.md
+++ b/docs/vesql_ir_multiple_pit_switchover.md
@@ -3,7 +3,7 @@ title: "Step 4. Specify Switchover Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_pit_switchover.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_ir_multiple_tas.md
+++ b/docs/vesql_ir_multiple_tas.md
@@ -3,7 +3,7 @@ title: "Instant Recovery to Another Server"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_ir_multiple_tas.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_mdf_multiple_pit_select_databases.md
+++ b/docs/vesql_mdf_multiple_pit_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_mdf_multiple_pit_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_mdf_multiple_tdl_select_databases.md
+++ b/docs/vesql_mdf_multiple_tdl_select_databases.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_mdf_multiple_tdl_select_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_remove_database.md
+++ b/docs/vesql_remove_database.md
@@ -3,7 +3,7 @@ title: "Removing Standalone Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_remove_database.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_restore_select_databases_multiple.md
+++ b/docs/vesql_restore_select_databases_multiple.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_restore_select_databases_multiple.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vesql_restore_select_databases_multiple_pit.md
+++ b/docs/vesql_restore_select_databases_multiple_pit.md
@@ -3,7 +3,7 @@ title: "Step 2. Select Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vesql_restore_select_databases_multiple_pit.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vet_adding_vbo_databases.md
+++ b/docs/vet_adding_vbo_databases.md
@@ -3,7 +3,7 @@ title: "Adding Veeam Backup for Microsoft 365 Databases"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vet_adding_vbo_databases.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vet_ports.md
+++ b/docs/vet_ports.md
@@ -3,7 +3,7 @@ title: "Ports"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vet_ports.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vet_prerequisites.md
+++ b/docs/vet_prerequisites.md
@@ -3,7 +3,7 @@ title: "Planning and Preparation"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vet_prerequisites.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vet_removing_database.md
+++ b/docs/vet_removing_database.md
@@ -3,7 +3,7 @@ title: "Removing Organizations"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vet_removing_database.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vet_restore_select_teams.md
+++ b/docs/vet_restore_select_teams.md
@@ -3,7 +3,7 @@ title: "Step 4. Select Teams"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vet_restore_select_teams.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/viewing_restored_files.md
+++ b/docs/viewing_restored_files.md
@@ -3,7 +3,7 @@ title: "Viewing Restored Backups"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/viewing_restored_files.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vm_copy_finish.md
+++ b/docs/vm_copy_finish.md
@@ -3,7 +3,7 @@ title: "Step 8. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vm_copy_finish.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vm_copy_name.md
+++ b/docs/vm_copy_name.md
@@ -3,7 +3,7 @@ title: "Step 2. Specify Job Name and Description"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vm_copy_name.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_point_hv.md
+++ b/docs/vmfile_restore_point_hv.md
@@ -3,7 +3,7 @@ title: "Step 3. Select Restore Point"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_point_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_reason_vm.md
+++ b/docs/vmfile_restore_reason_vm.md
@@ -3,7 +3,7 @@ title: "Step 5. Specify Restore Reason"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_reason_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_summary_hv.md
+++ b/docs/vmfile_restore_summary_hv.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_summary_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_summary_vm.md
+++ b/docs/vmfile_restore_summary_vm.md
@@ -3,7 +3,7 @@ title: "Step 6. Finish Working with Wizard"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_summary_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_vms_hv.md
+++ b/docs/vmfile_restore_vms_hv.md
@@ -3,7 +3,7 @@ title: "Step 2. Select VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_vms_hv.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmfile_restore_vms_vm.md
+++ b/docs/vmfile_restore_vms_vm.md
@@ -3,7 +3,7 @@ title: "Step 2. Select VM"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmfile_restore_vms_vm.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/vmware_server_apply.md
+++ b/docs/vmware_server_apply.md
@@ -3,7 +3,7 @@ title: "Step 4. Apply Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/vmware_server_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/wan_components.md
+++ b/docs/wan_components.md
@@ -3,7 +3,7 @@ title: "Step 4. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/wan_components.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/wasabi_apply.md
+++ b/docs/wasabi_apply.md
@@ -3,7 +3,7 @@ title: "Step 7. Apply Settings"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/wasabi_apply.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/wasabi_review.md
+++ b/docs/wasabi_review.md
@@ -3,7 +3,7 @@ title: "Step 6. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/wasabi_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 

--- a/docs/windows_server_review.md
+++ b/docs/windows_server_review.md
@@ -3,7 +3,7 @@ title: "Step 4. Review Components"
 product: "vbr"
 doc_type: "userguide"
 source_url: "https://helpcenter.veeam.com/docs/vbr/userguide/windows_server_review.html"
-last_updated: "6/4/2026"
+last_updated: "6/8/2026"
 product_version: "13.0.2.29"
 ---
 


### PR DESCRIPTION
## Documentation Update - VBR

Scraped from [Veeam Help Center](https://helpcenter.veeam.com) on 2026-06-09.

### Summary

| Type | New | Updated (Content) | Updated (Metadata) | Deleted |
|------|-----|-------------------|-------------------|---------|
| Markdown | 0 | 14 | 393 | 0 |
| Images | 0 | 0 | - | 0 |
### Content Updates (14)

#### Cloud (1)

| File | Changes | Summary |
|------|---------|---------|
| `docs/cloud/cloud_connect_limitations.md` | +3/-3 | Clarified instant recovery support for Nutanix AHV from cloud repository backups. |

#### Userguide (13)

| File | Changes | Summary |
|------|---------|---------|
| `docs/backup_job_limitations.md` | +4/-3 | Updated limitations for using replicas as a source for backup jobs and added note on 4K native disks. |
| `docs/backup_job_storage_hv.md` | +3/-3 | Updated backup job mapping to use the term "available" backups. |
| `docs/backup_job_storage_vm.md` | +3/-3 | Updated backup job mapping to use the term "available" backups. |
| `docs/editing_jobs.md` | +7/-2 | Added note on preserving existing backup chains when changing backup scope. |
| `docs/editing_jobs_hv.md` | +7/-2 | Added note on preserving existing backup chains when changing backup scope. |
| `docs/editing_jobs_hv_web.md` | +7/-2 | Added note on preserving existing backup chains when changing backup scope. |
| `docs/editing_jobs_web.md` | +7/-2 | Added note on preserving existing backup chains when changing backup scope. |
| `docs/restore_olvm_rhv.md` | +6/-6 | Updated plugin name and restore procedure for OLVM and RHV. |
| `docs/securing_backup_infrastructure.md` | +5/-3 | Added recommendation to restrict access to storage devices connected to the backup server. |
| `docs/surebackup_job_joblink_hv.md` | +3/-3 | Clarified exclusion of removed or deleted machines from SureBackup jobs. |
| `docs/surebackup_job_joblink_vm.md` | +4/-4 | Clarified exclusion of removed or deleted machines from SureBackup jobs. |
| `docs/system_requirements_limitations.md` | +4/-3 | Updated VMware NSX-T and NSX version support. |
| `docs/tape_copy_source.md` | +12/-4 | Updated tape copy process to reflect new behavior for dependent tapes. |


### Metadata-Only Updates (393)

<details><summary>393 files with only frontmatter changes (version, date)</summary>

- `docs/add_gfs_media_pool_name.md`
- `docs/add_gfs_media_pool_set.md`
- `docs/add_media_pool_name.md`
- `docs/add_media_pool_review.md`
- `docs/add_media_pool_set.md`
- `docs/agent_job_manage_job.md`
- `docs/agent_job_manage_policy.md`
- `docs/agent_policy_target_set_unix.md`
- `docs/ahv_instant_recovery.md`
- `docs/ahv_ir_target_container_ahv.md`
- `docs/ahv_ir_workloads_ahv.md`
- `docs/appgroup_launch_hv.md`
- `docs/appgroup_name_hv.md`
- `docs/appgroup_review_hv.md`
- `docs/assess_results.md`
- `docs/backup_copy_advanced_notifications_hana.md`
- `docs/backup_copy_advanced_notifications_rman.md`
- `docs/backup_copy_advanced_notifications_sap_oracle.md`
- `docs/backup_copy_advanced_rpo_monitor_hana.md`
- `docs/backup_copy_advanced_rpo_monitor_rman.md`
- ... and 373 more files\n
</details>

---
*Automatically generated by [veeam-docs-scraper](https://github.com/comnam90/veeam-docs-scraper)*
